### PR TITLE
feat: implement user preferences API with validation and defaults

### DIFF
--- a/app/api/user/preferences/route.ts
+++ b/app/api/user/preferences/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { validatePreferencesUpdate, ValidationError } from '@/utils/validation/preferences-validation';
+import { DEFAULT_PREFERENCES } from '@/utils/constants/supported-values';
+import { UserPreferences } from '@/utils/types/user.types';
+
+// In-memory storage for demo purposes (replace with actual database in production)
+let userPreferences: UserPreferences = { ...DEFAULT_PREFERENCES };
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = await request.json();
+    
+    // Validate the request body
+    validatePreferencesUpdate(body);
+    
+    // Update preferences with validated data
+    userPreferences = {
+      ...userPreferences,
+      ...body,
+    };
+    
+    return NextResponse.json({
+      success: true,
+      data: userPreferences,
+    });
+    
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: error.message,
+        },
+        { status: 400 }
+      );
+    }
+    
+    // Handle other errors
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Internal server error',
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET() {
+  return NextResponse.json({
+    success: true,
+    data: userPreferences,
+  });
+}

--- a/app/api/user/profile/route.ts
+++ b/app/api/user/profile/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { DEFAULT_PREFERENCES } from '@/utils/constants/supported-values';
+import { UserProfile, UserPreferences } from '@/utils/types/user.types';
+
+// In-memory storage for demo purposes (replace with actual database in production)
+let userProfile: UserProfile = {
+  id: 'user_123',
+  email: 'user@example.com',
+  name: 'John Doe',
+  preferences: { ...DEFAULT_PREFERENCES },
+};
+
+export async function GET() {
+  // Ensure preferences always have default values for missing keys
+  const preferencesWithDefaults: UserPreferences = {
+    currency: userProfile.preferences.currency || DEFAULT_PREFERENCES.currency,
+    language: userProfile.preferences.language || DEFAULT_PREFERENCES.language,
+    notifications_enabled: userProfile.preferences.notifications_enabled ?? DEFAULT_PREFERENCES.notifications_enabled,
+    timezone: userProfile.preferences.timezone,
+  };
+  
+  const responseProfile: UserProfile = {
+    ...userProfile,
+    preferences: preferencesWithDefaults,
+  };
+  
+  return NextResponse.json({
+    success: true,
+    data: responseProfile,
+  });
+}

--- a/docs/user-preferences-api.md
+++ b/docs/user-preferences-api.md
@@ -1,0 +1,167 @@
+# User Preferences API Documentation
+
+## Overview
+
+This document describes the user preferences API endpoints for managing user settings including currency, language, notifications, and timezone preferences.
+
+## Endpoints
+
+### GET /api/user/profile
+
+Returns the user's profile including preferences with default values applied for any missing settings.
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "id": "user_123",
+    "email": "user@example.com",
+    "name": "John Doe",
+    "preferences": {
+      "currency": "USD",
+      "language": "en",
+      "notifications_enabled": true,
+      "timezone": "America/New_York"
+    }
+  }
+}
+```
+
+### PATCH /api/user/preferences
+
+Updates user preferences with validation.
+
+**Request Body:**
+```json
+{
+  "currency": "EUR",
+  "language": "fr",
+  "notifications_enabled": false,
+  "timezone": "Europe/Paris"
+}
+```
+
+**Success Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "currency": "EUR",
+    "language": "fr",
+    "notifications_enabled": false,
+    "timezone": "Europe/Paris"
+  }
+}
+```
+
+**Error Response (400):**
+```json
+{
+  "success": false,
+  "error": "Invalid currency: INVALID. Supported currencies: USD, EUR, GBP, JPY, CAD, AUD, CHF, CNY, INR, BRL, MXN, ZAR, NGN, KES, GHS, UGX, TZS, RWF, BIF, XOF"
+}
+```
+
+## Schema
+
+### UserPreferences
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| currency | string | Yes | USD | ISO 4217 currency code |
+| language | string | Yes | en | ISO 639-1 language code |
+| notifications_enabled | boolean | Yes | true | Whether notifications are enabled |
+| timezone | string | No | - | IANA timezone identifier |
+
+## Supported Values
+
+### Currencies (ISO 4217)
+
+The following currencies are supported:
+
+- **USD** - US Dollar
+- **EUR** - Euro
+- **GBP** - British Pound
+- **JPY** - Japanese Yen
+- **CAD** - Canadian Dollar
+- **AUD** - Australian Dollar
+- **CHF** - Swiss Franc
+- **CNY** - Chinese Yuan
+- **INR** - Indian Rupee
+- **BRL** - Brazilian Real
+- **MXN** - Mexican Peso
+- **ZAR** - South African Rand
+- **NGN** - Nigerian Naira
+- **KES** - Kenyan Shilling
+- **GHS** - Ghanaian Cedi
+- **UGX** - Ugandan Shilling
+- **TZS** - Tanzanian Shilling
+- **RWF** - Rwandan Franc
+- **BIF** - Burundian Franc
+- **XOF** - West African CFA Franc
+
+### Languages (ISO 639-1)
+
+The following languages are supported:
+
+- **en** - English
+- **es** - Spanish
+- **fr** - French
+- **de** - German
+- **it** - Italian
+- **pt** - Portuguese
+- **zh** - Chinese
+- **ja** - Japanese
+- **ko** - Korean
+- **ar** - Arabic
+- **hi** - Hindi
+- **sw** - Swahili
+- **yo** - Yoruba
+- **ig** - Igbo
+- **ha** - Hausa
+- **zu** - Zulu
+- **xh** - Xhosa
+- **af** - Afrikaans
+- **nl** - Dutch
+- **ru** - Russian
+
+### Timezones
+
+Common timezones include (but not limited to):
+
+- **UTC** - Coordinated Universal Time
+- **America/New_York** - Eastern Time
+- **America/Los_Angeles** - Pacific Time
+- **America/Chicago** - Central Time
+- **Europe/London** - GMT/BST
+- **Europe/Paris** - Central European Time
+- **Europe/Berlin** - Central European Time
+- **Asia/Tokyo** - Japan Standard Time
+- **Asia/Shanghai** - China Standard Time
+- **Asia/Dubai** - Gulf Standard Time
+- **Africa/Lagos** - West Africa Time
+- **Africa/Nairobi** - East Africa Time
+
+## Validation Rules
+
+1. **Currency**: Must be one of the supported ISO 4217 currency codes
+2. **Language**: Must be one of the supported ISO 639-1 language codes
+3. **Notifications Enabled**: Must be a boolean value
+4. **Timezone**: Optional, must be a string if provided
+
+## Default Values
+
+When a user profile is created or when preferences are missing, the following defaults are applied:
+
+- **currency**: USD
+- **language**: en
+- **notifications_enabled**: true
+- **timezone**: undefined (optional)
+
+## Error Handling
+
+- **400 Bad Request**: Returned when validation fails for any field
+- **500 Internal Server Error**: Returned for unexpected server errors
+
+All error responses include a descriptive error message explaining what went wrong.

--- a/utils/constants/supported-values.ts
+++ b/utils/constants/supported-values.ts
@@ -1,0 +1,25 @@
+// Supported currencies (ISO 4217)
+export const SUPPORTED_CURRENCIES = [
+  'USD', 'EUR', 'GBP', 'JPY', 'CAD', 'AUD', 'CHF', 'CNY', 'INR', 'BRL',
+  'MXN', 'ZAR', 'NGN', 'KES', 'GHS', 'UGX', 'TZS', 'RWF', 'BIF', 'XOF'
+] as const;
+
+// Supported languages (ISO 639-1)
+export const SUPPORTED_LANGUAGES = [
+  'en', 'es', 'fr', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar',
+  'hi', 'sw', 'yo', 'ig', 'ha', 'zu', 'xh', 'af', 'nl', 'ru'
+] as const;
+
+// Default values
+export const DEFAULT_PREFERENCES = {
+  currency: 'USD',
+  language: 'en',
+  notifications_enabled: true,
+} as const;
+
+// Common timezones
+export const COMMON_TIMEZONES = [
+  'UTC', 'America/New_York', 'America/Los_Angeles', 'America/Chicago',
+  'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Asia/Tokyo',
+  'Asia/Shanghai', 'Asia/Dubai', 'Africa/Lagos', 'Africa/Nairobi'
+] as const;

--- a/utils/types/user.types.ts
+++ b/utils/types/user.types.ts
@@ -1,0 +1,20 @@
+export interface UserPreferences {
+  currency: string; // ISO 4217 currency code
+  language: string; // ISO 639-1 language code
+  notifications_enabled: boolean;
+  timezone?: string; // Optional timezone
+}
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  name: string;
+  preferences: UserPreferences;
+}
+
+export interface PreferencesUpdateRequest {
+  currency?: string;
+  language?: string;
+  notifications_enabled?: boolean;
+  timezone?: string;
+}

--- a/utils/validation/preferences-validation.ts
+++ b/utils/validation/preferences-validation.ts
@@ -1,0 +1,51 @@
+import { SUPPORTED_CURRENCIES, SUPPORTED_LANGUAGES } from '../constants/supported-values';
+import { PreferencesUpdateRequest } from '../types/user.types';
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}
+
+export function validateCurrency(currency: string): void {
+  if (!SUPPORTED_CURRENCIES.includes(currency as any)) {
+    throw new ValidationError(`Invalid currency: ${currency}. Supported currencies: ${SUPPORTED_CURRENCIES.join(', ')}`);
+  }
+}
+
+export function validateLanguage(language: string): void {
+  if (!SUPPORTED_LANGUAGES.includes(language as any)) {
+    throw new ValidationError(`Invalid language: ${language}. Supported languages: ${SUPPORTED_LANGUAGES.join(', ')}`);
+  }
+}
+
+export function validateNotificationsEnabled(value: any): void {
+  if (typeof value !== 'boolean') {
+    throw new ValidationError(`notifications_enabled must be a boolean, got ${typeof value}`);
+  }
+}
+
+export function validateTimezone(timezone?: string): void {
+  if (timezone && typeof timezone !== 'string') {
+    throw new ValidationError(`timezone must be a string, got ${typeof timezone}`);
+  }
+}
+
+export function validatePreferencesUpdate(data: PreferencesUpdateRequest): void {
+  if (data.currency !== undefined) {
+    validateCurrency(data.currency);
+  }
+  
+  if (data.language !== undefined) {
+    validateLanguage(data.language);
+  }
+  
+  if (data.notifications_enabled !== undefined) {
+    validateNotificationsEnabled(data.notifications_enabled);
+  }
+  
+  if (data.timezone !== undefined) {
+    validateTimezone(data.timezone);
+  }
+}


### PR DESCRIPTION
- Add user preferences schema with currency (ISO 4217), language (ISO 639-1), notifications_enabled, and optional timezone
- Implement validation rules for all preference fields with proper error handling
- Create PATCH /api/user/preferences endpoint with 400 validation errors for invalid inputs
- Add GET /api/user/profile endpoint that returns preferences with defaults (USD, en, true) for missing keys
- Define supported values for 20 currencies and 20 languages including major global and African markets
- Add comprehensive API documentation with examples and validation rules
- Implement TypeScript interfaces and custom ValidationError class
- Set up constants for default values and supported options

Closes: #186  user-preferences-implementation