### PR TITLE
feat: implement anchor webhook handler with signature verification (#171)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Session encryption for wallet-based auth (required for /api/auth/*).
 # Generate with: openssl rand -base64 32
 SESSION_PASSWORD=your-32-char-minimum-secret-here
+ANCHOR_WEBHOOK_SECRET="your_shared_anchor_secret_here"

--- a/app/api/webhooks/anchor/route.ts
+++ b/app/api/webhooks/anchor/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server'
+import crypto from 'crypto'
+
+export async function POST(request: Request) {
+  try {
+    // 1. Read the raw body as text for accurate signature verification
+    const rawBody = await request.text()
+
+    // 2. Get the signature from headers
+    const signature = request.headers.get('x-anchor-signature')
+    const secret = process.env.ANCHOR_WEBHOOK_SECRET
+
+    if (!secret) {
+      console.error('[Webhook] Secret not configured in environment.')
+      return NextResponse.json(
+        { error: 'Server misconfiguration' },
+        { status: 500 }
+      )
+    }
+
+    if (!signature) {
+      return NextResponse.json({ error: 'Missing signature' }, { status: 401 })
+    }
+
+    // 3. Verify Signature using HMAC SHA-256
+    const expectedSignature = crypto
+      .createHmac('sha256', secret)
+      .update(rawBody)
+      .digest('hex')
+
+    // Secure compare to prevent timing attacks
+    const isSignatureValid = crypto.timingSafeEqual(
+      Buffer.from(signature),
+      Buffer.from(expectedSignature)
+    )
+
+    if (!isSignatureValid) {
+      console.warn('[Webhook] Invalid webhook signature detected.')
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
+    }
+
+    // 4. Parse the trusted payload
+    const payload = JSON.parse(rawBody)
+
+    // 5. Process the event asynchronously (Fire and forget to return 200 quickly)
+    // Note: If deployed on Vercel, you might need `waitUntil` for background tasks,
+    // but standard async execution works for typical setups.
+    handleAnchorEvent(payload).catch(console.error)
+
+    // 6. Return 200 quickly to acknowledge receipt
+    return NextResponse.json({ received: true }, { status: 200 })
+  } catch (error) {
+    console.error('[Webhook] Error handling request:', error)
+    return NextResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 }
+    )
+  }
+}
+
+// Internal function to handle the business logic
+async function handleAnchorEvent(payload: any) {
+  const { event_type, transaction_id, status } = payload
+
+  console.log(
+    `[Webhook] Processing event: ${event_type} for tx: ${transaction_id}`
+  )
+
+  switch (event_type) {
+    case 'deposit_completed':
+      // TODO: Update transaction status in DB to 'completed'
+      console.log(`[Webhook] Deposit completed for tx ${transaction_id}`)
+      break
+    case 'withdrawal_failed':
+      // TODO: Update transaction status in DB to 'failed'
+      console.log(`[Webhook] Withdrawal failed for tx ${transaction_id}`)
+      break
+    default:
+      console.log(`[Webhook] Unhandled event type received: ${event_type}`)
+  }
+}

--- a/docs/Anchor_Webhooks.md
+++ b/docs/Anchor_Webhooks.md
@@ -1,0 +1,37 @@
+# Anchor Webhook Integration
+
+This document outlines how external Anchors or payment providers can send asynchronous transaction updates (like deposit/withdrawal statuses) to the Remitwise platform.
+
+## Endpoint Details
+- **URL**: `https://<your-domain>/api/webhooks/anchor`
+- **Method**: `POST`
+- **Content-Type**: `application/json`
+
+## Security & Authentication
+Webhooks are unauthenticated but cryptographically verified. The Anchor must sign the **raw JSON body** using HMAC SHA-256 and a shared secret. The resulting hex string must be passed in the headers.
+
+**Required Environment Variable:**
+\`\`\`env
+ANCHOR_WEBHOOK_SECRET="your_shared_secret_here"
+\`\`\`
+
+**Required Header:**
+`x-anchor-signature`: `<hmac-sha256-hex>`
+
+## Expected Payload Shape
+The webhook expects a JSON payload containing at minimum the `event_type`, `transaction_id`, and `status`.
+
+\`\`\`json
+{
+  "event_type": "deposit_completed",
+  "transaction_id": "tx_123abc456def",
+  "status": "completed",
+  "amount": "100.00",
+  "asset": "USDC",
+  "timestamp": "2026-02-24T21:13:00Z"
+}
+\`\`\`
+
+### Supported Event Types
+1. **`deposit_completed`**: Fired when an anchor successfully processes a user's fiat deposit and issues on-chain assets.
+2. **`withdrawal_failed`**: Fired when an on-chain withdrawal to fiat fails at the anchor level.


### PR DESCRIPTION
Closes #171 

**Changes Made:**
- Implemented `POST /api/webhooks/anchor` route to listen for provider callbacks.
- Added HMAC SHA-256 signature verification using `crypto.timingSafeEqual` and `ANCHOR_WEBHOOK_SECRET`.
- Added parsing switch-case for `deposit_completed` and `withdrawal_failed` events.
- Added `docs/ANCHOR_WEBHOOKS.md` outlining the endpoint details, security, and payload structure.
- Updated `.env.example`.