### PR TITLE
Add webhook signature verification helper

### DIFF
--- a/docs/Anchor_Webhooks.md
+++ b/docs/Anchor_Webhooks.md
@@ -10,6 +10,8 @@ This document outlines how external Anchors or payment providers can send asynch
 ## Security & Authentication
 Webhooks are unauthenticated but cryptographically verified. The Anchor must sign the **raw JSON body** using HMAC SHA-256 and a shared secret. The resulting hex string must be passed in the headers.
 
+Signature verification is handled by `lib/webhooks/verify.ts`. See `docs/api/webhooks.md` for common providers and header/secret conventions.
+
 **Required Environment Variable:**
 \`\`\`env
 ANCHOR_WEBHOOK_SECRET="your_shared_secret_here"

--- a/docs/api/webhooks.md
+++ b/docs/api/webhooks.md
@@ -1,0 +1,48 @@
+# Webhook Signature Verification
+
+This project centralizes webhook signature verification in `lib/webhooks/verify.ts`.
+
+## Helper
+
+```
+verifySignature(payload: string | Buffer, signature: string, secret: string, algorithm?: string): boolean
+```
+
+Supported algorithms:
+- `hmac-sha256` (default): HMAC SHA-256 of the raw payload.
+- `stripe-v1`: Stripe-style header values (`t=timestamp,v1=signature`).
+- `ed25519`: Ed25519 verification using a PEM-encoded public key.
+
+## Providers
+
+Anchor
+- Header: `x-anchor-signature`
+- Env var: `ANCHOR_WEBHOOK_SECRET`
+- Algorithm: `hmac-sha256`
+- Signature format: hex digest of HMAC-SHA256 over the raw request body.
+
+Stripe
+- Header: `stripe-signature`
+- Env var: `STRIPE_WEBHOOK_SECRET`
+- Algorithm: `stripe-v1`
+- Signature format: `t=timestamp,v1=hex_signature` where the payload is `${timestamp}.${rawBody}`.
+
+Ed25519 (generic)
+- Header: `x-signature`
+- Env var: `WEBHOOK_PUBLIC_KEY`
+- Algorithm: `ed25519`
+- Signature format: base64 or hex signature; secret must be a PEM public key.
+
+## Usage
+
+```
+import { verifySignature } from '@/lib/webhooks/verify'
+
+const rawBody = await request.text()
+const signature = request.headers.get('x-anchor-signature')
+const secret = process.env.ANCHOR_WEBHOOK_SECRET
+
+if (!signature || !secret || !verifySignature(rawBody, signature, secret, 'hmac-sha256')) {
+  return NextResponse.json({ error: 'Invalid webhook signature' }, { status: 401 })
+}
+```

--- a/lib/webhooks/verify.ts
+++ b/lib/webhooks/verify.ts
@@ -1,0 +1,132 @@
+import crypto from 'crypto';
+
+export type WebhookSignatureAlgorithm = 'hmac-sha256' | 'stripe-v1' | 'ed25519';
+
+function toBuffer(payload: string | Buffer): Buffer {
+  return typeof payload === 'string' ? Buffer.from(payload) : payload;
+}
+
+function stripKnownPrefixes(signature: string): string {
+  const trimmed = signature.trim();
+  const prefixes = ['sha256=', 'v1='];
+  for (const prefix of prefixes) {
+    if (trimmed.startsWith(prefix)) {
+      return trimmed.slice(prefix.length);
+    }
+  }
+  return trimmed;
+}
+
+function decodeSignature(signature: string): Buffer | null {
+  const normalized = stripKnownPrefixes(signature);
+  if (!normalized) return null;
+
+  if (/^[0-9a-f]+$/i.test(normalized) && normalized.length % 2 === 0) {
+    return Buffer.from(normalized, 'hex');
+  }
+
+  try {
+    return Buffer.from(normalized, 'base64');
+  } catch {
+    return null;
+  }
+}
+
+function safeEqual(a: Buffer, b: Buffer): boolean {
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
+function verifyHmacSha256(payload: Buffer, signature: string, secret: string): boolean {
+  const provided = decodeSignature(signature);
+  if (!provided) return false;
+
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(payload)
+    .digest();
+
+  return safeEqual(provided, expected);
+}
+
+function parseStripeSignature(signature: string): { timestamp: string; signatures: string[] } | null {
+  const parts = signature.split(',').map(part => part.trim());
+  let timestamp = '';
+  const signatures: string[] = [];
+
+  for (const part of parts) {
+    const [key, value] = part.split('=');
+    if (!key || !value) continue;
+    if (key === 't') {
+      timestamp = value;
+    }
+    if (key === 'v1') {
+      signatures.push(value);
+    }
+  }
+
+  if (!timestamp || signatures.length === 0) return null;
+
+  return { timestamp, signatures };
+}
+
+function verifyStripeV1(payload: Buffer, signature: string, secret: string): boolean {
+  const parsed = parseStripeSignature(signature);
+  if (!parsed) return false;
+
+  const signedPayload = `${parsed.timestamp}.${payload.toString()}`;
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(signedPayload)
+    .digest();
+
+  return parsed.signatures.some(sig => {
+    if (!/^[0-9a-f]+$/i.test(sig) || sig.length % 2 !== 0) {
+      return false;
+    }
+    const provided = Buffer.from(sig, 'hex');
+    return safeEqual(provided, expected);
+  });
+}
+
+function verifyEd25519(payload: Buffer, signature: string, secret: string): boolean {
+  const provided = decodeSignature(signature);
+  if (!provided) return false;
+
+  try {
+    const publicKey = crypto.createPublicKey(secret);
+    return crypto.verify(null, payload, publicKey, provided);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify webhook signature with a shared secret.
+ *
+ * Supported algorithms:
+ * - "hmac-sha256" (default): HMAC SHA-256 of the raw payload.
+ * - "stripe-v1": Stripe-style header "t=timestamp,v1=signature".
+ * - "ed25519": Ed25519 verification with a PEM-encoded public key.
+ */
+export function verifySignature(
+  payload: string | Buffer,
+  signature: string,
+  secret: string,
+  algorithm: WebhookSignatureAlgorithm = 'hmac-sha256'
+): boolean {
+  if (!payload || !signature || !secret) return false;
+
+  const body = toBuffer(payload);
+
+  switch (algorithm) {
+    case 'hmac-sha256':
+      return verifyHmacSha256(body, signature, secret);
+    case 'stripe-v1':
+      return verifyStripeV1(body, signature, secret);
+    case 'ed25519':
+      return verifyEd25519(body, signature, secret);
+    default:
+      return false;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "npm run test:unit",
-    "test:unit": "node -e \"process.exit(0)\"",
+    "test:unit": "node --test tests/unit/webhooks-verify.test.cjs",
     "test:integration": "node -e \"process.exit(0)\"",
     "test:e2e": "playwright test"
   },

--- a/tests/unit/webhooks-verify.test.cjs
+++ b/tests/unit/webhooks-verify.test.cjs
@@ -1,0 +1,82 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+let ts;
+try {
+  ts = require('typescript');
+} catch (error) {
+  test('webhook verify tests skipped (typescript not installed)', { skip: true }, () => {});
+}
+
+function loadVerifyModule() {
+  if (!ts) {
+    return null;
+  }
+  const file = path.resolve(__dirname, '../../lib/webhooks/verify.ts');
+  const source = fs.readFileSync(file, 'utf8');
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+  });
+
+  const module = { exports: {} };
+  const context = {
+    module,
+    exports: module.exports,
+    require,
+    __dirname: path.dirname(file),
+    __filename: file,
+    Buffer,
+    console,
+    process,
+    global,
+    setTimeout,
+    clearTimeout,
+  };
+
+  vm.runInNewContext(outputText, context, { filename: 'verify.js' });
+  return module.exports;
+}
+
+const loaded = loadVerifyModule();
+if (loaded) {
+  const { verifySignature } = loaded;
+
+  test('hmac-sha256 verifies hex signature', () => {
+    const payload = 'hello world';
+    const secret = 'test-secret';
+    const signature = crypto.createHmac('sha256', secret).update(payload).digest('hex');
+
+    assert.equal(verifySignature(payload, signature, secret, 'hmac-sha256'), true);
+    assert.equal(verifySignature(payload, `sha256=${signature}`, secret, 'hmac-sha256'), true);
+    assert.equal(verifySignature(payload, 'deadbeef', secret, 'hmac-sha256'), false);
+  });
+
+  test('stripe-v1 verifies timestamped signature', () => {
+    const payload = 'payload';
+    const secret = 'stripe-secret';
+    const timestamp = '1700000000';
+    const signedPayload = `${timestamp}.${payload}`;
+    const signature = crypto.createHmac('sha256', secret).update(signedPayload).digest('hex');
+    const header = `t=${timestamp},v1=${signature}`;
+
+    assert.equal(verifySignature(payload, header, secret, 'stripe-v1'), true);
+    assert.equal(verifySignature(payload, `t=${timestamp},v1=deadbeef`, secret, 'stripe-v1'), false);
+  });
+
+  test('ed25519 verifies signature', () => {
+    const payload = Buffer.from('signed payload');
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    const signature = crypto.sign(null, payload, privateKey).toString('base64');
+    const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+
+    assert.equal(verifySignature(payload, signature, publicKeyPem, 'ed25519'), true);
+    assert.equal(verifySignature(payload, signature, 'not-a-key', 'ed25519'), false);
+  });
+}


### PR DESCRIPTION
 What

  - Added reusable webhook signature verification helper supporting hmac-sha256, Stripe v1, and ed25519.
  - Integrated helper into Anchor webhook route with clear 401 on failure.
  - Documented provider header/secret conventions and usage.
  - Added unit tests for the helper and wired test:unit.

  Why

  - Standardize webhook verification across providers and prevent payload processing without valid signatures.

  Changes

  - New helper: lib/webhooks/verify.ts
  - Anchor webhook updated: app/api/webhooks/anchor/route.ts
  - Docs: docs/api/webhooks.md, update docs/Anchor_Webhooks.md
  - Tests: tests/unit/webhooks-verify.test.cjs
  - Script update: package.json test:unit

  Testing

  - npm run test:unit
  
  ---
  closes #218 