### PR TITLE
feat(api): add centralized API error handler with request-id logging

### DIFF
--- a/app/api/v1/bills/[id]/pay/route.ts
+++ b/app/api/v1/bills/[id]/pay/route.ts
@@ -1,20 +1,22 @@
 import { NextResponse } from 'next/server'
 import { buildPayBillTx } from '../../../../../../lib/contracts/bill-payments'
 import { StrKey } from '@stellar/stellar-sdk'
+import { ApiRouteError, withApiErrorHandler } from '@/lib/api/error-handler'
 
-export async function POST(req: Request, { params }: { params: { id: string } }) {
-  try {
-    const caller = req.headers.get('x-user')
-    if (!caller || !StrKey.isValidEd25519PublicKey(caller)) {
-      return NextResponse.json({ error: 'Unauthorized: missing or invalid x-user header' }, { status: 401 })
-    }
-
-    const billId = params?.id
-    if (!billId) return NextResponse.json({ error: 'Missing bill id' }, { status: 400 })
-
-    const xdr = await buildPayBillTx(caller, billId)
-    return NextResponse.json({ xdr })
-  } catch (err: any) {
-    return NextResponse.json({ error: err?.message || String(err) }, { status: 500 })
+export const POST = withApiErrorHandler(async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const caller = req.headers.get('x-user')
+  if (!caller || !StrKey.isValidEd25519PublicKey(caller)) {
+    throw new ApiRouteError(401, 'UNAUTHORIZED', 'Unauthorized')
   }
-}
+
+  const billId = params?.id
+  if (!billId) {
+    throw new ApiRouteError(400, 'VALIDATION_ERROR', 'Missing bill id')
+  }
+
+  const xdr = await buildPayBillTx(caller, billId)
+  return NextResponse.json({ xdr })
+})

--- a/app/api/v1/bills/route.ts
+++ b/app/api/v1/bills/route.ts
@@ -1,34 +1,31 @@
 import { NextResponse } from 'next/server'
 import { buildCreateBillTx } from '../../../../lib/contracts/bill-payments'
 import { StrKey } from '@stellar/stellar-sdk'
+import { ApiRouteError, withApiErrorHandler } from '@/lib/api/error-handler'
 
-export async function POST(req: Request) {
-  try {
-    const caller = req.headers.get('x-user')
-    if (!caller || !StrKey.isValidEd25519PublicKey(caller)) {
-      return NextResponse.json({ error: 'Unauthorized: missing or invalid x-user header' }, { status: 401 })
-    }
-
-    const body = await req.json()
-    const { name, amount, dueDate, recurring = false, frequencyDays } = body || {}
-
-    if (!name || typeof name !== 'string') {
-      return NextResponse.json({ error: 'Invalid name' }, { status: 400 })
-    }
-    const numAmount = Number(amount)
-    if (!(numAmount > 0)) {
-      return NextResponse.json({ error: 'Invalid amount; must be > 0' }, { status: 400 })
-    }
-    if (recurring && !(frequencyDays && Number(frequencyDays) > 0)) {
-      return NextResponse.json({ error: 'Invalid frequencyDays for recurring bill' }, { status: 400 })
-    }
-    if (!dueDate || Number.isNaN(Date.parse(dueDate))) {
-      return NextResponse.json({ error: 'Invalid dueDate' }, { status: 400 })
-    }
-
-    const xdr = await buildCreateBillTx(caller, name, numAmount, dueDate, Boolean(recurring), frequencyDays ? Number(frequencyDays) : undefined)
-    return NextResponse.json({ xdr })
-  } catch (err: any) {
-    return NextResponse.json({ error: err?.message || String(err) }, { status: 500 })
+export const POST = withApiErrorHandler(async function POST(req: Request) {
+  const caller = req.headers.get('x-user')
+  if (!caller || !StrKey.isValidEd25519PublicKey(caller)) {
+    throw new ApiRouteError(401, 'UNAUTHORIZED', 'Unauthorized')
   }
-}
+
+  const body = await req.json()
+  const { name, amount, dueDate, recurring = false, frequencyDays } = body || {}
+
+  if (!name || typeof name !== 'string') {
+    throw new ApiRouteError(400, 'VALIDATION_ERROR', 'Invalid name')
+  }
+  const numAmount = Number(amount)
+  if (!(numAmount > 0)) {
+    throw new ApiRouteError(400, 'VALIDATION_ERROR', 'Invalid amount; must be > 0')
+  }
+  if (recurring && !(frequencyDays && Number(frequencyDays) > 0)) {
+    throw new ApiRouteError(400, 'VALIDATION_ERROR', 'Invalid frequencyDays for recurring bill')
+  }
+  if (!dueDate || Number.isNaN(Date.parse(dueDate))) {
+    throw new ApiRouteError(400, 'VALIDATION_ERROR', 'Invalid dueDate')
+  }
+
+  const xdr = await buildCreateBillTx(caller, name, numAmount, dueDate, Boolean(recurring), frequencyDays ? Number(frequencyDays) : undefined)
+  return NextResponse.json({ xdr })
+})

--- a/app/api/v1/insurance/route.ts
+++ b/app/api/v1/insurance/route.ts
@@ -1,28 +1,33 @@
 import { NextResponse } from 'next/server'
 import { buildCreatePolicyTx } from '../../../../lib/contracts/insurance'
 import { StrKey } from '@stellar/stellar-sdk'
+import { ApiRouteError, withApiErrorHandler } from '@/lib/api/error-handler'
 
-export async function POST(req: Request) {
-  try {
-    const caller = req.headers.get('x-user')
-    if (!caller || !StrKey.isValidEd25519PublicKey(caller)) {
-      return NextResponse.json({ error: 'Unauthorized: missing or invalid x-user header' }, { status: 401 })
-    }
-
-    const body = await req.json()
-    const { name, coverageType, monthlyPremium, coverageAmount } = body || {}
-
-    if (!name || typeof name !== 'string') return NextResponse.json({ error: 'Invalid name' }, { status: 400 })
-    if (!coverageType || typeof coverageType !== 'string') return NextResponse.json({ error: 'Invalid coverageType' }, { status: 400 })
-
-    const mp = Number(monthlyPremium)
-    const ca = Number(coverageAmount)
-    if (!(mp > 0)) return NextResponse.json({ error: 'Invalid monthlyPremium; must be > 0' }, { status: 400 })
-    if (!(ca > 0)) return NextResponse.json({ error: 'Invalid coverageAmount; must be > 0' }, { status: 400 })
-
-    const xdr = await buildCreatePolicyTx(caller, name, coverageType, mp, ca)
-    return NextResponse.json({ xdr })
-  } catch (err: any) {
-    return NextResponse.json({ error: err?.message || String(err) }, { status: 500 })
+export const POST = withApiErrorHandler(async function POST(req: Request) {
+  const caller = req.headers.get('x-user')
+  if (!caller || !StrKey.isValidEd25519PublicKey(caller)) {
+    throw new ApiRouteError(401, 'UNAUTHORIZED', 'Unauthorized')
   }
-}
+
+  const body = await req.json()
+  const { name, coverageType, monthlyPremium, coverageAmount } = body || {}
+
+  if (!name || typeof name !== 'string') {
+    throw new ApiRouteError(400, 'VALIDATION_ERROR', 'Invalid name')
+  }
+  if (!coverageType || typeof coverageType !== 'string') {
+    throw new ApiRouteError(400, 'VALIDATION_ERROR', 'Invalid coverageType')
+  }
+
+  const mp = Number(monthlyPremium)
+  const ca = Number(coverageAmount)
+  if (!(mp > 0)) {
+    throw new ApiRouteError(400, 'VALIDATION_ERROR', 'Invalid monthlyPremium; must be > 0')
+  }
+  if (!(ca > 0)) {
+    throw new ApiRouteError(400, 'VALIDATION_ERROR', 'Invalid coverageAmount; must be > 0')
+  }
+
+  const xdr = await buildCreatePolicyTx(caller, name, coverageType, mp, ca)
+  return NextResponse.json({ xdr })
+})

--- a/lib/api/error-handler.ts
+++ b/lib/api/error-handler.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from 'next/server';
+import { ValidationError } from '@/utils/validation/preferences-validation';
+import type { ApiErrorCode } from '@/lib/api/types';
+
+type KnownCode = Extract<ApiErrorCode, 'UNAUTHORIZED' | 'VALIDATION_ERROR' | 'NOT_FOUND' | 'INTERNAL_ERROR'>;
+
+export class ApiRouteError extends Error {
+  readonly status: number;
+  readonly code: KnownCode;
+
+  constructor(status: number, code: KnownCode, message: string) {
+    super(message);
+    this.status = status;
+    this.code = code;
+    this.name = 'ApiRouteError';
+  }
+}
+
+type Handler<TContext = unknown> = (
+  request: Request,
+  context: TContext
+) => Promise<Response> | Response;
+
+function getRequestId(request: Request): string {
+  return request.headers.get('x-request-id') ?? crypto.randomUUID();
+}
+
+function mapError(error: unknown): ApiRouteError {
+  if (error instanceof ApiRouteError) {
+    return error;
+  }
+
+  if (error instanceof Response) {
+    if (error.status === 400) return new ApiRouteError(400, 'VALIDATION_ERROR', 'Invalid request');
+    if (error.status === 401) return new ApiRouteError(401, 'UNAUTHORIZED', 'Unauthorized');
+    if (error.status === 404) return new ApiRouteError(404, 'NOT_FOUND', 'Resource not found');
+    return new ApiRouteError(error.status || 500, 'INTERNAL_ERROR', 'Internal server error');
+  }
+
+  if (error instanceof ValidationError) {
+    return new ApiRouteError(400, 'VALIDATION_ERROR', error.message);
+  }
+
+  if (
+    error &&
+    typeof error === 'object' &&
+    'name' in error &&
+    (error as { name?: string }).name === 'ApiError' &&
+    'status' in error &&
+    typeof (error as { status?: unknown }).status === 'number'
+  ) {
+    const status = (error as { status: number }).status;
+    const message =
+      'message' in error && typeof (error as { message?: unknown }).message === 'string'
+        ? (error as { message: string }).message
+        : 'Request failed';
+
+    if (status === 400) return new ApiRouteError(400, 'VALIDATION_ERROR', message);
+    if (status === 401) return new ApiRouteError(401, 'UNAUTHORIZED', message);
+    if (status === 404) return new ApiRouteError(404, 'NOT_FOUND', message);
+    return new ApiRouteError(status, 'INTERNAL_ERROR', 'Internal server error');
+  }
+
+  return new ApiRouteError(500, 'INTERNAL_ERROR', 'Internal server error');
+}
+
+export function withApiErrorHandler<TContext = unknown>(handler: Handler<TContext>) {
+  return async function wrappedHandler(request: Request, context: TContext): Promise<Response> {
+    const requestId = getRequestId(request);
+    const url = new URL(request.url);
+    const path = url.pathname;
+    const method = request.method;
+
+    try {
+      const response = await handler(request, context);
+      response.headers.set('x-request-id', requestId);
+      return response;
+    } catch (error) {
+      const mapped = mapError(error);
+
+      if (mapped.code === 'INTERNAL_ERROR') {
+        console.error('[api-error]', { requestId, path, method, error });
+      } else {
+        console.warn('[api-error]', {
+          requestId,
+          path,
+          method,
+          status: mapped.status,
+          code: mapped.code,
+          message: mapped.message,
+        });
+      }
+
+      return NextResponse.json(
+        {
+          success: false as const,
+          error: {
+            code: mapped.code,
+            message: mapped.message,
+          },
+          requestId,
+        },
+        {
+          status: mapped.status,
+          headers: {
+            'x-request-id': requestId,
+          },
+        }
+      );
+    }
+  };
+}


### PR DESCRIPTION
## Summary
Implements issue #147  by introducing a centralized API error handler for Next.js route handlers, with request-context logging and standardized client-safe error responses.

### What was added
- New shared handler:
  - `lib/api/error-handler.ts`
- Provides:
  - `withApiErrorHandler(...)` wrapper for route handlers
  - `ApiRouteError` for explicit known error mapping
  - request context logging (`path`, `method`, `requestId`)
  - request ID propagation via `x-request-id` (uses incoming header or generates one)

## Error Handling Behavior

### Known errors
Mapped to standardized status/code pairs:
- `401` -> `UNAUTHORIZED`
- `400` -> `VALIDATION_ERROR`
- `404` -> `NOT_FOUND`

### Unknown errors
- Full error is logged server-side with request context
- Client receives generic:
  - status: `500`
  - code: `INTERNAL_ERROR`
  - message: `Internal server error`
- No stack traces or internal details are returned to clients

### Response shape
```json
{
  "success": false,
  "error": {
    "code": "INTERNAL_ERROR",
    "message": "Internal server error"
  },
  "requestId": "..."
}
```
closed: #147 