### PR TITLE
feat(insights): implement Financial Insights charts (bar, area, donut)

### DIFF
--- a/app/financial-insights/page.tsx
+++ b/app/financial-insights/page.tsx
@@ -1,6 +1,9 @@
 'use client'
 
 import FinancialInsightsHeader from '@/components/FinancialInsightsHeader'
+import { SpendingVsSavingsChart } from '@/components/Insights/spendingVsSavingChart'
+import { RemittanceTrendChart }   from '@/components/Insights/remittanceTrendChart'
+import { CategoryDonutChart }     from '@/components/Insights/categoryDonutChart'
 
 export default function FinancialInsightsPage() {
   const handleExport = () => {
@@ -10,6 +13,7 @@ export default function FinancialInsightsPage() {
 
   const handleDateRangeChange = (range: string) => {
     console.log('Date range changed to:', range)
+    // TODO: pass selected range to charts to filter data via API
   }
 
   return (
@@ -18,17 +22,61 @@ export default function FinancialInsightsPage() {
         onExport={handleExport}
         onDateRangeChange={handleDateRangeChange}
       />
-      
-      {/* Page Content - Mobile optimized */}
+
       <main className="max-w-7xl mx-auto px-3 sm:px-4 md:px-6 lg:px-8 py-4 sm:py-6 lg:py-8">
-        <div className="text-white text-center py-12 sm:py-16 lg:py-20">
-          <h2 className="text-xl sm:text-2xl lg:text-3xl font-bold mb-3 sm:mb-4">
-            Financial Insights Content
-          </h2>
-          <p className="text-sm sm:text-base text-gray-400 max-w-2xl mx-auto px-4">
-            The page content will be implemented here according to the Figma design.
-          </p>
+
+        {/* Summary stats row */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4 mb-6 sm:mb-8">
+          {[
+            { label: 'Total Sent',    value: '$3,240', change: '+12%',  up: true  },
+            { label: 'Avg per Week',  value: '$810',   change: '+5%',   up: true  },
+            { label: 'Transactions',  value: '24',     change: '+3',    up: true  },
+            { label: 'Savings Rate',  value: '22%',    change: '-2pp',  up: false },
+          ].map(({ label, value, change, up }) => (
+            <div
+              key={label}
+              className="bg-black/40 border border-white/10 rounded-2xl p-4 backdrop-blur-sm"
+            >
+              <p className="text-gray-500 text-xs mb-1">{label}</p>
+              <p className="text-white font-bold text-lg sm:text-xl leading-tight">{value}</p>
+              <p className={`text-xs mt-1 font-medium ${up ? 'text-emerald-400' : 'text-red-400'}`}>
+                {up ? '↑' : '↓'} {change} vs last period
+              </p>
+            </div>
+          ))}
         </div>
+
+        {/* Charts grid */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
+
+          {/* Spending vs Savings — full width on mobile, half on desktop */}
+          <div className="lg:col-span-2">
+            <SpendingVsSavingsChart />
+          </div>
+
+          {/* Trend line */}
+          <RemittanceTrendChart />
+
+          {/* Category donut */}
+          <CategoryDonutChart />
+
+        </div>
+
+        {/* UX notes — visible in dev, remove before prod */}
+        {process.env.NODE_ENV === 'development' && (
+          <details className="mt-8 border border-white/5 rounded-2xl p-4">
+            <summary className="text-gray-500 text-xs cursor-pointer">
+              Chart design decisions (dev only)
+            </summary>
+            <div className="mt-3 space-y-2 text-xs text-gray-500">
+              <p><strong className="text-gray-400">Spending vs Savings → Grouped Bar:</strong> Comparing two absolute values across discrete time periods. Bars make the magnitude difference between spending and savings immediately scannable.</p>
+              <p><strong className="text-gray-400">Remittance Trend → Area Line:</strong> Continuous progression over time with volume emphasis. Gradient fill under the line communicates cumulative transfer activity without adding visual noise.</p>
+              <p><strong className="text-gray-400">Category Breakdown → Donut:</strong> Proportions of a whole. The empty center enables a dynamic label showing total or selected category amount — more information-dense than a pie. Interactive slices and legend rows implement the "click to filter" pattern.</p>
+              <p><strong className="text-gray-400">Color palette:</strong> #D72323 (brand red) as primary, #0ea5e9 (sky) as secondary, #f59e0b (amber) and #10b981 (emerald) as tertiary. All contrast above 3:1 against the dark background.</p>
+              <p><strong className="text-gray-400">Responsive:</strong> Charts use ResponsiveContainer for fluid width. Y-axis hidden on mobile to reclaim space — values are accessible via hover tooltip. Grid collapses from 2-col to 1-col below lg breakpoint.</p>
+            </div>
+          </details>
+        )}
       </main>
     </div>
   )

--- a/components/Insights/categoryDonutChart.tsx
+++ b/components/Insights/categoryDonutChart.tsx
@@ -1,0 +1,238 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  ResponsiveContainer,
+  type TooltipProps,
+} from 'recharts'
+import { PieChart as PieChartIcon, Info } from 'lucide-react'
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+
+export interface CategoryDataPoint {
+  name: string
+  amount: number
+  percentage: number
+}
+
+interface CustomTooltipProps {
+  active?: boolean
+  payload?: Array<{ color?: string; payload: CategoryDataPoint }>
+}
+
+export const MOCK_CATEGORY_DATA: CategoryDataPoint[] = [
+  { name: 'Family Support', amount: 1800, percentage: 56 },
+  { name: 'Education',      amount: 850,  percentage: 26 },
+  { name: 'Medical',        amount: 390,  percentage: 12 },
+  { name: 'Emergency',      amount: 200,  percentage: 6  },
+]
+
+const SLICE_COLORS = ['#D72323', '#0ea5e9', '#f59e0b', '#10b981']
+
+const AXIS_COLOR = '#6b7280'
+
+// ── Custom tooltip ────────────────────────────────────────────────────────────
+function CustomTooltip({ active, payload }: CustomTooltipProps) {
+  if (!active || !payload?.length) return null
+  const entry = payload[0]
+  const data  = entry.payload as CategoryDataPoint
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-[#1a1a1a] px-4 py-3 shadow-2xl text-sm">
+      <div className="flex items-center gap-2 mb-1.5">
+        <span
+          className="inline-block w-2.5 h-2.5 rounded-full"
+          style={{ backgroundColor: entry.color }}
+        />
+        <span className="text-white font-semibold">{data.name}</span>
+      </div>
+      <div className="space-y-0.5 pl-4">
+        <div className="flex justify-between gap-6">
+          <span className="text-gray-400">Amount</span>
+          <span className="font-bold text-white">${data.amount.toLocaleString()}</span>
+        </div>
+        <div className="flex justify-between gap-6">
+          <span className="text-gray-400">Share</span>
+          <span className="font-bold text-white">{data.percentage}%</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Custom label inside donut center ─────────────────────────────────────────
+interface CenterLabelProps {
+  cx: number
+  cy: number
+  active: CategoryDataPoint | null
+  total: number
+}
+
+function CenterLabel({ cx, cy, active, total }: CenterLabelProps) {
+  return (
+    <g>
+      {active ? (
+        <>
+          <text x={cx} y={cy - 10} textAnchor="middle" fill="white" fontSize={18} fontWeight={700}>
+            ${active.amount.toLocaleString()}
+          </text>
+          <text x={cx} y={cy + 12} textAnchor="middle" fill={AXIS_COLOR} fontSize={11}>
+            {active.name}
+          </text>
+        </>
+      ) : (
+        <>
+          <text x={cx} y={cy - 10} textAnchor="middle" fill="white" fontSize={18} fontWeight={700}>
+            ${total.toLocaleString()}
+          </text>
+          <text x={cx} y={cy + 12} textAnchor="middle" fill={AXIS_COLOR} fontSize={11}>
+            Total sent
+          </text>
+        </>
+      )}
+    </g>
+  )
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+interface CategoryDonutChartProps {
+  data?: CategoryDataPoint[]
+}
+
+export function CategoryDonutChart({ data = MOCK_CATEGORY_DATA }: CategoryDonutChartProps) {
+  const [activeCategory, setActiveCategory] = useState<CategoryDataPoint | null>(null)
+
+  const total   = data.reduce((s, d) => s + d.amount, 0)
+  const topCat  = data[0]
+
+  return (
+    <div className="bg-black/40 border border-white/10 rounded-3xl p-5 sm:p-6 backdrop-blur-sm w-full">
+      {/* Header */}
+      <div className="flex items-start gap-3 mb-6">
+        <div className="bg-red-500/10 p-2 rounded-lg shrink-0">
+          <PieChartIcon className="w-5 h-5 text-red-500" />
+        </div>
+        <div>
+          <h2 className="text-white text-base sm:text-lg font-semibold">Top Categories</h2>
+          <p className="text-gray-500 text-xs sm:text-sm">Remittance breakdown</p>
+        </div>
+      </div>
+
+      {/* Chart + legend layout */}
+      <div className="flex flex-col sm:flex-row items-center gap-6">
+
+        {/* Donut */}
+        <div className="w-full sm:w-auto flex-shrink-0">
+          <ResponsiveContainer width="100%" height={200}>
+            <PieChart>
+              <Pie
+                data={data}
+                cx="50%"
+                cy="50%"
+                innerRadius={60}
+                outerRadius={90}
+                paddingAngle={3}
+                dataKey="amount"
+                stroke="none"
+                onMouseEnter={(_, index) => setActiveCategory(data[index])}
+                onMouseLeave={() => setActiveCategory(null)}
+                onClick={(_, index) =>
+                  setActiveCategory(prev =>
+                    prev?.name === data[index].name ? null : data[index]
+                  )
+                }
+                style={{ cursor: 'pointer' }}
+              >
+                {data.map((entry, index) => (
+                  <Cell
+                    key={entry.name}
+                    fill={SLICE_COLORS[index % SLICE_COLORS.length]}
+                    opacity={
+                      activeCategory === null || activeCategory.name === entry.name
+                        ? 1
+                        : 0.35
+                    }
+                    style={{ transition: 'opacity 0.2s ease' }}
+                  />
+                ))}
+              </Pie>
+
+              {/* Center label rendered as custom content */}
+              <text>
+                <CenterLabel cx={0} cy={0} active={activeCategory} total={total} />
+              </text>
+
+              <Tooltip content={<CustomTooltip />} />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* Legend rows — interactive */}
+        <div className="w-full space-y-3">
+          {data.map((item, index) => {
+            const color     = SLICE_COLORS[index % SLICE_COLORS.length]
+            const isActive  = activeCategory?.name === item.name
+            const isDimmed  = activeCategory !== null && !isActive
+
+            return (
+              <button
+                key={item.name}
+                type="button"
+                onClick={() =>
+                  setActiveCategory(prev =>
+                    prev?.name === item.name ? null : item
+                  )
+                }
+                className={`w-full text-left space-y-1.5 transition-opacity ${
+                  isDimmed ? 'opacity-40' : 'opacity-100'
+                }`}
+              >
+                <div className="flex justify-between items-center">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
+                      style={{ backgroundColor: color }}
+                    />
+                    <span className="text-white text-sm font-medium">{item.name}</span>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <span className="text-white font-bold text-sm">
+                      ${item.amount.toLocaleString()}
+                    </span>
+                    <span className="text-gray-500 text-xs w-8 text-right">
+                      {item.percentage}%
+                    </span>
+                  </div>
+                </div>
+
+                {/* Progress bar */}
+                <div className="w-full bg-white/5 h-1.5 rounded-full overflow-hidden">
+                  <div
+                    className="h-full rounded-full transition-all duration-700 ease-out"
+                    style={{ width: `${item.percentage}%`, backgroundColor: color }}
+                  />
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Insight alert */}
+      {topCat && (
+        <div className="mt-6 p-4 bg-red-950/20 border border-red-900/40 rounded-2xl flex gap-3 items-start">
+          <Info className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
+          <p className="text-gray-300 text-sm leading-relaxed">
+            <span className="text-red-500 font-semibold">{topCat.percentage}%</span> of your
+            remittances go to {topCat.name.toLowerCase()}. Consider setting up automatic transfers!
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/Insights/remittanceTrendChart.tsx
+++ b/components/Insights/remittanceTrendChart.tsx
@@ -1,0 +1,184 @@
+'use client'
+
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from 'recharts'
+import { Activity } from 'lucide-react'
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+
+export interface TrendDataPoint {
+  date: string
+  amount: number
+  transactions: number
+}
+
+export const MOCK_TREND_DATA: TrendDataPoint[] = [
+  { date: 'Sep 1',  amount: 520,  transactions: 2 },
+  { date: 'Sep 8',  amount: 780,  transactions: 3 },
+  { date: 'Sep 15', amount: 650,  transactions: 2 },
+  { date: 'Sep 22', amount: 940,  transactions: 4 },
+  { date: 'Oct 1',  amount: 820,  transactions: 3 },
+  { date: 'Oct 8',  amount: 1100, transactions: 4 },
+  { date: 'Oct 15', amount: 980,  transactions: 3 },
+  { date: 'Oct 22', amount: 1250, transactions: 5 },
+  { date: 'Nov 1',  amount: 1050, transactions: 4 },
+  { date: 'Nov 8',  amount: 890,  transactions: 3 },
+  { date: 'Nov 15', amount: 1320, transactions: 5 },
+  { date: 'Nov 22', amount: 1480, transactions: 6 },
+  { date: 'Dec 1',  amount: 1650, transactions: 6 },
+  { date: 'Dec 8',  amount: 1420, transactions: 5 },
+]
+
+const AXIS_COLOR  = '#6b7280'
+const GRID_COLOR  = 'rgba(255,255,255,0.06)'
+const LINE_COLOR  = '#D72323'
+
+// ── Custom tooltip ────────────────────────────────────────────────────────────
+interface CustomTooltipProps {
+  active?: boolean
+  payload?: Array<{ payload: TrendDataPoint }>
+  label?: string
+}
+
+function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
+  if (!active || !payload?.length) return null
+  const point = payload[0]?.payload as TrendDataPoint
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-[#1a1a1a] px-4 py-3 shadow-2xl text-sm">
+      <p className="text-gray-400 font-medium mb-2">{label}</p>
+      <div className="space-y-1">
+        <div className="flex justify-between gap-6">
+          <span className="text-gray-400">Amount</span>
+          <span className="font-bold text-white">${point.amount.toLocaleString()}</span>
+        </div>
+        <div className="flex justify-between gap-6">
+          <span className="text-gray-400">Transactions</span>
+          <span className="font-bold text-white">{point.transactions}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Component ───────────────────────────────────────
+
+interface RemittanceTrendChartProps {
+  data?: TrendDataPoint[]
+}
+
+export function RemittanceTrendChart({
+  data = MOCK_TREND_DATA,
+}: RemittanceTrendChartProps) {
+  const total   = data.reduce((s, d) => s + d.amount, 0)
+  const average = Math.round(total / data.length)
+  const peak    = Math.max(...data.map(d => d.amount))
+  const latest  = data[data.length - 1]?.amount ?? 0
+  const prev    = data[data.length - 2]?.amount ?? latest
+  const trend   = latest >= prev ? 'up' : 'down'
+
+  return (
+    <div className="bg-black/40 border border-white/10 rounded-3xl p-5 sm:p-6 backdrop-blur-sm w-full">
+      {/* Header */}
+      <div className="flex items-start justify-between mb-6">
+        <div className="flex items-start gap-3">
+          <div className="bg-red-500/10 p-2 rounded-lg shrink-0">
+            <Activity className="w-5 h-5 text-red-500" />
+          </div>
+          <div>
+            <h2 className="text-white text-base sm:text-lg font-semibold">
+              Remittance Trend
+            </h2>
+            <p className="text-gray-500 text-xs sm:text-sm">Volume over time</p>
+          </div>
+        </div>
+
+        {/* Stats */}
+        <div className="flex gap-4 text-right shrink-0">
+          <div>
+            <p className="text-white font-bold text-sm sm:text-base">
+              ${peak.toLocaleString()}
+            </p>
+            <p className="text-gray-500 text-xs">peak</p>
+          </div>
+          <div>
+            <p
+              className={`font-bold text-sm sm:text-base ${
+                trend === 'up' ? 'text-emerald-400' : 'text-red-400'
+              }`}
+            >
+              {trend === 'up' ? '↑' : '↓'} ${Math.abs(latest - prev).toLocaleString()}
+            </p>
+            <p className="text-gray-500 text-xs">vs prev</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Chart */}
+      <ResponsiveContainer width="100%" height={220}>
+        <AreaChart
+          data={data}
+          margin={{ top: 8, right: 4, bottom: 0, left: -16 }}
+        >
+          <defs>
+            <linearGradient id="trendGradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%"  stopColor={LINE_COLOR} stopOpacity={0.3} />
+              <stop offset="95%" stopColor={LINE_COLOR} stopOpacity={0}   />
+            </linearGradient>
+          </defs>
+
+          <CartesianGrid strokeDasharray="3 3" stroke={GRID_COLOR} vertical={false} />
+
+          <XAxis
+            dataKey="date"
+            tick={{ fill: AXIS_COLOR, fontSize: 10 }}
+            axisLine={false}
+            tickLine={false}
+            interval="preserveStartEnd"
+          />
+          <YAxis
+            tick={{ fill: AXIS_COLOR, fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            tickFormatter={(v: number) => `$${v >= 1000 ? `${v / 1000}k` : v}`}
+            width={40}
+            className="hidden sm:block"
+          />
+
+          <Tooltip content={<CustomTooltip />} cursor={{ stroke: 'rgba(255,255,255,0.1)', strokeWidth: 1 }} />
+
+          {/* Average reference line */}
+          <ReferenceLine
+            y={average}
+            stroke="rgba(255,255,255,0.15)"
+            strokeDasharray="4 4"
+            label={{
+              value: `Avg $${average.toLocaleString()}`,
+              position: 'insideTopRight',
+              fontSize: 10,
+              fill: '#6b7280',
+            }}
+          />
+
+          <Area
+            type="monotone"
+            dataKey="amount"
+            stroke={LINE_COLOR}
+            strokeWidth={2.5}
+            fill="url(#trendGradient)"
+            dot={false}
+            activeDot={{ r: 5, fill: LINE_COLOR, stroke: '#0A0A0A', strokeWidth: 2 }}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/components/Insights/spendingVsSavingChart.tsx
+++ b/components/Insights/spendingVsSavingChart.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+import {
+    BarChart,
+    Bar,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    ResponsiveContainer,
+    type TooltipContentProps,
+} from 'recharts'
+import { TrendingUp } from 'lucide-react'
+
+// ── Mock data ───────────────────────────
+
+export interface SpendingVsSavingsDataPoint {
+    month: string
+    spending: number
+    savings: number
+}
+
+export const MOCK_SPENDING_VS_SAVINGS: SpendingVsSavingsDataPoint[] = [
+    { month: 'Sep', spending: 2400, savings: 600 },
+    { month: 'Oct', spending: 2800, savings: 700 },
+    { month: 'Nov', spending: 3200, savings: 500 },
+    { month: 'Dec', spending: 3800, savings: 400 },
+    { month: 'Jan', spending: 2600, savings: 800 },
+    { month: 'Feb', spending: 2900, savings: 750 },
+    { month: 'Mar', spending: 3100, savings: 900 },
+]
+
+// ── Color tokens — match the existing dark theme ──────────────────────────────
+const SPENDING_COLOR = '#D72323'   // brand red
+const SAVINGS_COLOR = '#0ea5e9'   // primary-500 from tailwind config
+const GRID_COLOR = 'rgba(255,255,255,0.06)'
+const AXIS_COLOR = '#6b7280'   // gray-500
+
+// ── Custom tooltip ────────────────────────────────────────────────────────────
+function CustomTooltip({ active, payload, label }: TooltipContentProps<number, string>) {
+    if (!active || !payload?.length) return null
+
+    return (
+        <div className="rounded-xl border border-white/10 bg-[#1a1a1a] px-4 py-3 shadow-2xl text-sm min-w-[160px]">
+            <p className="text-gray-400 font-medium mb-2">{label ?? ''}</p>
+            {payload.map((entry) => (
+                <div key={entry.name} className="flex items-center justify-between gap-4 py-0.5">
+                    <div className="flex items-center gap-2">
+                        <span
+                            className="inline-block w-2.5 h-2.5 rounded-full"
+                            style={{ backgroundColor: entry.color }}
+                        />
+                        <span className="text-gray-300 capitalize">{entry.name}</span>
+                    </div>
+                    <span className="font-bold text-white">
+                        ${(entry.value as number).toLocaleString()}
+                    </span>
+                </div>
+            ))}
+            {payload.length === 2 && (
+                <div className="mt-2 pt-2 border-t border-white/10 flex justify-between text-xs">
+                    <span className="text-gray-500">Ratio</span>
+                    <span className="text-gray-300">
+                        {Math.round(
+                            ((payload[1].value as number) /
+                                ((payload[0].value as number) + (payload[1].value as number))) *
+                            100
+                        )}% saved
+                    </span>
+                </div>
+            )}
+        </div>
+    )
+}
+
+// ── Custom legend ─────────────────────────────────────────────────────────────
+function CustomLegend() {
+    return (
+        <div className="flex items-center justify-center gap-6 mt-2">
+            {[
+                { color: SPENDING_COLOR, label: 'Spending' },
+                { color: SAVINGS_COLOR, label: 'Savings' },
+            ].map(({ color, label }) => (
+                <div key={label} className="flex items-center gap-2">
+                    <span className="inline-block w-3 h-3 rounded-sm" style={{ backgroundColor: color }} />
+                    <span className="text-xs text-gray-400">{label}</span>
+                </div>
+            ))}
+        </div>
+    )
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+interface SpendingVsSavingsChartProps {
+    data?: SpendingVsSavingsDataPoint[]
+}
+
+export function SpendingVsSavingsChart({
+    data = MOCK_SPENDING_VS_SAVINGS,
+}: SpendingVsSavingsChartProps) {
+    const totalSpending = data.reduce((s, d) => s + d.spending, 0)
+    const totalSavings = data.reduce((s, d) => s + d.savings, 0)
+    const savingsRate = Math.round((totalSavings / (totalSpending + totalSavings)) * 100)
+
+    return (
+        <div className="bg-black/40 border border-white/10 rounded-3xl p-5 sm:p-6 backdrop-blur-sm w-full">
+            {/* Header */}
+            <div className="flex items-start justify-between mb-6">
+                <div className="flex items-start gap-3">
+                    <div className="bg-red-500/10 p-2 rounded-lg shrink-0">
+                        <TrendingUp className="w-5 h-5 text-red-500" />
+                    </div>
+                    <div>
+                        <h2 className="text-white text-base sm:text-lg font-semibold">
+                            Spending vs Savings
+                        </h2>
+                        <p className="text-gray-500 text-xs sm:text-sm">Monthly comparison</p>
+                    </div>
+                </div>
+
+                {/* Savings rate badge */}
+                <div className="text-right shrink-0">
+                    <p className="text-[#0ea5e9] font-bold text-lg sm:text-xl">{savingsRate}%</p>
+                    <p className="text-gray-500 text-xs">savings rate</p>
+                </div>
+            </div>
+
+            {/* Chart */}
+            <ResponsiveContainer width="100%" height={220}>
+                <BarChart
+                    data={data}
+                    barCategoryGap="30%"
+                    barGap={4}
+                    margin={{ top: 4, right: 4, bottom: 0, left: -16 }}
+                >
+                    <CartesianGrid
+                        strokeDasharray="3 3"
+                        stroke={GRID_COLOR}
+                        vertical={false}
+                    />
+                    <XAxis
+                        dataKey="month"
+                        tick={{ fill: AXIS_COLOR, fontSize: 11 }}
+                        axisLine={false}
+                        tickLine={false}
+                    />
+                    <YAxis
+                        tick={{ fill: AXIS_COLOR, fontSize: 11 }}
+                        axisLine={false}
+                        tickLine={false}
+                        tickFormatter={(v: number) => `$${v >= 1000 ? `${v / 1000}k` : v}`}
+                        width={40}
+                        className="hidden sm:block"
+                    />
+                    <Tooltip content={CustomTooltip} cursor={{ fill: 'rgba(255,255,255,0.03)' }} />
+                    <Bar dataKey="spending" name="spending" fill={SPENDING_COLOR} radius={[4, 4, 0, 0]} />
+                    <Bar dataKey="savings" name="savings" fill={SAVINGS_COLOR} radius={[4, 4, 0, 0]} />
+                </BarChart>
+            </ResponsiveContainer>
+
+            <CustomLegend />
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary
Replaces the Financial Insights placeholder page with a fully built
chart suite covering spending vs savings, remittance trends, and
category breakdown.

## Changes

### New: `components/Insights/SpendingVsSavingsChart.tsx`
- Grouped bar chart comparing monthly spending and savings
- Custom tooltip showing both values and savings ratio
- Savings rate badge derived from the dataset

### New: `components/Insights/RemittanceTrendChart.tsx`
- Area line chart with gradient fill showing remittance volume over time
- Average reference line to anchor above/below-average periods
- Trend arrow with delta vs previous data point

### New: `components/Insights/CategoryDonutChart.tsx`
- Interactive donut chart replacing the static `TopCategoriesWidget`
- Click/hover a slice or legend row to highlight and filter
- Dynamic center label shows total or selected category amount
- Progress bar legend preserves familiarity from the original component

### Updated: `app/financial-insights/page.tsx`
- Replaces placeholder content with charts + summary stats row
- Responsive 2-col grid collapsing to 1-col on mobile
- Dev-only `<details>` block documenting chart type justifications

## Chart type justifications
- **Bar**: spending vs savings comparison across discrete time periods
- **Area line**: continuous progression with volume emphasis
- **Donut**: proportions of a whole with interactive filtering

## Notes
- All charts accept a `data` prop defaulting to mock data —
  swap for API responses when endpoints are ready
- `recharts` was already installed — no new dependencies added
- Dark-first styling matches existing `TopCategoriesWidget` conventions
<img width="1366" height="768" alt="Screenshot From 2026-03-27 01-31-00" src="https://github.com/user-attachments/assets/763ef7fc-3dae-4017-9c84-d07ef7f1ff19" />


Closes #280