### PR TITLE
Uiux/emergency transfer microcopy

### DIFF
--- a/app/send/components/EmergencyTransferModal.tsx
+++ b/app/send/components/EmergencyTransferModal.tsx
@@ -111,8 +111,8 @@ export default function EmergencyTransferModal({
                   </span>
                 </div>
                 <p className="mt-2 max-w-2xl text-sm leading-6 text-gray-300">
-                  Emergency sends need stronger feedback than a single button spinner.
-                  This modal keeps review details on the left and submission behavior on the right.
+                  Funds arrive in 2–5 minutes. A $2.00 priority fee applies.
+                  This transfer cannot be reversed — only use it for urgent situations.
                 </p>
               </div>
             </div>
@@ -170,9 +170,9 @@ export default function EmergencyTransferModal({
                   }`}
                 >
                   <p className="text-sm font-semibold text-white">Emergency</p>
-                  <p className="mt-2 text-2xl font-semibold text-white">2-5 min</p>
+                  <p className="mt-2 text-2xl font-semibold text-white">2–5 min</p>
                   <p className="mt-2 text-sm leading-6 text-gray-300">
-                    Highest priority path. Use for urgent household needs only.
+                    Highest priority. +$2.00 fee. Use for urgent household or family needs only.
                   </p>
                 </button>
 
@@ -186,10 +186,9 @@ export default function EmergencyTransferModal({
                   }`}
                 >
                   <p className="text-sm font-semibold text-white">Regular</p>
-                  <p className="mt-2 text-2xl font-semibold text-white">30-60 min</p>
+                  <p className="mt-2 text-2xl font-semibold text-white">30–60 min</p>
                   <p className="mt-2 text-sm leading-6 text-gray-300">
-                    Lower urgency flow. Keep the same status pattern, but reduce
-                    priority styling.
+                    Standard processing. No extra fee. Choose this if the transfer is not time-critical.
                   </p>
                 </button>
               </div>
@@ -199,7 +198,7 @@ export default function EmergencyTransferModal({
                   <div>
                     <p className="text-sm font-medium text-gray-300">Transfer summary</p>
                     <p className="mt-1 text-sm text-gray-500">
-                      Keep fees and total in the same reading zone as the confirm action.
+                      Review the amount and fee before confirming. These figures are final.
                     </p>
                   </div>
                   <DollarSign className="h-5 w-5 text-red-300" />
@@ -237,10 +236,10 @@ export default function EmergencyTransferModal({
 
               <AsyncSubmissionStatus
                 pending={false}
-                idleTitle="Submission placement"
-                idleDescription="Build and review feedback should remain inside the modal. After the user signs, move progress into the persistent stacked status surface so they can keep navigating."
-                pendingTitle="Preparing emergency contract request"
-                pendingDescription="The modal footer should hold the active loading state until wallet approval can begin."
+                idleTitle="Ready to submit"
+                idleDescription="Check the recipient, amount, and fee above. Once you confirm, the transfer is queued immediately and cannot be cancelled."
+                pendingTitle="Preparing emergency transfer"
+                pendingDescription="Building the transaction. Your wallet approval will be requested next."
               />
 
               <label className="flex items-start gap-3 rounded-2xl border border-white/[0.08] bg-black/20 p-4 text-sm text-gray-300 cursor-pointer">
@@ -251,8 +250,8 @@ export default function EmergencyTransferModal({
                   className="mt-1 h-4 w-4 rounded border-gray-500 bg-[#1a1a1a] text-red-600 focus:ring-red-500"
                 />
                 <span className="leading-6">
-                  I understand this is an emergency transfer, fees apply, and the
-                  confirmation state should persist after this modal closes.
+                  I confirm this is an urgent transfer. I understand the $2.00 priority
+                  fee will be charged and this transaction cannot be reversed once submitted.
                 </span>
               </label>
 
@@ -279,10 +278,10 @@ export default function EmergencyTransferModal({
               <AsyncOperationsPanel
                 eyebrow="Async behavior"
                 title="Emergency Submission Pattern"
-                description="Urgent transfers need the clearest duration language in the product, which makes this modal a good place to standardize contract-submission feedback."
+                description="Urgent transfers carry the highest stakes in the product. Each stage below shows what the user sees and how long to expect it to take."
                 stages={emergencyStages}
                 queueTitle="Stack behavior"
-                queueDescription="The modal owns early review states. After signature, move progress into the global stack so it does not disappear when the user closes or moves away from the modal."
+                queueDescription="The modal owns the review and build stages. After wallet signature, progress moves into the global stack so it stays visible if the user navigates away."
                 queueItems={emergencyQueue}
               />
             </aside>

--- a/components/Dashboard/EmergencyTransferModal.tsx
+++ b/components/Dashboard/EmergencyTransferModal.tsx
@@ -44,7 +44,7 @@ const EmergencyTransferModal = ({
                 </span>
               </div>
               <p className="text-xs sm:text-sm text-zinc-500 font-medium mt-1">
-                Priority processing guaranteed.
+                Funds arrive in 2–5 minutes. Use only for urgent needs.
               </p>
             </div>
           </div>
@@ -61,11 +61,13 @@ const EmergencyTransferModal = ({
             <AlertCircle size={20} className="shrink-0 text-red-500" />
             <div className="text-xs sm:text-[13px] leading-relaxed">
               <span className="font-bold text-[#DC2626] text-sm block mb-1">
-                Emergency Priority Transfer:
+                Before you continue
               </span>
               <span className="text-white opacity-55">
-                This transfer will be processed with highest priority.
-                Additional fees apply.
+                Emergency transfers are processed immediately and{" "}
+                <strong className="text-white opacity-80">cannot be reversed</strong>.
+                A $2.00 priority fee applies. Only use this for urgent situations
+                — medical, family emergencies, or time-critical payments.
               </span>
             </div>
           </div>
@@ -162,7 +164,7 @@ const EmergencyTransferModal = ({
             />
             <span className="text-sm font-bold text-white">Emergency</span>
             <span className="text-[10px] text-zinc-500 uppercase font-black">
-              2-5 Minutes
+              2–5 Minutes · +$2.00 fee
             </span>
           </button>
 
@@ -173,7 +175,7 @@ const EmergencyTransferModal = ({
             <Clock size={18} className="text-zinc-400" />
             <span className="text-sm font-bold text-zinc-200">Regular</span>
             <span className="text-[10px] text-zinc-300 uppercase font-black">
-              30-60 Minutes
+              30–60 Minutes · No extra fee
             </span>
           </button>
         </div>
@@ -191,11 +193,11 @@ const EmergencyTransferModal = ({
             className="hidden"
           />
           <span className="text-xs text-zinc-500 group-hover:text-zinc-300 transition-colors select-none">
-            I agree to the{" "}
+            I confirm this transfer is for an urgent need. I understand the{" "}
             <span className="text-red-500 hover:underline">
-              Priority Fee terms
+              $2.00 priority fee
             </span>{" "}
-            and understand this action is irreversible.
+            will be charged and this transaction cannot be reversed once submitted.
           </span>
         </label>
 

--- a/docs/bills-state-inventory.md
+++ b/docs/bills-state-inventory.md
@@ -1,0 +1,392 @@
+# Bills Module – Component State Inventory
+
+> **Purpose:** Reduce implementation ambiguity by enumerating every UI state, copy, and interaction note for each Bills component. Cross-reference with `docs/DESIGN_QA_CHECKLIST.md` before shipping.
+>
+> **Route:** `/bills` → `app/bills/page.tsx`
+> **Last updated:** 2026-04-28
+
+---
+
+## Table of Contents
+
+1. [Status Model](#1-status-model)
+2. [BillsCard](#2-billscard)
+3. [UnpaidBillsSection](#3-unpaidbillssection)
+4. [RecentPaymentsSection](#4-recentpaymentssection)
+5. [BillPaymentsStatsCards](#5-billpaymentsstatscard)
+6. [Add Bill Form](#6-add-bill-form)
+7. [AsyncSubmissionStatus](#7-asyncsubmissionstatus)
+8. [AsyncOperationsPanel (sidebar)](#8-asyncoperationspanel-sidebar)
+9. [Reminders / Due-Soon](#9-reminders--due-soon)
+10. [Edge States & Global Notes](#10-edge-states--global-notes)
+
+---
+
+## 1. Status Model
+
+All bill status values are derived by `lib/bills/urgency.ts`. No component should compute urgency independently.
+
+| Status | Trigger condition | Days diff |
+|--------|-------------------|-----------|
+| `overdue` | Due date is in the past | `diff < 0` |
+| `urgent` | Due within 0–3 days (inclusive) | `0 ≤ diff ≤ 3` |
+| `upcoming` | Due in 4+ days | `diff > 3` |
+| `paid` | Manually set; never derived from date | — |
+
+**`daysInfo` label mapping** (from `computeDaysInfo`):
+
+| Condition | Label |
+|-----------|-------|
+| `diff < 0` | `{n}d overdue` |
+| `diff === 0` | `Due today` |
+| `diff === 1` | `Due tomorrow` |
+| `diff > 1` | `{n}d left` |
+| Paid | `Paid` (hardcoded in mock; real API should return this) |
+
+**Recurring fields** (optional on `Bill`):
+
+- `isRecurring: boolean` — drives the recurring badge and charge-type label
+- `recurrenceLabel?: string` — e.g. `"Monthly"`, `"Weekly"`
+- `nextOccurrence?: string` — ISO date of the next charge; shown in the recurring badge tooltip/sub-label
+
+---
+
+## 2. BillsCard
+
+**File:** `components/Bills/BillsCard.tsx`  
+**Variants:** `comfortable` (default) | `compact` (when `density === "compact"` from `DensityContext`)
+
+### 2.1 StatusBadge
+
+Rendered inside every card variant.
+
+| State | Icon | Badge copy | Badge color tokens |
+|-------|------|------------|--------------------|
+| `overdue` | `AlertCircle` | **Overdue** | `status-error-*` (red) |
+| `urgent` | `AlertCircle` | **Due Soon** | `status-warning-*` (amber) |
+| `upcoming` | `Clock4` | **Upcoming** | `status-info-*` (blue) |
+| `paid` | `CheckCircle2` | **Paid** | `status-success-*` (green) |
+
+- `aria-label` must be `"Status: {label}"` — already implemented; do not remove.
+- Icon is `aria-hidden="true"`.
+
+### 2.2 RecurringBadge
+
+Shown when `bill.isRecurring === true`.
+
+| Field present | Display |
+|---------------|---------|
+| `recurrenceLabel` only | `{recurrenceLabel}` (e.g. "Monthly") |
+| `recurrenceLabel` + `nextOccurrence` | `{recurrenceLabel} · Next {formattedDate}` |
+| Neither | `Recurring` (fallback copy) |
+
+**Interaction note:** The badge is informational only — no click action. If `nextOccurrence` is in the past (missed recurrence), surface a warning variant matching `urgent` color tokens.
+
+### 2.3 Comfortable card states
+
+| State | Due-date row | Pay Now button | Glow / border |
+|-------|-------------|----------------|---------------|
+| `overdue` | Red bg (`status-error-soft`), red border | Visible, red gradient | `border-status-error-border` |
+| `urgent` | Amber bg (`status-warning-soft`), amber border | Visible, red gradient | `border-status-warning-border` |
+| `upcoming` | Blue bg (`status-info-soft`), blue border | Visible, red gradient | `border-status-info-border` |
+| `paid` | Green bg (`status-success-soft`), green border | **Hidden** | `border-status-success-border` |
+
+**Charge-type sub-label** (below status badge):
+
+| `isRecurring` | Icon | Copy |
+|---------------|------|------|
+| `true` | `Repeat` | `Recurring charge` |
+| `false` | `CalendarClock` | `One-time charge` |
+
+**Pay Now button:**
+
+- Label: `Pay Now` with `Zap` icon.
+- Disabled state: not currently implemented — add `disabled` + `aria-disabled` when a payment is in-flight for this bill.
+- Loading state: replace label with `<Loader2 className="animate-spin" /> Processing…` while the XDR is being submitted.
+- Hidden entirely when `status === "paid"`.
+
+### 2.4 Compact card states
+
+Same status logic as comfortable. Differences:
+
+- Amount is right-aligned, larger (`text-lg`).
+- Due date is collapsed into a single line: `{category} · Due {dueDate}`.
+- Pay Now is an icon-only button (`Zap`). Must include `title="Pay Now"` and `aria-label="Pay Now"` for accessibility.
+- No recurring badge — recurring is not surfaced in compact mode. Consider adding a `Repeat` icon indicator if space allows.
+
+### 2.5 Edge states
+
+| Scenario | Expected behavior |
+|----------|-------------------|
+| `amount === 0` | Show `$0.00`; do not hide the card. Flag as a data anomaly in dev. |
+| `title` is very long (>40 chars) | Truncate with `truncate` class; full title in `title` attribute for tooltip. |
+| `dueDate` is missing / invalid | Show `—` in the due date field; log a console warning. |
+| `isRecurring === true` but `recurrenceLabel` absent | Fall back to `"Recurring"` copy. |
+| `nextOccurrence` is in the past | Show recurring badge with `urgent` color tokens and copy `"Missed recurrence"`. |
+
+---
+
+## 3. UnpaidBillsSection
+
+**File:** `components/Bills/UnpaidBillsSection.tsx`
+
+Filters `mockBills` (or API data) to statuses `['overdue', 'urgent', 'upcoming']`.
+
+### States
+
+| State | Condition | Header sub-copy | Grid content |
+|-------|-----------|-----------------|--------------|
+| **Populated** | ≥1 unpaid bill | `"{n} bills pending payment"` | Grid of `BillsCard` |
+| **Empty** | 0 unpaid bills | `"All bills are paid"` | Empty state illustration + copy (see below) |
+| **Loading** | Data fetch in-flight | `"Loading bills…"` | Skeleton cards (3 placeholders matching grid layout) |
+| **Error** | Fetch failed | `"Could not load bills"` | Inline error message + retry button |
+
+**Empty state copy:**
+> **You're all caught up!**
+> No unpaid bills right now. New bills you add will appear here.
+
+**Interaction notes:**
+- Section header "Unpaid Bills" is an `<h2>`. Do not change heading level.
+- The count in the sub-copy must update reactively when a bill is paid inline.
+- Density toggle (`compact` / `comfortable`) switches between `flex-col` list and CSS grid — already implemented.
+
+### Edge states
+
+| Scenario | Behavior |
+|----------|----------|
+| All bills are `upcoming` (none overdue/urgent) | Section still renders; no special callout needed. |
+| Mix of recurring and one-time bills | No grouping required; sort order: `overdue` → `urgent` → `upcoming`. |
+| Single bill | Grid renders one card; no layout change needed. |
+
+---
+
+## 4. RecentPaymentsSection
+
+**File:** `components/Bills/RecentPaymentsSection.tsx`
+
+Renders `mockPaidBills` (or API data filtered to `status === "paid"`).
+
+### States
+
+| State | Condition | Sub-copy | Content |
+|-------|-----------|----------|---------|
+| **Populated** | ≥1 paid bill | `"Last {n} payments"` | Grid of `BillsCard` (paid variant) |
+| **Empty** | 0 paid bills | `"No payments yet"` | Empty state (see below) |
+| **Loading** | Fetch in-flight | — | Skeleton cards |
+| **Error** | Fetch failed | — | Inline error + retry |
+
+**Empty state copy:**
+> **No payments recorded yet.**
+> Bills you pay will appear here for your records.
+
+**Interaction notes:**
+- Section uses `role="list"` on the grid and each `BillsCard` should carry `role="listitem"` in this context.
+- Paid cards have no Pay Now button — verify `status === "paid"` suppresses it.
+- Density toggle applies identically to `UnpaidBillsSection`.
+
+---
+
+## 5. BillPaymentsStatsCards
+
+**File:** `app/bills/components/BillPaymentsStatsCards.tsx`
+
+Three stat tiles: **Total Unpaid**, **Overdue Bills**, **Paid This Month**.
+
+### Per-tile states
+
+#### Total Unpaid
+
+| State | Amount display | Sub-copy |
+|-------|---------------|----------|
+| Normal | `${amount}` | `"{n} bills pending"` |
+| Zero unpaid | `$0` | `"0 bills pending"` |
+| Loading | Skeleton | — |
+
+#### Overdue Bills
+
+| State | Count display | Sub-copy | Color |
+|-------|--------------|----------|-------|
+| ≥1 overdue | `{n}` | `"Requires immediate attention"` | `text-red-500` |
+| 0 overdue | `0` | `"No overdue bills"` | `text-gray-400` (neutral) |
+| Loading | Skeleton | — | — |
+
+**Interaction note:** When `overdueCount === 0`, change sub-copy to neutral and remove the red `AlertCircle` badge background — use a muted icon instead to avoid false urgency.
+
+#### Paid This Month
+
+| State | Amount display | Sub-copy |
+|-------|---------------|----------|
+| Normal | `${amount}` | `"{n} payments made"` |
+| Zero paid | `$0` | `"No payments this month"` |
+| Loading | Skeleton | — |
+
+### Edge states
+
+| Scenario | Behavior |
+|----------|----------|
+| Stats API unavailable | Show `—` in all amount/count fields; do not crash. |
+| Very large amounts (>6 digits) | Use compact notation: `$1.2M`, `$10K`. |
+
+---
+
+## 6. Add Bill Form
+
+**Location:** `app/bills/page.tsx` (inline form section)
+
+### Form field states
+
+#### Bill Name (`name`)
+
+| State | Visual | Copy |
+|-------|--------|------|
+| Empty / idle | Placeholder: `e.g., Electricity, School Fees, Rent` | — |
+| Focused | Red focus ring (`focus:ring-red-500`) | — |
+| Validation error | Red error text below field | `{validationErrors[name].message}` |
+| Filled | Normal border | — |
+
+#### Amount (`amount`)
+
+| State | Visual | Copy |
+|-------|--------|------|
+| Empty / idle | Placeholder: `50.00`, `$` prefix | — |
+| Focused | Red focus ring | — |
+| Validation error | Red error text | `{validationErrors[amount].message}` |
+| Zero or negative | Validation error | `"Amount must be greater than 0"` |
+
+#### Due Date (`dueDate`)
+
+| State | Visual | Copy |
+|-------|--------|------|
+| Empty / idle | Native date picker | — |
+| Past date selected | Validation error | `"Due date cannot be in the past"` |
+| Validation error | Red error text | `{validationErrors[dueDate].message}` |
+
+**Note:** Past-date validation is not yet enforced in `actions.ts` — add `z.coerce.date().min(new Date(), ...)` when the action is uncommented.
+
+#### Recurring toggle (`recurring`)
+
+| State | Visual | Behavior |
+|-------|--------|----------|
+| Unchecked (default) | Unchecked checkbox | No frequency field shown |
+| Checked | Red checkbox | Reveal `frequencyDays` input (not yet implemented — see edge states) |
+
+**Edge state:** When `recurring === true`, the API requires `frequencyDays > 0`. The form must reveal a frequency input and validate it before submission. This field is absent from the current UI — it must be added before the action is enabled.
+
+### Submit button states
+
+| State | Label | Visual |
+|-------|-------|--------|
+| Idle | `Add Bill` | Red bg, full opacity |
+| Pending | `Preparing Contract Request…` | `Loader2` spinner, `disabled`, 70% opacity |
+| Success | Resets to idle after `AsyncSubmissionStatus` clears | — |
+| Error | Resets to idle; error shown in `AsyncSubmissionStatus` | — |
+
+**Interaction note:** The button is `disabled` during `pending`. Do not re-enable it until the async status resolves (success or error) to prevent duplicate submissions.
+
+---
+
+## 7. AsyncSubmissionStatus
+
+**File:** `components/AsyncSubmissionStatus.tsx` (shared component, used in bills form)
+
+| State | Title | Description |
+|-------|-------|-------------|
+| Idle | `"Submission placement"` | Explains inline vs. stack placement pattern |
+| Pending | `"Preparing bill contract request"` | `"Hold the user in this form context until the bill payload is ready for wallet approval."` |
+| Success | `"Bill contract request created"` | `"The next step should open wallet approval immediately…"` |
+| Error | `"Bill request could not be prepared"` | Error detail from `state.error` |
+
+**Interaction notes:**
+- The idle state is instructional copy for developers/designers — replace with a neutral placeholder or hide it in production.
+- On success, the wallet approval modal/sheet should open automatically without requiring another user action.
+- On error, the form fields must remain populated (controlled via `defaultValue={state.*}`) so the user can correct and resubmit.
+
+---
+
+## 8. AsyncOperationsPanel (sidebar)
+
+**File:** `components/AsyncOperationsPanel.tsx` (shared component, used in bills page sidebar)
+
+Displays the four-stage bill submission pattern and a live queue of async operations.
+
+### Stage states
+
+| Stage | Duration hint | Placement guidance |
+|-------|--------------|-------------------|
+| Validate bill details | 0–2 sec | Inline at field level |
+| Prepare contract payload | 2–6 sec | Inline above submit button |
+| Collect wallet approval | 15–45 sec | Wallet modal or sheet |
+| Submit and confirm | 5–30 sec | Top-right desktop, inline mobile |
+
+### Queue item states
+
+| Status | Visual | Copy pattern |
+|--------|--------|--------------|
+| `active` | Expanded, highlighted | Primary submission in progress |
+| `queued` | Compressed | Secondary task waiting |
+| `complete` | Success indicator | Brief success visible before auto-dismiss |
+
+**Interaction note:** On mobile, the sidebar collapses below the form. The queue stack should render directly below the form footer, not in a fixed overlay, to avoid obscuring the keyboard.
+
+---
+
+## 9. Reminders / Due-Soon
+
+**Endpoint:** `GET /api/bills/due-soon`  
+**Docs:** `docs/bill-reminders.md`
+
+The endpoint returns bills where `dueDate ≤ today + 7 days`, including overdue bills.
+
+### Reminder banner / notification states
+
+| State | Condition | Copy |
+|-------|-----------|------|
+| No reminders | 0 bills due soon | Do not render the banner |
+| 1 bill due | 1 result | `"{Bill name} is due {daysInfo}"` |
+| Multiple bills due | ≥2 results | `"{n} bills are due soon — view all"` |
+| Overdue included | Any result with `diff < 0` | Prepend overdue count: `"{n} overdue · {m} due soon"` |
+| API error | Fetch fails | Silently suppress; do not block page render |
+
+**Interaction notes:**
+- Poll on dashboard load and once per day (or on page focus).
+- Clicking the banner scrolls to `UnpaidBillsSection` or filters to the relevant bill.
+- Overdue bills must remain in the reminder list until `status` transitions to `paid` — they are not auto-dismissed by date.
+- Reminder state is not persisted client-side; re-fetch on each page load.
+
+---
+
+## 10. Edge States & Global Notes
+
+### Density context
+
+All bill list components consume `useDensity()` from `lib/context/DensityContext`. The toggle is global — changing it affects `UnpaidBillsSection`, `RecentPaymentsSection`, and any future bill list simultaneously.
+
+| Density | Layout | Card variant |
+|---------|--------|--------------|
+| `comfortable` | CSS grid (1 → 2 → 3 cols) | Full comfortable card |
+| `compact` | Single-column flex list | Compact card row |
+
+### Accessibility checklist (per DESIGN_QA_CHECKLIST.md §4)
+
+- [ ] All status badges have `aria-label="Status: {label}"`.
+- [ ] Icon-only Pay Now button in compact mode has `aria-label="Pay Now"`.
+- [ ] `UnpaidBillsSection` heading is `<h2>`; `RecentPaymentsSection` heading is `<h2>`.
+- [ ] `RecentPaymentsSection` grid has `role="list"`; cards have `role="listitem"`.
+- [ ] Color is never the sole differentiator — each status uses a distinct icon.
+- [ ] Focus ring is visible on all interactive elements (`focus-visible:ring-2 focus-visible:ring-red-400`).
+- [ ] Form inputs have associated `<label>` elements (currently using `htmlFor` — verify IDs match).
+
+### Data / API integration notes
+
+- Current implementation uses `mockBills` and `mockPaidBills`. Replace with `GET /api/bills` (paginated, cursor-based) when the API is live.
+- `POST /api/bills` returns `{ xdr: string }`. The frontend must sign the XDR and submit to Horizon — this step is not yet wired up. The form's success state should trigger the wallet signing flow, not show a final confirmation.
+- `POST /api/bills/[id]/pay` and `POST /api/bills/[id]/cancel` follow the same XDR pattern.
+- The `recurring` + `frequencyDays` field pairing must be validated together: if `recurring === true` and `frequencyDays` is absent or `≤ 0`, the API returns a 400.
+
+### Open questions
+
+1. **Frequency input UI** — What control for `frequencyDays`? Numeric input, dropdown (Weekly/Monthly/Custom), or both?
+2. **Inline pay confirmation** — Should "Pay Now" open a confirmation modal before building the XDR, or proceed immediately?
+3. **Overdue auto-escalation** — Should an `urgent` bill automatically become `overdue` client-side at midnight, or only on next page load / API refresh?
+4. **Compact mode recurring indicator** — Is a `Repeat` icon sufficient, or should the recurrence label be shown in compact rows?
+5. **Stats cards data source** — Are stats derived client-side from the bills list, or fetched from a dedicated `/api/bills/stats` endpoint?


### PR DESCRIPTION
## Summary
  
  Improves microcopy across both `EmergencyTransferModal` components for clarity, risk
  communication, and tone. Copy is now calm, direct, and unambiguous about what happens, what it
  costs, and when emergency transfers are appropriate.
  
  ## Changes
  
  ### `components/Dashboard/EmergencyTransferModal.tsx`
  - **Subtitle:** replaced vague "Priority processing guaranteed" with delivery time and use-case
  guidance
  - **Alert banner:** replaced generic fee warning with specific $2.00 amount, irreversibility
  statement, and appropriate-use examples (medical, family emergencies, time-critical payments)
  - **Speed options:** added fee and no-fee callout to Emergency/Regular labels
  - **Checkbox:** replaced legal-sounding "agree to terms" with plain-language confirmation
  naming the exact fee and irreversibility
  
  ### `app/send/components/EmergencyTransferModal.tsx`
  - **Subtitle:** replaced dev-facing implementation note with user-facing risk summary
  - **Speed option descriptions:** replaced dev-facing notes with user-facing guidance on when to
  choose each option
  - **Transfer summary subtitle:** replaced layout guidance with "These figures are final"
  - **AsyncSubmissionStatus:** replaced dev-facing placement notes with user-facing ready/pending
  states
  - **Checkbox:** aligned with Dashboard version — exact fee, urgency intent, irreversibility
  - **AsyncOperationsPanel description:** replaced dev-facing standardization note with
  user-oriented framing
  
  ## Files changed
  
  | File | Change |
  |------|--------|
  | `components/Dashboard/EmergencyTransferModal.tsx` | Microcopy updates |
  | `app/send/components/EmergencyTransferModal.tsx` | Microcopy updates |
  
  ## Testing
  
  - Verified copy does not introduce layout overflow (all strings are equal or shorter than
  originals)
  - No logic, styling, or component structure changed — copy only

closes #388 