### PR TITLE
feat(uiux): design family member limit controls and utilization meters

### DIFF
--- a/app/family/components/FamilyMemberStatCard.tsx
+++ b/app/family/components/FamilyMemberStatCard.tsx
@@ -56,43 +56,37 @@ const FamilyMemberStatCard: React.FC<FamilyMemberStatCardProps> = ({
 	};
 
 	const getUsageMeta = (usedPercentage: number) => {
-		if (usedPercentage >= 80) {
+		if (usedPercentage >= 100) {
 			return {
-				label: "Approaching limit",
-				textClass: "text-red-200",
-				badgeClass: "border-red-500/30 bg-red-500/[0.12] text-red-100",
-				barClass: "bg-gradient-to-r from-red-600 to-red-400",
-				helper: "Review this member's allowance soon.",
+				label: "Over limit",
+				textClass: "text-status-error-fg",
+				badgeClass: "border-status-error-border bg-status-error-bg text-status-error-fg",
+				barClass: "bg-status-error-fg",
+				panelBorderClass: "border-status-error-border",
+				helper: "Exceeded monthly limit.",
 			};
 		}
 
-		if (usedPercentage >= 40) {
+		if (usedPercentage >= 75) {
 			return {
-				label: "On track",
-				textClass: "text-amber-100",
-				badgeClass: "border-amber-500/30 bg-amber-500/[0.12] text-amber-100",
-				barClass: "bg-gradient-to-r from-amber-500 to-orange-400",
-				helper: "Usage is within the expected range.",
-			};
-		}
-
-		if (usedPercentage > 0) {
-			return {
-				label: "Low usage",
-				textClass: "text-emerald-100",
-				badgeClass:
-					"border-emerald-500/30 bg-emerald-500/[0.12] text-emerald-100",
-				barClass: "bg-gradient-to-r from-emerald-500 to-emerald-300",
-				helper: "This member still has plenty of budget available.",
+				label: "Near limit",
+				textClass: "text-status-warning-fg",
+				badgeClass: "border-status-warning-border bg-status-warning-bg text-status-warning-fg",
+				barClass: "bg-status-warning-fg",
+				panelBorderClass: "border-status-warning-border",
+				helper: "Approaching spending cap.",
 			};
 		}
 
 		return {
-			label: "Unused",
-			textClass: "text-gray-300",
-			badgeClass: "border-white/10 bg-white/[0.03] text-gray-200",
-			barClass: "bg-white/10",
-			helper: "No spending recorded yet this month.",
+			label: "On track",
+			textClass: "text-status-success-fg",
+			badgeClass: "border-status-success-border bg-status-success-bg text-status-success-fg",
+			barClass: "bg-status-success-fg",
+			panelBorderClass: "border-white/[0.08]",
+			helper: usedPercentage > 0
+				? "Usage is within range."
+				: "No spending recorded yet.",
 		};
 	};
 
@@ -113,7 +107,7 @@ const FamilyMemberStatCard: React.FC<FamilyMemberStatCardProps> = ({
 
 	const roleMeta = getRoleMeta(member.role);
 	const usageMeta = getUsageMeta(member.usedPercentage);
-	const remaining = Math.max(member.spendingLimit - member.used, 0);
+	const remaining = member.spendingLimit - member.used;
 
 	return (
 		<article className='rounded-3xl border border-white/10 bg-[linear-gradient(180deg,rgba(36,11,11,0.92),rgba(13,13,13,0.98))] p-6 shadow-[0_24px_60px_rgba(0,0,0,0.32)]'>
@@ -209,13 +203,13 @@ const FamilyMemberStatCard: React.FC<FamilyMemberStatCardProps> = ({
 					<p className='text-xs font-semibold uppercase tracking-[0.18em] text-gray-500'>
 						Remaining
 					</p>
-					<p className='mt-3 text-lg font-semibold text-white'>
+					<p className={`mt-3 text-lg font-semibold ${remaining < 0 ? "text-status-error-fg" : "text-white"}`}>
 						{currencyFormatter.format(remaining)}
 					</p>
 				</div>
 			</div>
 
-			<div className='mt-4 rounded-2xl border border-white/[0.08] bg-black/25 p-4'>
+			<div className={`mt-4 rounded-2xl border bg-black/25 p-4 ${usageMeta.panelBorderClass}`}>
 				<div className='flex flex-wrap items-center justify-between gap-2'>
 					<p className='text-sm font-medium text-white'>Utilization</p>
 					<p className={`text-sm ${usageMeta.textClass}`}>{usageMeta.helper}</p>
@@ -224,7 +218,7 @@ const FamilyMemberStatCard: React.FC<FamilyMemberStatCardProps> = ({
 				<div className='mt-4 h-2.5 w-full overflow-hidden rounded-full bg-white/[0.06]'>
 					<div
 						className={`h-full rounded-full transition-all duration-500 ${usageMeta.barClass}`}
-						style={{ width: `${member.usedPercentage}%` }}></div>
+						style={{ width: `${Math.min(member.usedPercentage, 100)}%` }}></div>
 				</div>
 
 				<div className='mt-3 flex items-center justify-between text-sm text-gray-400'>

--- a/docs/family-member-limits-utilization-handoff.md
+++ b/docs/family-member-limits-utilization-handoff.md
@@ -1,0 +1,106 @@
+# Family Member Limits and Utilization Handoff
+
+Feature area:
+- Family Wallets per-member spending limit controls and utilization visuals
+
+Route mapping:
+- `/family` -> `app/family/page.tsx`
+- Member card component -> `app/family/components/FamilyMemberStatCard.tsx`
+- Member section -> `app/family/components/FamilyMemberSection.tsx`
+- Summary cards -> `app/family/components/FamilyWalletsStatsCards.tsx`
+- Status tokens -> `tailwind.config.js` (`status.success.*`, `status.warning.*`, `status.error.*`)
+
+Primary user task:
+- Quickly scan member cards by utilization to identify who needs a limit review.
+- See at a glance whether a member is on track, near their cap, or over their limit.
+- Understand the limit-edit affordance even though contract integration is pending.
+
+---
+
+## Utilization Meter
+
+Each member card includes a utilization section with a labeled progress meter, status badge, and helper text.
+
+### Thresholds
+
+| Threshold | Range | Status Token | Badge Label | Bar Fill | Helper Text |
+|-----------|-------|-------------|-------------|----------|-------------|
+| On track | 0–74% | `status.success.*` | "On track" | `bg-status-success-fg` | "Usage is within range." / "No spending recorded yet." |
+| Near limit | 75–99% | `status.warning.*` | "Near limit" | `bg-status-warning-fg` | "Approaching spending cap." |
+| Over limit | ≥ 100% | `status.error.*` | "Over limit" | `bg-status-error-fg` | "Exceeded monthly limit." |
+
+### Visual design
+
+- Progress bar fills left-to-right with a solid status-token color (`bg-status-{tone}-fg`).
+- The meter container shows the current percentage centered between 0% and 100% labels.
+- When usage ≥ 75%, the utilization panel border changes to `border-status-warning-border` or `border-status-error-border` for quick visual scanning.
+- The "Remaining" stat card below the meter turns `text-status-error-fg` when remaining is negative (over limit).
+
+---
+
+## Limit-Edit Affordance
+
+The "Edit Limits" button is rendered as a full-width disabled button with:
+- `Edit2` icon (pencil) from lucide-react
+- Disabled cursor (`cursor-not-allowed`) and reduced opacity (`opacity-60`)
+- Red-tinted background (`bg-red-500/10`, `border-red-500/20`) to visually separate from the "View Details" neutral button
+- Helper text beneath: "Member actions will unlock after the wallet contract integration is connected."
+
+This affordance communicates the intended interaction (adjust per-member spending limits) while making the pre-integration state explicit. When contract integration ships, the `disabled` attribute is removed and the button wires to the limit-adjustment flow.
+
+---
+
+## Member Card Layout
+
+### Card structure (top to bottom)
+
+1. **Identity row** — Avatar initial, name, role badge, usage-status badge
+2. **Monthly usage** — Amount used this month, percentage of limit
+3. **Stellar address** — ID with copy button
+4. **Limit stats row** — 3-column grid: Spending limit, Spent, Remaining (red when negative)
+5. **Utilization meter** — Status-colored progress bar with panel border feedback
+6. **Action buttons** — "View Details" (neutral) and "Edit Limits" (accent, disabled)
+
+### Breakpoints
+
+| Breakpoint | Layout |
+|-----------|--------|
+| Mobile (< 640px) | Single-column card stack. Limit stats and action buttons stack vertically. Utilization meter spans full width. |
+| Tablet (640px–1023px) | Two-column card grid (`md:grid-cols-2`). Identity row shifts to horizontal flex. Limit stats row shows 3 columns. |
+| Desktop (≥ 1024px) | Two-column card grid. Right rail with roles and add-member panel pinned via `xl:sticky`. |
+
+---
+
+## Accessibility
+
+- Utilization state is conveyed by text label + percentage value + progress meter (not by color alone).
+- Status badges use `status.*` token colors which pass AA contrast on dark backgrounds:
+  - Success green (`#86EFAC`) on dark bg
+  - Warning yellow (`#FDE68A`) on dark bg
+  - Error pink/red (`#FDA4AF`) on dark bg
+- Focus-visible rings use `ring-red-400` with `ring-offset-2` offset against `#0d0d0d` for keyboard navigation.
+- Button touch targets are 44px+ (WCAG 2.1 AAA).
+
+---
+
+## Tailwind Tokens Used
+
+- `text-status-success-fg`, `bg-status-success-fg`, `border-status-success-border`, `bg-status-success-bg`
+- `text-status-warning-fg`, `bg-status-warning-fg`, `border-status-warning-border`, `bg-status-warning-bg`
+- `text-status-error-fg`, `bg-status-error-fg`, `border-status-error-border`, `bg-status-error-bg`
+
+All tokens already exist in `tailwind.config.js`. No new tokens were added.
+
+---
+
+## Open Questions
+
+- Should the 75% warning threshold be configurable per wallet in a later pass?
+- Should admins with no personal spending limit be excluded from utilization reporting?
+- Should over-limit members be surfaced with inline alert copy in addition to the red meter?
+
+---
+
+## Closure Note
+
+- design: handoff ready in repo docs; utilization meter and limit affordance implemented in code


### PR DESCRIPTION
## Summary

Implements per-member spending limit controls and utilization visuals on Family Wallets as specified in issue #413.

## Changes

### `app/family/components/FamilyMemberStatCard.tsx`
- **Three-threshold utilization meter** using `status.*` tokens:
  - **On track** (< 75%): `status.success.*` tokens green progress bar, green helper text
  - **Near limit** (75–99%): `status.warning.*` tokens amber progress bar, amber panel border, "Approaching spending cap" helper
  - **Over limit** (>= 100%): `status.error.*` tokens red progress bar, red panel border, red "Remaining" value, "Exceeded monthly limit" helper
- **Status token integration**: Replaced 4 custom color states with 3 semantic states using `status.success.*`, `status.warning.*`, `status.error.*` tokens from `tailwind.config.js`
- **Over-limit state**: New state for members who exceed their cap panel border glows red, remaining shows negative amount in red
- **Progress bar**: Caps at 100% width (`Math.min`) so over-limit members don't overflow the meter visually
- **Remaining calculation**: Removed `Math.max(..., 0)` to show actual (possibly negative) headroom
- **Pre-integration affordance**: "Edit Limits" button stays disabled with red-tinted styling and explanatory helper text

### `docs/family-member-limits-utilization-handoff.md`
New design handoff document documenting:
- Threshold semantics and status token mapping table
- Utilization meter visual design
- Limit-edit affordance design and pre-integration state
- Card structure (top-to-bottom layout)
- Responsive breakpoints: mobile stack, two-column tablet, desktop grid with right rail
- Accessibility notes (text + meter, AA contrast, focus rings)
- Open questions for future iterations

## Design Decisions

| Threshold | Range | Status Token | Visual Feedback |
|-----------|-------|-------------|-----------------|
| On track | 0-74% | `success` | Green bar, neutral border |
| Near limit | 75-99% | `warning` | Amber bar, amber border |
| Over limit | >= 100% | `error` | Red bar, red border, red remaining |

- **75% warning threshold** matches the existing handoff doc (open question #2 in `family-wallets-handoff.md`)
- No new Tailwind tokens were added; all `status.*` tokens existed from the color-contrast-status-semantics pass
- Mobile single-column layout unchanged cards already used `grid-cols-1` with proper stacking

## Risk & Rollback

- **Risk level**: Low
- Changes are purely presentational (no data fetching, no business logic, no contract integration)
- All existing member cards render identically except for updated color tokens and threshold labels
- Rollback: revert commit `81f41a3`

Closes #413
