### PR TITLE
docs: add CONTRIBUTING guide and frontend architecture overview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,185 @@
+# Contributing to RemitWise Frontend
+
+Thank you for contributing! This guide covers everything you need to get started: branch conventions, the verified test commands, and PR expectations.
+
+For a deeper look at how the codebase is structured, see [docs/architecture.md](docs/architecture.md).
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Branch Naming](#branch-naming)
+3. [Development Setup](#development-setup)
+4. [Test Commands](#test-commands)
+5. [PR Expectations](#pr-expectations)
+6. [Where to Add Things](#where-to-add-things)
+7. [Adding an i18n Key](#adding-an-i18n-key)
+
+---
+
+## Prerequisites
+
+- Node.js 18+
+- npm (or pnpm — a `pnpm-lock.yaml` is present)
+- A `.env` file with at minimum `DATABASE_URL="file:./dev.db"` and `SESSION_PASSWORD` (≥32 chars)
+
+```bash
+npm install
+npx prisma migrate dev
+npm run dev
+```
+
+---
+
+## Branch Naming
+
+Follow the pattern already used in this repo:
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| UI/UX work | `uiux/<short-description>` | `uiux/dashboard-empty-states` |
+| Feature | `feat/<short-description>` | `feat/recurring-remittance` |
+| Bug fix | `fix/<short-description>` | `fix/session-expiry-redirect` |
+| Docs | `docs/<short-description>` | `docs/contributing-architecture` |
+| Refactor | `refactor/<short-description>` | `refactor/contract-cache-types` |
+
+---
+
+## Development Setup
+
+```bash
+git checkout -b <your-branch>
+npm install
+npx prisma migrate dev   # only needed if schema changed
+npm run dev
+```
+
+---
+
+## Test Commands
+
+All commands below are verified against `package.json`.
+
+### Quick reference
+
+```bash
+npm run lint              # ESLint across the whole project
+npm run build             # Next.js production build (also runs tsc)
+npm run test              # Alias for test:unit
+npm run test:unit         # Runs BOTH node:test suites AND Vitest unit tests (see below)
+npm run test:coverage     # Vitest run with coverage report
+npm run test:watch        # Vitest in watch mode
+npm run test:ui           # Vitest UI
+npm run test:property     # Property-based tests via Vitest
+npm run test:integration  # node:test integration suites + Vitest integration tests
+npm run test:e2e          # Playwright end-to-end tests
+```
+
+### Two test runners in `test:unit`
+
+`npm run test:unit` runs two sub-commands back-to-back:
+
+```
+test:unit:node    →  node --test tests/unit/webhooks-verify.test.cjs
+                              tests/unit/middleware.test.cjs
+                              tests/unit/contract-cache.test.cjs
+
+test:unit:vitest  →  vitest run tests/unit/validation/savings-goals.test.ts
+```
+
+**Why two runners?** The `.cjs` suites use Node's built-in `node:test` runner because they test CommonJS-compatible modules (webhook verification, raw middleware logic, and the LRU contract-cache) that do not need a browser-like environment. The `.ts` Vitest suite handles TypeScript validation logic and benefits from Vitest's `expect` API and fast ESM transform. When adding new unit tests:
+
+- Write `.cjs` with `node:test` / `assert` when testing a Node-native module (crypto, HTTP internals, or anything in `lib/` that has no JSX).
+- Write `.ts` with Vitest when you need TypeScript types, `vi.mock`, or `expect` matchers.
+
+### Integration tests
+
+```bash
+npm run test:integration
+```
+
+This runs:
+
+1. `node --test tests/integration/auth.test.cjs tests/integration/health.test.cjs tests/integration/validation.test.cjs` — node:test suites that spin up real HTTP calls against a running (or in-process) server.
+2. `vitest run tests/integration/api/goals-validation.test.ts` — Vitest integration tests for the goals API.
+
+Integration tests require `DATABASE_URL` to point to a real (SQLite) database. They do **not** mock the database layer.
+
+### End-to-end tests
+
+```bash
+npm run test:e2e   # Playwright — requires the dev server to be running
+```
+
+---
+
+## PR Expectations
+
+1. **Claim the issue first** — comment on the GitHub issue before starting work.
+2. **One concern per PR** — keep scope tight; large PRs stall in review.
+3. **Lint must pass** — run `npm run lint` locally before pushing. CI will reject lint failures.
+4. **Build must pass** — run `npm run build` to catch TypeScript errors early.
+5. **Tests** — add or update tests that cover your change. Prefer the existing runner for the file type (`.cjs` → node:test, `.ts` → Vitest).
+6. **PR description** — summarise what changed and why. Link the issue (`Closes #NNN`).
+7. **No commented-out code** — remove dead code rather than commenting it out.
+8. **i18n** — any user-visible string must use the i18n system (see [Adding an i18n Key](#adding-an-i18n-key)).
+
+Example commit message style used in this repo:
+
+```
+feat: add recurring remittance schedule UI
+
+Implements the schedule picker and wires it to POST /api/remittance/recurring.
+Closes #301
+```
+
+---
+
+## Where to Add Things
+
+| What you're adding | Where it lives |
+|--------------------|----------------|
+| New page/route | `app/<route-name>/page.tsx` (Next.js App Router) |
+| Shared UI component | `components/ui/` |
+| Feature-specific component | `components/<feature>/` |
+| React hook | `lib/hooks/` |
+| Server-side API route | `app/api/<resource>/route.ts` |
+| Versioned API route | `app/api/v1/<resource>/route.ts` |
+| Soroban contract read/write | `lib/contracts/<feature>.ts` |
+| Cached contract reads | wrap in `lib/cache/contract-cache.ts` helpers |
+| Auth/session helpers | `lib/session.ts` or `lib/auth/` |
+| Database queries | `lib/db.ts` or a dedicated file under `lib/` |
+| i18n strings | `lib/i18n/locales/en.json` **and** `lib/i18n/locales/es.json` |
+| Type definitions | `types/` |
+| Utility functions | `utils/` or a file under `lib/` |
+
+See [docs/architecture.md](docs/architecture.md) for a full layer map.
+
+---
+
+## Adding an i18n Key
+
+1. Add the key + English value to `lib/i18n/locales/en.json`.
+2. Add the **same key** with a Spanish translation to `lib/i18n/locales/es.json`. Use a placeholder (`"[ES] <English text>"`) if you are not a Spanish speaker — a translator will follow up.
+3. In server components or API routes, use the `getTranslator` helper from `lib/i18n/index.ts`:
+
+   ```ts
+   import { getTranslator } from '@/lib/i18n';
+   const t = getTranslator(request.headers.get('accept-language'));
+   t('your.new.key');
+   ```
+
+4. In client components, use the `useClientLocale` hook from `lib/i18n/client.ts`:
+
+   ```tsx
+   import { useClientLocale } from '@/lib/i18n/client';
+   const { t } = useClientLocale();
+   t('your.new.key');
+   ```
+
+---
+
+## Questions?
+
+Join the [RemitWise Discord](https://discord.gg/CtQuPZFMA) or open a discussion on GitHub.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Frontend application for the RemitWise remittance and financial planning platform.
 
+> **New contributors:** start with [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, verified test commands, and PR expectations, then read [docs/architecture.md](docs/architecture.md) for a full route and layer map.
+
 ## Overview
 
 This is a Next.js-based frontend skeleton that provides the UI structure for all RemitWise features. The application is built with:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,353 @@
+# Frontend Architecture
+
+This document maps the route structure, library layers, and key subsystems of the RemitWise Frontend. Read it alongside [CONTRIBUTING.md](../CONTRIBUTING.md) before making changes.
+
+---
+
+## Table of Contents
+
+1. [Tech Stack](#tech-stack)
+2. [Route Map](#route-map)
+3. [API Routes](#api-routes)
+4. [Library Layers](#library-layers)
+   - [Hooks (`lib/hooks/`)](#hooks-libhooks)
+   - [Client Utilities (`lib/client/`)](#client-utilities-libclient)
+   - [Contract Layer (`lib/contracts/`)](#contract-layer-libcontracts)
+   - [Cache Layer (`lib/cache/`)](#cache-layer-libcache)
+   - [Session & Auth (`lib/session.ts`, `lib/auth/`)](#session--auth)
+5. [i18n](#i18n)
+6. [Middleware (`middleware.ts`)](#middleware-middlewarets)
+7. [Database & Prisma](#database--prisma)
+8. [Testing Architecture](#testing-architecture)
+
+---
+
+## Tech Stack
+
+| Concern | Tool |
+|---------|------|
+| Framework | Next.js 14 (App Router) |
+| Language | TypeScript |
+| Styling | Tailwind CSS |
+| Icons | Lucide React |
+| Database | SQLite via Prisma |
+| Blockchain | Stellar / Soroban (stellar-sdk) |
+| Session | iron-session (encrypted cookie) |
+| i18n | i18next (server) + custom hook (client) |
+| Unit tests | node:test (.cjs) + Vitest (.ts) |
+| E2E tests | Playwright |
+
+---
+
+## Route Map
+
+All pages live under `app/` and use the Next.js App Router convention (`page.tsx` = route).
+
+```
+/                        app/page.tsx               — Landing / root redirect
+/dashboard               app/dashboard/page.tsx     — Main dashboard
+/dashboard/goals         app/dashboard/goals/page.tsx
+/dashboard/insight       app/dashboard/insight/page.tsx
+/dashboard/transaction-history  app/dashboard/transaction-history/page.tsx
+/send                    app/send/page.tsx           — Send money (remittance)
+/split                   app/split/page.tsx          — Smart money split
+/bills                   app/bills/page.tsx          — Bill payments
+/family                  app/family/page.tsx         — Family wallets
+/insurance               app/insurance/page.tsx      — Micro-insurance
+/transactions            app/transactions/page.tsx
+/insights                app/insights/page.tsx
+/financial-insight       app/financial-insight/page.tsx
+/financial-insights      app/financial-insights/page.tsx
+/emergency-transfer      app/emergency-transfer/page.tsx
+/settings                app/settings/page.tsx
+/tutorial                app/tutorial/page.tsx
+/tutorial/[tutorialId]   app/tutorial/[tutorialId]/page.tsx
+/tutorial/[tutorialId]/chapter/[chapterId]  app/tutorial/[tutorialId]/chapter/[chapterId]/page.tsx
+```
+
+The shared layout (`app/layout.tsx`) wraps every page with providers, fonts, and the global nav.
+
+**Adding a new page:** create `app/<route-name>/page.tsx`. If it needs server-side auth, call `requireAuth()` from `lib/session.ts` at the top of the async server component.
+
+---
+
+## API Routes
+
+Internal Next.js API routes live under `app/api/`. A versioned namespace (`app/api/v1/`) is used for endpoints consumed by external wallets or integrators.
+
+### Auth
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/api/auth/login` | Verify signed nonce and create session |
+| POST | `/api/auth/logout` | Clear session cookie |
+| GET  | `/api/auth/me` | Return current session address |
+| GET  | `/api/auth/nonce` | Issue a nonce for wallet signing |
+| POST | `/api/auth/verify` | Verify a Stellar signature |
+
+### Dashboard & Insights
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/dashboard` | Aggregate dashboard data |
+| GET | `/api/insights` | Financial insights |
+
+### Remittance
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/api/remittance/build` | Build remittance transaction XDR |
+| GET  | `/api/remittance/history` | Remittance history |
+| POST | `/api/remittance/recurring` | Create recurring schedule |
+| GET  | `/api/v1/remittance/history` | Versioned history |
+| GET  | `/api/v1/remittance/status/[txHash]` | Poll transaction status |
+| POST | `/api/v1/remittance/emergency/build` | Emergency transfer XDR |
+
+### Bills
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET/POST | `/api/bills` | List / create bills |
+| GET/PUT/DELETE | `/api/bills/[id]` | Single bill |
+| GET | `/api/bills/total-unpaid` | Unpaid total |
+| GET | `/api/v1/bills` | Versioned list |
+| POST | `/api/v1/bills/[id]/pay` | Pay a bill |
+| POST | `/api/v1/bills/[id]/cancel` | Cancel a bill |
+| GET | `/api/v1/bills/due-soon` | Bills due within threshold |
+
+### Savings Goals
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET/POST | `/api/goals` | List / create goals |
+| GET/PUT/DELETE | `/api/goals/[id]` | Single goal |
+| POST | `/api/goals/[id]/add` | Add funds |
+| POST | `/api/goals/[id]/withdraw` | Withdraw funds |
+| POST | `/api/goals/[id]/lock` | Lock goal |
+| POST | `/api/goals/[id]/unlock` | Unlock goal |
+| GET  | `/api/goals/[id]/completed` | Mark completed |
+
+### Insurance
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET/POST | `/api/insurance` | List / create policies |
+| GET/DELETE | `/api/insurance/[id]` | Single policy |
+| GET | `/api/insurance/total-premium` | Total premiums |
+| GET | `/api/insurance/reminders` | Upcoming renewals |
+| POST | `/api/v1/insurance/[id]/pay` | Pay premium (returns XDR) |
+| POST | `/api/v1/insurance/[id]/deactivate` | Deactivate policy (returns XDR) |
+
+### Family Wallets
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/family` | Family overview |
+| GET/POST | `/api/family/members` | List / add members |
+| GET/PUT/DELETE | `/api/family/members/[id]` | Single member |
+| PUT | `/api/family/members/[id]/limit` | Update spending limit |
+| GET | `/api/family/members/[id]/check` | Check spending allowance |
+
+### Send / Split
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/api/send` | Submit send transaction |
+| GET/POST | `/api/split` | Split config |
+| POST | `/api/split/calculate` | Calculate split amounts |
+| POST | `/api/split/initialize` | Initialise split state |
+| PUT  | `/api/split/update` | Update split percentages |
+
+### User
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET/PUT | `/api/user/profile` | User profile |
+| GET/PUT | `/api/user/preferences` | User preferences |
+
+### Anchor (Stellar SEP)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/api/anchor/deposit` | Initiate deposit |
+| POST | `/api/anchor/withdraw` | Initiate withdrawal |
+| GET  | `/api/anchor/rates` | Exchange rates |
+| (v1 mirrors of the above) | `/api/v1/anchor/*` | |
+
+### Admin
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/admin/users` | List users |
+| GET | `/api/admin/audit` | Audit log |
+| POST | `/api/admin/cache/clear` | Clear server cache |
+| (v1 mirrors + webhook DLQ) | `/api/v1/admin/*` | |
+
+### Webhooks & Discovery
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/api/webhooks/anchor` | Anchor webhook receiver |
+| GET  | `/api/.well-known/openapi` | OpenAPI spec redirect |
+| GET  | `/api/docs/spec` | Serve `openapi.yaml` |
+| GET  | `/api/health` | Health check |
+| GET  | `/api/metrics` | Prometheus-style metrics |
+
+---
+
+## Library Layers
+
+### Hooks (`lib/hooks/`)
+
+Client-side React hooks. These run in the browser (all files have `"use client"` or are imported only from client components).
+
+| File | Export | Purpose |
+|------|--------|---------|
+| `useFormAction.ts` | `useFormAction<T>(url, method)` | Generic form submission hook that wraps `fetch` in a React `useTransition`. Returns `[state, formAction, isPending]`. Use this whenever a component submits data to an API route via `FormData`. |
+| `useSessionExpiry.ts` | `useSessionExpiry` (via `lib/client/`) | Detects 401 responses and triggers a redirect to re-authenticate. |
+
+**When to add a hook:** extract shared stateful logic that is needed by two or more client components. One-off component state stays inside the component.
+
+### Client Utilities (`lib/client/`)
+
+Browser-safe helpers imported from client components and hooks.
+
+| File | Purpose |
+|------|---------|
+| `apiClient.ts` | Thin `fetch` wrapper (`apiClient.get/post/put/delete`) that detects session expiry (HTTP 401) and delegates to `sessionHandler` to redirect the user. Use this in client components instead of raw `fetch` for any authenticated request. |
+| `sessionHandler.ts` | Reads `sessionHandler.isSessionExpired(response)` and calls `sessionHandler.handleSessionExpiry(currentPath)`. Imported by `apiClient`. |
+| `logout.ts` | Calls `POST /api/auth/logout` and clears local state. |
+
+### Contract Layer (`lib/contracts/`)
+
+Soroban smart-contract integration. Each file corresponds to one deployed contract.
+
+| File | Contract | Key exports |
+|------|----------|-------------|
+| `savings-goal.ts` | Savings Goals | `getSavingsGoal`, `getAllGoals`, `buildAddFundsTx`, `buildWithdrawTx`, `buildLockTx` |
+| `bill-payments.ts` | Bill Payments | `buildPayBillTx`, `buildCreateBillTx` |
+| `remittance-split.ts` | Remittance Split | `buildSplitTx`, `calculateSplit` |
+| `insurance.ts` | Insurance | `buildCreatePolicyTx`, `buildPayPremiumTx`, `buildDeactivateTx` |
+| `family-wallet.ts` | Family Wallet | `getMember`, `getAllMembers`, `buildAddMemberTx`, `buildUpdateSpendingLimitTx`, `checkSpendingLimit` |
+| `network-resolution.ts` | — | `resolveContractId(name)` — reads contract IDs from env vars based on `SOROBAN_NETWORK` |
+| `dashboard-aggregate.ts` | — | Aggregates reads from multiple contracts for the dashboard |
+| `insurance-cached.ts` | — | Insurance reads wrapped with the cache layer |
+| `remittance-split-cached.ts` | — | Split reads wrapped with the cache layer |
+
+**Contract ID resolution:** `resolveContractId("SAVINGS_GOALS")` reads `SAVINGS_GOALS_CONTRACT_ID_TESTNET` or `SAVINGS_GOALS_CONTRACT_ID_MAINNET` (depending on `SOROBAN_NETWORK`). You can also set `CONTRACT_IDS_JSON` as a single JSON blob keyed by network.
+
+**Adding a new contract:** create `lib/contracts/<feature>.ts`, import `resolveContractId` from `network-resolution.ts`, and export typed build/read functions. Read functions that are called frequently should be wrapped with the cache layer (see below).
+
+### Cache Layer (`lib/cache/`)
+
+LRU in-memory cache for Soroban contract **read** operations (writes always go straight to the network).
+
+| File | Purpose |
+|------|---------|
+| `contract-cache.ts` | `ContractCache` class with `get`, `set`, `invalidate`, `getStats`. Implements TTL eviction, input validation, and DoS protection (max key length, max entry count). |
+| `registry.ts` | Pre-configured cache instances for each contract domain. Import the named instance (e.g. `savingsGoalCache`) rather than constructing your own. |
+
+**When to add a cached read:** if a contract read is called on every page load or from multiple components, add a cache wrapper in `lib/contracts/<feature>-cached.ts` that checks the registry cache before calling the RPC node. Never cache writes or reads that must be real-time (e.g. spending-limit checks before a transaction).
+
+**Invalidation:** call `POST /api/admin/cache/clear` (admin only) or `POST /api/cache/invalidate` to bust the server-side cache after a write.
+
+### Session & Auth
+
+| File | Purpose |
+|------|---------|
+| `lib/session.ts` | `requireAuth()` — throws a 401 Response if no valid session. `getSessionWithRefresh()` — returns session or null. Uses iron-session with an encrypted cookie keyed by `SESSION_PASSWORD`. |
+| `lib/auth/` | Middleware helpers, action-state types, and fetch wrappers used by server actions. |
+| `lib/client/sessionHandler.ts` | Client-side detection of expired sessions (401 responses). |
+
+**Auth flow:**
+1. Wallet signs a nonce from `GET /api/auth/nonce`.
+2. Frontend posts signature to `POST /api/auth/login`.
+3. Server verifies the Stellar signature and sets an iron-session cookie.
+4. Subsequent API calls carry the cookie; server routes call `requireAuth()` to validate.
+5. On 401, `apiClient` calls `sessionHandler.handleSessionExpiry()` which redirects to login.
+
+---
+
+## i18n
+
+Supported locales: **English (`en`)** and **Spanish (`es`)**.
+
+| File | Role |
+|------|------|
+| `lib/i18n/locales/en.json` | English strings (source of truth) |
+| `lib/i18n/locales/es.json` | Spanish translations |
+| `lib/i18n/index.ts` | `getTranslator(acceptLanguageHeader)` — server-side helper, reads `Accept-Language` header |
+| `lib/i18n/client.ts` | `useClientLocale()` hook — client-side, reads `navigator.language` |
+
+Both files must stay in sync. When adding a key, add it to `en.json` first, then add the same key to `es.json`. See [CONTRIBUTING.md — Adding an i18n Key](../CONTRIBUTING.md#adding-an-i18n-key).
+
+---
+
+## Middleware (`middleware.ts`)
+
+The Next.js middleware runs on every request before routing. It handles:
+
+- **CORS** — allowed origins are configured via the `ALLOWED_ORIGINS` env var (comma-separated list).
+- **Security headers** — `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`.
+- **Request body size limit** — default 1 MB, overridden by `API_MAX_BODY_SIZE`.
+- **Request logging** — structured logs via `lib/logger.ts` with a per-request ID from `lib/requestId.ts`.
+- **Metrics** — in-memory request/error counters exposed at `GET /api/metrics`.
+
+The middleware does **not** perform auth checks; auth is enforced inside each route handler via `requireAuth()`.
+
+---
+
+## Database & Prisma
+
+Schema: `prisma/schema.prisma`. Client: `lib/prisma.ts` (singleton with connection pooling tuned for serverless).
+
+```bash
+npx prisma migrate dev      # apply pending migrations
+npx prisma studio           # browse data locally
+```
+
+Database access belongs in API route handlers or server components only — never import `lib/prisma.ts` from client code.
+
+---
+
+## Testing Architecture
+
+See [CONTRIBUTING.md — Test Commands](../CONTRIBUTING.md#test-commands) for the exact commands. This section explains the structure.
+
+```
+tests/
+├── unit/
+│   ├── webhooks-verify.test.cjs     # node:test — webhook HMAC verification
+│   ├── middleware.test.cjs          # node:test — raw middleware logic
+│   ├── contract-cache.test.cjs      # node:test — LRU cache behaviour
+│   ├── contract-cache.test.ts       # Vitest mirror (TypeScript types)
+│   ├── sanitize.test.ts             # Vitest — input sanitisation
+│   ├── cached-wrappers.test.ts      # Vitest — cached contract read wrappers
+│   └── validation/
+│       └── savings-goals.test.ts    # Vitest — savings-goal schema validation
+├── integration/
+│   ├── auth.test.cjs                # node:test — auth flow against real DB
+│   ├── health.test.cjs              # node:test — health endpoint
+│   ├── validation.test.cjs          # node:test — input validation
+│   ├── split.test.cjs               # node:test — split calculations
+│   └── api/
+│       └── goals-validation.test.ts # Vitest — goals API validation
+├── property/                        # Vitest property-based tests
+├── session/                         # Session handling tests
+└── e2e/                             # Playwright specs
+    ├── auth.spec.ts
+    ├── health.spec.ts
+    ├── remittance-api.spec.ts
+    └── responsive-split-savings.spec.ts
+```
+
+### node:test vs Vitest
+
+| Concern | Use `node:test` (`.cjs`) | Use Vitest (`.ts`) |
+|---------|--------------------------|-------------------|
+| File extension | `.cjs` | `.ts` |
+| Run via | `node --test <files>` | `vitest run <files>` |
+| Best for | Node built-ins, crypto, raw HTTP | TypeScript, React, `vi.mock`, `expect` |
+| Examples in this repo | Webhook HMAC, raw middleware, LRU cache | Validation schemas, cached wrappers, savings-goal logic |
+
+Both runners are exercised by `npm run test:unit` and `npm run test:integration`. New tests should follow the convention of the directory they're added to.


### PR DESCRIPTION
- Add CONTRIBUTING.md with branch naming, PR expectations, and verified test commands
- Add docs/architecture.md covering route map, hooks, contract/cache/api layers, and i18n
- Document node:test vs Vitest suite distinction
- Cross-link from README.md

Closes #482