### PR TITLE
feat(transactions): add filters, debounced search, and date grouping

### DIFF
--- a/app/api/v1/remittance/history/route.ts
+++ b/app/api/v1/remittance/history/route.ts
@@ -5,10 +5,10 @@ import { fetchTransactionHistory } from '../../../../../lib/remittance/horizon';
 export const dynamic = 'force-dynamic';
 
 /**
- * GET /api/remittance/history (protected)
+ * GET /api/v1/remittance/history (protected)
  * Returns list of transactions for session user.
- * 
- * Query params: 
+ *
+ * Query params:
  * - limit: number (default 10, max 200)
  * - cursor: string (pagination)
  * - status: 'completed' | 'failed' | 'pending'
@@ -35,7 +35,10 @@ export async function GET(req: NextRequest) {
       status: status || undefined,
     });
 
-    return NextResponse.json(history);
+    return NextResponse.json({
+      ...history,
+      userAddress: session.address,
+    });
   } catch (error: any) {
     console.error('Error fetching remittance history:', error);
     return NextResponse.json(

--- a/app/dashboard/transaction-history/page.tsx
+++ b/app/dashboard/transaction-history/page.tsx
@@ -1,209 +1,623 @@
 "use client";
 
-import { useState, useEffect, useCallback } from 'react';
-import TransactionHistoryItem from '@/components/Dashboard/TransactionHistoryItem';
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { Download, FilterIcon, Loader2, SearchX, Inbox, X } from "lucide-react";
+import TransactionHistoryItem from "@/components/Dashboard/TransactionHistoryItem";
 import TransactionHistoryHeader from "./components/transaction-history-header";
 import TransactionHistorySearchInput from "./components/transaction-history-search-input";
 import Button from "./components/transaction-history-button";
-import { Download, FilterIcon, Loader2 } from "lucide-react";
-import { TransactionItem } from '@/lib/remittance/horizon';
-import { useClientTranslator } from '@/lib/i18n/client';
+import WidgetEmptyState from "@/components/ui/WidgetEmptyState";
+import { TransactionItem } from "@/lib/remittance/horizon";
+import { useClientTranslator } from "@/lib/i18n/client";
+import { useDebounce } from "@/lib/hooks/useDebounce";
+import type { Transaction, TransactionStatus } from "@/components/Dashboard/TransactionHistoryItem";
+
+type Direction = "all" | "sent" | "received";
+
+type GroupKey = "today" | "yesterday" | "earlier";
+
+function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function getGroupKey(date: Date, todayStart: Date, yesterdayStart: Date): GroupKey {
+  const d = startOfDay(date);
+  if (d.getTime() === todayStart.getTime()) return "today";
+  if (d.getTime() === yesterdayStart.getTime()) return "yesterday";
+  return "earlier";
+}
 
 const TransactionHistoryPage = () => {
   const { t } = useClientTranslator();
   const [transactions, setTransactions] = useState<TransactionItem[]>([]);
+  const [userAddress, setUserAddress] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [initialLoading, setInitialLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [statusFilter, setStatusFilter] = useState<'all' | 'completed' | 'failed' | 'pending'>('all');
+  const [searchTerm, setSearchTerm] = useState("");
+  const debouncedSearch = useDebounce(searchTerm, 300);
+  const [statusFilter, setStatusFilter] = useState<"all" | "completed" | "failed" | "pending">("all");
+  const [directionFilter, setDirectionFilter] = useState<Direction>("all");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
   const [cursor, setCursor] = useState<string | undefined>();
   const [hasMore, setHasMore] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
 
-  const fetchTransactions = useCallback(async (currentCursor?: string, reset = false) => {
-    try {
-      setLoading(true);
-      setError(null);
-      
-      const params = new URLSearchParams();
-      params.append('limit', '10');
-      if (currentCursor && !reset) {
-        params.append('cursor', currentCursor);
-      }
-      if (statusFilter !== 'all') {
-        params.append('status', statusFilter);
-      }
+  const todayStart = useMemo(() => startOfDay(new Date()), []);
+  const yesterdayStart = useMemo(() => {
+    const d = new Date();
+    d.setDate(d.getDate() - 1);
+    return startOfDay(d);
+  }, []);
 
-      const response = await fetch(`/api/v1/remittance/history?${params}`);
-      if (!response.ok) {
-        throw new Error(t('transactionHistory.alerts.fetchFailed'));
-      }
+  const groupLabels: Record<GroupKey, { label: string; helper: string }> = useMemo(
+    () => ({
+      today: {
+        label: t("transactionHistory.dateGroups.today"),
+        helper: t("transactionHistory.dateGroups.todayHelper"),
+      },
+      yesterday: {
+        label: t("transactionHistory.dateGroups.yesterday"),
+        helper: t("transactionHistory.dateGroups.yesterdayHelper"),
+      },
+      earlier: {
+        label: t("transactionHistory.dateGroups.earlier"),
+        helper: t("transactionHistory.dateGroups.earlierHelper"),
+      },
+    }),
+    [t]
+  );
 
-      const data = await response.json();
-      
-      if (reset) {
-        setTransactions(data.transactions || []);
-      } else {
-        setTransactions(prev => [...prev, ...(data.transactions || [])]);
+  const fetchTransactions = useCallback(
+    async (currentCursor?: string, reset = false) => {
+      try {
+        if (reset) {
+          setLoading(true);
+        } else {
+          setLoadingMore(true);
+        }
+        setError(null);
+
+        const params = new URLSearchParams();
+        params.append("limit", "50");
+        if (currentCursor && !reset) {
+          params.append("cursor", currentCursor);
+        }
+        if (statusFilter !== "all") {
+          params.append("status", statusFilter);
+        }
+
+        const response = await fetch(`/api/v1/remittance/history?${params}`);
+        if (!response.ok) {
+          throw new Error(t("transactionHistory.alerts.fetchFailed"));
+        }
+
+        const data = await response.json();
+
+        if (data.userAddress) {
+          setUserAddress(data.userAddress);
+        }
+
+        if (reset) {
+          setTransactions(data.transactions || []);
+        } else {
+          setTransactions((prev) => [...prev, ...(data.transactions || [])]);
+        }
+
+        setCursor(data.nextCursor);
+        setHasMore(!!data.nextCursor);
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : t("transactionHistory.alerts.genericError")
+        );
+      } finally {
+        setLoading(false);
+        setInitialLoading(false);
+        setLoadingMore(false);
       }
-      
-      setCursor(data.nextCursor);
-      setHasMore(!!data.nextCursor);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t('transactionHistory.alerts.genericError'));
-    } finally {
-      setLoading(false);
-    }
-  }, [statusFilter]);
+    },
+    [statusFilter, t]
+  );
 
   useEffect(() => {
     fetchTransactions(undefined, true);
   }, [fetchTransactions]);
 
-  const handleLoadMore = () => {
-    if (hasMore && !loading) {
+  const handleLoadMore = useCallback(() => {
+    if (hasMore && !loadingMore) {
       fetchTransactions(cursor, false);
     }
-  };
+  }, [hasMore, loadingMore, cursor, fetchTransactions]);
 
-  const handleFilterClick = () => {
-    // TODO: Implement filter modal/dropdown
-    alert(t('transactionHistory.alerts.filtersSoon'));
-  };
+  const handleClearFilters = useCallback(() => {
+    setSearchTerm("");
+    setStatusFilter("all");
+    setDirectionFilter("all");
+    setDateFrom("");
+    setDateTo("");
+  }, []);
 
-  const handleExportClick = () => {
-    // TODO: Implement export functionality
-    alert(t('transactionHistory.alerts.exportSoon'));
-  };
+  const hasActiveFilters =
+    debouncedSearch.trim().length > 0 ||
+    statusFilter !== "all" ||
+    directionFilter !== "all" ||
+    dateFrom.length > 0 ||
+    dateTo.length > 0;
 
-  const filteredTransactions = transactions.filter(tx => 
-    tx.hash.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    tx.recipient.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    tx.sender.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    (tx.memo && tx.memo.toLowerCase().includes(searchTerm.toLowerCase()))
-  );
+  const filteredTransactions = useMemo(() => {
+    const query = debouncedSearch.trim().toLowerCase();
 
-  // Convert API transaction format to component format
-  const convertToComponentTransaction = (tx: TransactionItem): import('@/components/Dashboard/TransactionHistoryItem').Transaction => ({
-    id: tx.hash.slice(0, 8), // Short hash for display
-    hash: tx.hash, // Full hash for explorer link
-    type: (tx.sender === tx.recipient ? 'Received' : 'Send Money') as 'Send Money' | 'Received',
-    amount: parseFloat(tx.amount),
-    currency: tx.currency,
-    counterpartyName: tx.sender === tx.recipient ? tx.sender : tx.recipient,
-    counterpartyLabel: tx.sender === tx.recipient ? 'From' : 'To',
-    date: new Date(tx.date).toLocaleString(),
-    fee: 0.01, // Default fee - should come from API if available
-    status: (tx.status === 'completed' ? 'Completed' : 
-            tx.status === 'failed' ? 'Failed' : 'Pending') as 'Completed' | 'Failed' | 'Pending',
-  });
+    return transactions.filter((tx) => {
+      if (statusFilter !== "all") {
+        if (tx.status === "pending" && statusFilter !== "pending") return false;
+        if (tx.status === "completed" && statusFilter !== "completed") return false;
+        if (tx.status === "failed" && statusFilter !== "failed") return false;
+      }
 
-  const resultsSubtitle =
-    filteredTransactions.length > 0
-      ? t('transactionHistory.resultsCount').replace('{{count}}', `${filteredTransactions.length}`)
-      : t('transactionHistory.resultsCountZero');
+      if (directionFilter !== "all" && userAddress) {
+        const isSent = tx.sender === userAddress;
+        if (directionFilter === "sent" && !isSent) return false;
+        if (directionFilter === "received" && isSent) return false;
+      }
 
-  const statusLabels: Record<typeof statusFilter, string> = {
-    all: t('transactionHistory.tabs.all'),
-    completed: t('transactionHistory.tabs.completed'),
-    pending: t('transactionHistory.tabs.pending'),
-    failed: t('transactionHistory.tabs.failed'),
-  };
+      if (dateFrom) {
+        const txDate = new Date(tx.date);
+        const fromDate = new Date(dateFrom);
+        if (txDate < fromDate) return false;
+      }
+      if (dateTo) {
+        const txDate = new Date(tx.date);
+        const toDate = new Date(dateTo);
+        toDate.setHours(23, 59, 59, 999);
+        if (txDate > toDate) return false;
+      }
+
+      if (query.length > 0) {
+        const searchableText = [
+          tx.hash,
+          tx.recipient,
+          tx.sender,
+          tx.memo || "",
+          tx.amount,
+          tx.currency,
+          tx.id,
+        ]
+          .join(" ")
+          .toLowerCase();
+        if (!searchableText.includes(query)) return false;
+      }
+
+      return true;
+    });
+  }, [transactions, debouncedSearch, statusFilter, directionFilter, dateFrom, dateTo, userAddress]);
+
+  const groupedTransactions = useMemo(() => {
+    const groups: Record<GroupKey, Transaction[]> = {
+      today: [],
+      yesterday: [],
+      earlier: [],
+    };
+
+    filteredTransactions.forEach((tx) => {
+      const txDate = new Date(tx.date);
+      const groupKey = getGroupKey(txDate, todayStart, yesterdayStart);
+      const isSent = userAddress ? tx.sender === userAddress : tx.sender !== tx.recipient;
+
+      const componentTx: Transaction = {
+        id: tx.hash.slice(0, 8),
+        hash: tx.hash,
+        type: isSent ? "Send Money" : "Received",
+        amount: parseFloat(tx.amount) * (isSent ? -1 : 1),
+        currency: tx.currency,
+        counterpartyName: isSent ? tx.recipient : tx.sender,
+        counterpartyLabel: isSent ? "To" : "From",
+        date: new Date(tx.date).toLocaleString(),
+        fee: 0,
+        status: (tx.status === "completed"
+          ? "Completed"
+          : tx.status === "failed"
+            ? "Failed"
+            : "Pending") as TransactionStatus,
+      };
+
+      groups[groupKey].push(componentTx);
+    });
+
+    return groups;
+  }, [filteredTransactions, todayStart, yesterdayStart, userAddress]);
+
+  const totalCount = transactions.length;
+  const filteredCount = filteredTransactions.length;
+  const isLoading = initialLoading && loading;
+  const noTransactions = !isLoading && !error && totalCount === 0;
+  const noResults = !isLoading && !error && totalCount > 0 && filteredCount === 0 && hasActiveFilters;
+
+  const resultsAriaLive = useMemo(() => {
+    if (filteredCount === 0) return t("transactionHistory.resultsAriaLive.none");
+    if (filteredCount === 1) return t("transactionHistory.resultsAriaLive.one");
+    return t("transactionHistory.resultsAriaLive.many").replace(
+      "{{count}}",
+      String(filteredCount)
+    );
+  }, [filteredCount, t]);
 
   return (
     <main className="w-full min-h-screen bg-[#010101] font-inter">
       <TransactionHistoryHeader
-        title={t('transactionHistory.title')}
-        subtitle={resultsSubtitle}
+        title={t("transactionHistory.title")}
+        subtitle={
+          totalCount > 0
+            ? t("transactionHistory.resultsCount").replace(
+                "{{count}}",
+                String(totalCount)
+              )
+            : t("transactionHistory.resultsCountZero")
+        }
       />
-      
+
       <div className="mx-4 mt-8 md:mx-20 md:mt-10">
-        {/* Search and Filter Bar */}
+        {/* Search and Action Bar */}
         <div className="flex flex-col gap-4 rounded-2xl border border-[#FFFFFF14] bg-gradient-to-b from-[#0F0F0F] to-[#0A0A0A] px-4 py-6 sm:gap-5">
-          <TransactionHistorySearchInput 
+          <TransactionHistorySearchInput
             value={searchTerm}
             onChange={setSearchTerm}
-            placeholder={t('transactionHistory.searchPlaceholder')}
-            mobilePlaceholder={t('transactionHistory.searchPlaceholderMobile')}
+            placeholder={t("transactionHistory.searchPlaceholder")}
+            mobilePlaceholder={t("transactionHistory.searchPlaceholderMobile")}
           />
           <div className="flex w-full flex-col items-stretch gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
             <Button
               icon={<FilterIcon size={17} className="text-white" />}
-              text={t('transactionHistory.filters')}
-              onclick={handleFilterClick}
+              text={t("transactionHistory.filters")}
+              onclick={() => {
+                const el = document.getElementById("transaction-filters-panel");
+                el?.scrollIntoView({ behavior: "smooth" });
+              }}
             />
             <Button
               icon={<Download size={17} className="text-white" />}
-              text={t('transactionHistory.export')}
-              onclick={handleExportClick}
+              text={t("transactionHistory.export")}
+              onclick={() => {
+                const rows = Object.values(groupedTransactions)
+                  .flat()
+                  .map((tx) => ({
+                    id: tx.id,
+                    hash: tx.hash || "",
+                    type: tx.type,
+                    status: tx.status,
+                    amount: tx.amount,
+                    currency: tx.currency,
+                    counterparty: tx.counterpartyName,
+                    date: tx.date,
+                    fee: tx.fee,
+                  }));
+
+                if (rows.length === 0) return;
+
+                const csv = [
+                  Object.keys(rows[0]).join(","),
+                  ...rows.map((row) =>
+                    Object.values(row)
+                      .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+                      .join(",")
+                  ),
+                ].join("\n");
+
+                const blob = new Blob([csv], {
+                  type: "text/csv;charset=utf-8",
+                });
+                const url = URL.createObjectURL(blob);
+                const link = document.createElement("a");
+                link.href = url;
+                link.download = "remitwise-transactions.csv";
+                link.click();
+                URL.revokeObjectURL(url);
+              }}
             />
           </div>
         </div>
 
-        {/* Status Filter Tabs */}
-        <div className="mt-6 flex flex-wrap gap-2">
-          {(['all', 'completed', 'pending', 'failed'] as const).map((status) => (
-            <button
-              key={status}
-              onClick={() => {
-                setStatusFilter(status);
-                setCursor(undefined);
-              }}
-              className={`min-h-[44px] rounded-xl px-4 py-2 text-sm font-medium transition-colors whitespace-normal sm:text-base ${
-                statusFilter === status
-                  ? 'bg-[#FF4B26] text-white'
-                  : 'bg-[#1A1A1A] text-gray-400 hover:bg-[#2A2A2A]'
-              }`}
-            >
-              {statusLabels[status]}
-            </button>
-          ))}
+        {/* Filters Panel */}
+        <div
+          id="transaction-filters-panel"
+          className="mt-6 rounded-2xl border border-[#FFFFFF14] bg-gradient-to-b from-[#0F0F0F] to-[#0A0A0A] px-4 py-5 sm:px-6"
+        >
+          <div className="flex items-center gap-2 mb-4">
+            <FilterIcon className="h-4 w-4 text-red-400" />
+            <h2 className="text-sm font-semibold text-white">
+              {t("transactionHistory.filtersHeading")}
+            </h2>
+          </div>
+
+          {/* Status Tabs */}
+          <fieldset className="mb-5">
+            <legend className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-500 mb-3">
+              {t("transactionHistory.statusFilterLabel", "Status")}
+            </legend>
+            <div className="flex flex-wrap gap-2">
+              {(["all", "completed", "pending", "failed"] as const).map(
+                (status) => (
+                  <button
+                    key={status}
+                    type="button"
+                    onClick={() => {
+                      setStatusFilter(status);
+                      setCursor(undefined);
+                    }}
+                    aria-pressed={statusFilter === status}
+                    className={`min-h-[40px] rounded-xl px-4 py-2 text-sm font-medium transition-colors whitespace-normal sm:text-base ${
+                      statusFilter === status
+                        ? "bg-[#FF4B26] text-white"
+                        : "bg-[#1A1A1A] text-gray-400 hover:bg-[#2A2A2A]"
+                    }`}
+                  >
+                    {t(`transactionHistory.tabs.${status}`)}
+                  </button>
+                )
+              )}
+            </div>
+          </fieldset>
+
+          {/* Type / Direction Filter */}
+          <fieldset className="mb-5">
+            <legend className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-500 mb-3">
+              {t("transactionHistory.typeFilterLabel", "Type")}
+            </legend>
+            <div className="flex flex-wrap gap-2">
+              {(["all", "sent", "received"] as const).map((direction) => (
+                <button
+                  key={direction}
+                  type="button"
+                  onClick={() => setDirectionFilter(direction)}
+                  aria-pressed={directionFilter === direction}
+                  className={`min-h-[40px] rounded-xl px-4 py-2 text-sm font-medium transition-colors ${
+                    directionFilter === direction
+                      ? "bg-sky-500/20 text-sky-100 ring-1 ring-sky-400/40"
+                      : "bg-[#1A1A1A] text-gray-400 hover:bg-[#2A2A2A]"
+                  }`}
+                >
+                  {direction === "all"
+                    ? t("transactionHistory.tabs.all")
+                    : direction === "sent"
+                      ? t("transactionHistory.typeFilter.send")
+                      : t("transactionHistory.typeFilter.received")}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          {/* Date Range Filter */}
+          <fieldset>
+            <legend className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-500 mb-3">
+              {t("transactionHistory.dateRange.label")}
+            </legend>
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="flex flex-col gap-1.5">
+                <label
+                  htmlFor="date-from"
+                  className="text-xs text-gray-400"
+                >
+                  {t("transactionHistory.dateRange.from")}
+                </label>
+                <input
+                  id="date-from"
+                  type="date"
+                  value={dateFrom}
+                  onChange={(e) => setDateFrom(e.target.value)}
+                  className="min-h-[40px] rounded-xl border border-[#FFFFFF14] bg-[#1A1A1A] px-3 py-2 text-sm text-white focus:border-red-400/40 focus:outline-none focus:ring-1 focus:ring-red-400/40"
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <label
+                  htmlFor="date-to"
+                  className="text-xs text-gray-400"
+                >
+                  {t("transactionHistory.dateRange.to")}
+                </label>
+                <input
+                  id="date-to"
+                  type="date"
+                  value={dateTo}
+                  onChange={(e) => setDateTo(e.target.value)}
+                  min={dateFrom || undefined}
+                  className="min-h-[40px] rounded-xl border border-[#FFFFFF14] bg-[#1A1A1A] px-3 py-2 text-sm text-white focus:border-red-400/40 focus:outline-none focus:ring-1 focus:ring-red-400/40"
+                />
+              </div>
+              {(dateFrom || dateTo) && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setDateFrom("");
+                    setDateTo("");
+                  }}
+                  className="min-h-[40px] rounded-xl border border-[#FFFFFF14] px-3 py-2 text-sm text-gray-400 hover:text-white transition-colors"
+                  aria-label={t("transactionHistory.dateRange.clear")}
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+          </fieldset>
+
+          {/* Active Filters */}
+          {hasActiveFilters && (
+            <div className="mt-5 flex flex-wrap items-center gap-2 border-t border-[#FFFFFF14] pt-4">
+              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-500">
+                {t("transactionHistory.activeFilters.label")}
+              </span>
+              {statusFilter !== "all" && (
+                <ActivePill
+                  label={t("transactionHistory.activeFilters.status").replace(
+                    "{{status}}",
+                    t(`transactionHistory.tabs.${statusFilter}`)
+                  )}
+                  onRemove={() => setStatusFilter("all")}
+                />
+              )}
+              {directionFilter !== "all" && (
+                <ActivePill
+                  label={t("transactionHistory.activeFilters.type").replace(
+                    "{{type}}",
+                    directionFilter === "sent"
+                      ? t("transactionHistory.typeFilter.send")
+                      : t("transactionHistory.typeFilter.received")
+                  )}
+                  onRemove={() => setDirectionFilter("all")}
+                />
+              )}
+              {debouncedSearch.trim().length > 0 && (
+                <ActivePill
+                  label={t("transactionHistory.activeFilters.search").replace(
+                    "{{query}}",
+                    debouncedSearch
+                  )}
+                  onRemove={() => setSearchTerm("")}
+                />
+              )}
+              {(dateFrom || dateTo) && (
+                <ActivePill
+                  label={`${dateFrom || "..."} - ${dateTo || "..."}`}
+                  onRemove={() => {
+                    setDateFrom("");
+                    setDateTo("");
+                  }}
+                />
+              )}
+              <button
+                type="button"
+                onClick={handleClearFilters}
+                className="text-xs text-red-400 hover:text-red-300 transition-colors ml-2"
+              >
+                {t("transactionHistory.activeFilters.clearAll")}
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Results Count (aria-live) */}
+        <div
+          aria-live="polite"
+          aria-atomic="true"
+          className="sr-only"
+        >
+          {resultsAriaLive}
         </div>
 
         {/* Error State */}
         {error && (
           <div className="mt-8 p-4 bg-red-500/10 border border-red-500/30 rounded-lg">
             <p className="text-red-400 text-center">{error}</p>
+            <div className="mt-3 text-center">
+              <button
+                type="button"
+                onClick={() => fetchTransactions(undefined, true)}
+                className="min-h-[40px] rounded-xl bg-[#FF4B26] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#FF4B26]/80"
+              >
+                Retry
+              </button>
+            </div>
           </div>
         )}
 
         {/* Loading State */}
-        {loading && transactions.length === 0 && (
+        {isLoading && (
           <div className="mt-8 flex justify-center">
             <Loader2 className="w-8 h-8 text-[#FF4B26] animate-spin" />
           </div>
         )}
 
-        {/* Transactions List */}
-        {!loading && filteredTransactions.length === 0 && !error && (
-          <div className="mt-8 text-center">
-            <p className="text-gray-400">{t('transactionHistory.empty')}</p>
+        {/* Empty State (no transactions at all) */}
+        {noTransactions && (
+          <div className="mt-8">
+            <WidgetEmptyState
+              icon={Inbox}
+              title={t("transactionHistory.emptyState.title")}
+              description={t("transactionHistory.emptyState.description")}
+              ctaLabel={t("transactionHistory.emptyState.cta")}
+              ctaHref="/send"
+            />
           </div>
         )}
 
-        <div className="mt-8 space-y-4">
-          {filteredTransactions.map((tx) => (
-            <TransactionHistoryItem 
-              key={tx.id} 
-              transaction={convertToComponentTransaction(tx)} 
+        {/* No Results State (transactions exist but filters match none) */}
+        {noResults && (
+          <div className="mt-8">
+            <WidgetEmptyState
+              icon={SearchX}
+              title={t("transactionHistory.noResults.title")}
+              description={t("transactionHistory.noResults.description")}
+              ctaLabel={t("transactionHistory.noResults.clearFilters")}
+              onAction={handleClearFilters}
             />
-          ))}
-        </div>
+          </div>
+        )}
+
+        {/* Grouped Transactions List */}
+        {!isLoading && filteredCount > 0 && (
+          <div className="mt-8 space-y-8">
+            {(["today", "yesterday", "earlier"] as GroupKey[]).map(
+              (groupKey) => {
+                const txs = groupedTransactions[groupKey];
+                if (txs.length === 0) return null;
+
+                return (
+                  <section key={groupKey} aria-labelledby={`group-${groupKey}-heading`}>
+                    <div className="mb-3 flex items-center justify-between border-b border-[#FFFFFF14] pb-3">
+                      <h2
+                        id={`group-${groupKey}-heading`}
+                        className="text-base font-semibold text-white"
+                      >
+                        {groupLabels[groupKey].label}
+                      </h2>
+                      <span className="text-xs font-medium text-gray-400">
+                        {txs.length}{" "}
+                        {txs.length === 1
+                          ? t("transactionHistory.results_one").replace(
+                              "{{count}}",
+                              "1"
+                            )
+                          : t("transactionHistory.results_many").replace(
+                              "{{count}}",
+                              String(txs.length)
+                            )}
+                      </span>
+                    </div>
+                    <div className="space-y-4">
+                      {txs.map((tx) => (
+                        <TransactionHistoryItem
+                          key={tx.hash || tx.id}
+                          transaction={tx}
+                        />
+                      ))}
+                    </div>
+                  </section>
+                );
+              }
+            )}
+          </div>
+        )}
 
         {/* Load More Button */}
-        {hasMore && !loading && filteredTransactions.length > 0 && (
+        {hasMore && !loading && filteredCount > 0 && (
           <div className="mt-8 text-center">
             <button
+              type="button"
               onClick={handleLoadMore}
-              className="min-h-[48px] rounded-xl bg-[#FF4B26] px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#FF4B26]/80 sm:text-base"
+              disabled={loadingMore}
+              className="min-h-[48px] rounded-xl bg-[#FF4B26] px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#FF4B26]/80 disabled:opacity-50 disabled:cursor-not-allowed sm:text-base"
             >
-              {t('transactionHistory.loadMore')}
+              {loadingMore
+                ? "Loading..."
+                : t("transactionHistory.loadMore")}
             </button>
           </div>
         )}
 
         {/* Loading More Indicator */}
-        {loading && transactions.length > 0 && (
-          <div className="mt-8 flex justify-center">
+        {loadingMore && filteredCount > 0 && (
+          <div className="mt-4 flex justify-center">
             <Loader2 className="w-6 h-6 text-[#FF4B26] animate-spin" />
           </div>
         )}
@@ -211,5 +625,27 @@ const TransactionHistoryPage = () => {
     </main>
   );
 };
+
+function ActivePill({
+  label,
+  onRemove,
+}: {
+  label: string;
+  onRemove: () => void;
+}) {
+  return (
+    <span className="inline-flex max-w-full items-center gap-2 rounded-full border border-[#FFFFFF14] bg-white/[0.04] px-3 py-1.5 text-xs text-gray-200">
+      <span className="truncate max-w-[200px]">{label}</span>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-gray-400 transition hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300"
+        aria-label={`Remove ${label} filter`}
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </span>
+  );
+}
 
 export default TransactionHistoryPage;

--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -8,8 +8,9 @@ import {
   FileText,
   FilterIcon,
   GitBranch,
-  Info,
+  Inbox,
   Search,
+  SearchX,
   Send,
   Shield,
   X,
@@ -20,6 +21,9 @@ import TransactionHistoryItem, {
   TransactionType,
 } from "@/components/Dashboard/TransactionHistoryItem";
 import { useDensity } from "@/lib/context/DensityContext";
+import { useClientTranslator } from "@/lib/i18n/client";
+import { useDebounce } from "@/lib/hooks/useDebounce";
+import WidgetEmptyState from "@/components/ui/WidgetEmptyState";
 
 const allTransactions: Transaction[] = [
   {
@@ -231,47 +235,24 @@ const statusStyles: Record<
   },
 };
 
-type GroupKey = "today" | "this-week" | "earlier";
-
-const groupLabels: Record<GroupKey, { label: string; helper: string }> = {
-  today: {
-    label: "Today",
-    helper: "Transactions from the latest activity day",
-  },
-  "this-week": {
-    label: "This Week",
-    helper: "Activity within 7 days of the latest transaction",
-  },
-  earlier: {
-    label: "Earlier",
-    helper: "Older activity kept in chronological order",
-  },
-};
-
-function parseTransactionDate(date: string) {
-  return new Date(date.replace(" ", "T"));
-}
+type GroupKey = "today" | "yesterday" | "earlier";
 
 function startOfDay(date: Date) {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
 
-function getLatestTransactionDate(transactions: Transaction[]) {
-  return transactions.reduce((latest, transaction) => {
-    const transactionDate = parseTransactionDate(transaction.date);
-    return transactionDate > latest ? transactionDate : latest;
-  }, parseTransactionDate(transactions[0]?.date ?? "2026-06-02 00:00:00"));
+function getGroupKey(date: Date): GroupKey {
+  const d = startOfDay(date);
+  const today = startOfDay(new Date());
+  const yesterday = startOfDay(new Date(Date.now() - 86400000));
+
+  if (d.getTime() === today.getTime()) return "today";
+  if (d.getTime() === yesterday.getTime()) return "yesterday";
+  return "earlier";
 }
 
-function getGroupKey(transaction: Transaction, referenceDate: Date): GroupKey {
-  const transactionDay = startOfDay(parseTransactionDate(transaction.date));
-  const referenceDay = startOfDay(referenceDate);
-  const dayDifference =
-    (referenceDay.getTime() - transactionDay.getTime()) / (1000 * 60 * 60 * 24);
-
-  if (dayDifference === 0) return "today";
-  if (dayDifference > 0 && dayDifference <= 7) return "this-week";
-  return "earlier";
+function parseTransactionDate(date: string) {
+  return new Date(date.replace(" ", "T"));
 }
 
 function formatShortDate(date: string) {
@@ -287,18 +268,32 @@ function normalizeQuery(value: string) {
 }
 
 export default function TransactionsPage() {
+  const { t } = useClientTranslator();
   const { density } = useDensity();
   const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearch = useDebounce(searchQuery, 300);
   const [selectedTypes, setSelectedTypes] = useState<TransactionType[]>([]);
   const [selectedStatuses, setSelectedStatuses] = useState<TransactionStatus[]>([]);
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
 
-  const referenceDate = useMemo(
-    () => getLatestTransactionDate(allTransactions),
-    []
-  );
+  const groupLabels: Record<GroupKey, { label: string; helper: string }> = {
+    today: {
+      label: t("transactionHistory.dateGroups.today"),
+      helper: t("transactionHistory.dateGroups.todayHelper"),
+    },
+    yesterday: {
+      label: t("transactionHistory.dateGroups.yesterday"),
+      helper: t("transactionHistory.dateGroups.yesterdayHelper"),
+    },
+    earlier: {
+      label: t("transactionHistory.dateGroups.earlier"),
+      helper: t("transactionHistory.dateGroups.earlierHelper"),
+    },
+  };
 
   const filteredTransactions = useMemo(() => {
-    const query = normalizeQuery(searchQuery);
+    const query = normalizeQuery(debouncedSearch);
 
     return allTransactions.filter((transaction) => {
       const searchableText = [
@@ -319,28 +314,44 @@ export default function TransactionsPage() {
         selectedStatuses.length === 0 ||
         selectedStatuses.includes(transaction.status);
 
-      return matchesSearch && matchesType && matchesStatus;
+      let matchesDate = true;
+      const txDate = parseTransactionDate(transaction.date);
+      if (dateFrom) {
+        const from = new Date(dateFrom);
+        if (txDate < from) matchesDate = false;
+      }
+      if (dateTo) {
+        const to = new Date(dateTo);
+        to.setHours(23, 59, 59, 999);
+        if (txDate > to) matchesDate = false;
+      }
+
+      return matchesSearch && matchesType && matchesStatus && matchesDate;
     });
-  }, [searchQuery, selectedStatuses, selectedTypes]);
+  }, [debouncedSearch, selectedStatuses, selectedTypes, dateFrom, dateTo]);
 
   const groupedTransactions = useMemo(() => {
     const groups: Record<GroupKey, Transaction[]> = {
       today: [],
-      "this-week": [],
+      yesterday: [],
       earlier: [],
     };
 
     filteredTransactions.forEach((transaction) => {
-      groups[getGroupKey(transaction, referenceDate)].push(transaction);
+      groups[getGroupKey(parseTransactionDate(transaction.date))].push(
+        transaction
+      );
     });
 
     return groups;
-  }, [filteredTransactions, referenceDate]);
+  }, [filteredTransactions]);
 
   const activeFilterCount =
     selectedTypes.length +
     selectedStatuses.length +
-    (normalizeQuery(searchQuery).length > 0 ? 1 : 0);
+    (normalizeQuery(debouncedSearch).length > 0 ? 1 : 0) +
+    (dateFrom.length > 0 ? 1 : 0) +
+    (dateTo.length > 0 ? 1 : 0);
 
   const hasTransactions = allTransactions.length > 0;
   const hasNoResults = hasTransactions && filteredTransactions.length === 0;
@@ -365,6 +376,8 @@ export default function TransactionsPage() {
     setSearchQuery("");
     setSelectedTypes([]);
     setSelectedStatuses([]);
+    setDateFrom("");
+    setDateTo("");
   };
 
   const handleExportClick = () => {
@@ -404,14 +417,13 @@ export default function TransactionsPage() {
           <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.28em] text-red-300">
-                Transaction history
+                {t("transactionHistory.titleStandalone")}
               </p>
               <h1 className="mt-3 text-2xl font-semibold text-white sm:text-3xl">
                 USDC activity
               </h1>
               <p className="mt-2 max-w-2xl text-sm leading-6 text-gray-400">
-                Search, filter, and review payment, split, bill, and insurance
-                activity with grouped results by date.
+                {t("transactionHistory.subtitleStandalone")}
               </p>
             </div>
             <button
@@ -421,7 +433,7 @@ export default function TransactionsPage() {
               className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-xl border border-red-400/30 bg-red-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#010101] disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/5 disabled:text-gray-500"
             >
               <Download className="h-4 w-4" />
-              Export current view
+              {t("transactionHistory.export")}
             </button>
           </div>
 
@@ -437,18 +449,20 @@ export default function TransactionsPage() {
                     id="transaction-filters-heading"
                     className="text-sm font-semibold text-white"
                   >
-                    Filter transactions
+                    {t("transactionHistory.filtersHeading")}
                   </h2>
                 </div>
                 <label className="relative block">
-                  <span className="sr-only">Search transactions</span>
+                  <span className="sr-only">
+                    {t("transactionHistory.searchStandalonePlaceholder")}
+                  </span>
                   <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-500" />
                   <input
                     type="search"
                     value={searchQuery}
                     onChange={(event) => setSearchQuery(event.target.value)}
                     className="min-h-[48px] w-full rounded-xl border border-white/10 bg-black/40 py-3 pl-12 pr-12 text-sm text-white placeholder:text-gray-500 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-red-400"
-                    placeholder="Search ID, recipient, type, status, amount"
+                    placeholder={t("transactionHistory.searchStandalonePlaceholder")}
                     aria-describedby="transaction-results-count"
                   />
                   {searchQuery.length > 0 && (
@@ -456,7 +470,7 @@ export default function TransactionsPage() {
                       type="button"
                       onClick={() => setSearchQuery("")}
                       className="absolute right-3 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-lg text-gray-400 transition hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300"
-                      aria-label="Clear transaction search"
+                      aria-label={t("transactionHistory.activeFilters.clearSearch")}
                     >
                       <X className="h-4 w-4" />
                     </button>
@@ -470,11 +484,12 @@ export default function TransactionsPage() {
                   className="font-medium text-white"
                   aria-live="polite"
                 >
-                  Showing {filteredTransactions.length} of{" "}
-                  {allTransactions.length} transactions
+                  {t("transactionHistory.showing")
+                    .replace("{{count}}", String(filteredTransactions.length))
+                    .replace("{{total}}", String(allTransactions.length))}
                 </div>
                 <p className="mt-1 text-xs leading-5 text-gray-500">
-                  Search combines with every selected type and status chip.
+                  {t("transactionHistory.filtersHelper")}
                 </p>
               </div>
             </div>
@@ -482,7 +497,7 @@ export default function TransactionsPage() {
             <div className="mt-5 grid gap-5 xl:grid-cols-[1fr_0.9fr]">
               <fieldset>
                 <legend className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-500">
-                  Type
+                  {t("transactionHistory.typeFilterLabel", "Type")}
                 </legend>
                 <div className="mt-3 flex flex-wrap gap-2">
                   <FilterChip
@@ -515,7 +530,7 @@ export default function TransactionsPage() {
 
               <fieldset>
                 <legend className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-500">
-                  Status
+                  {t("transactionHistory.statusFilterLabel", "Status")}
                 </legend>
                 <div className="mt-3 flex flex-wrap gap-2">
                   <FilterChip
@@ -536,37 +551,110 @@ export default function TransactionsPage() {
               </fieldset>
             </div>
 
+            {/* Date Range Filter */}
+            <div className="mt-5 border-t border-white/10 pt-4">
+              <fieldset>
+                <legend className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-500">
+                  {t("transactionHistory.dateRange.label")}
+                </legend>
+                <div className="mt-3 flex flex-wrap items-end gap-3">
+                  <div className="flex flex-col gap-1.5">
+                    <label
+                      htmlFor="tx-date-from"
+                      className="text-xs text-gray-400"
+                    >
+                      {t("transactionHistory.dateRange.from")}
+                    </label>
+                    <input
+                      id="tx-date-from"
+                      type="date"
+                      value={dateFrom}
+                      onChange={(e) => setDateFrom(e.target.value)}
+                      className="min-h-[40px] rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-sm text-white focus:border-red-400/40 focus:outline-none focus:ring-1 focus:ring-red-400/40"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <label
+                      htmlFor="tx-date-to"
+                      className="text-xs text-gray-400"
+                    >
+                      {t("transactionHistory.dateRange.to")}
+                    </label>
+                    <input
+                      id="tx-date-to"
+                      type="date"
+                      value={dateTo}
+                      onChange={(e) => setDateTo(e.target.value)}
+                      min={dateFrom || undefined}
+                      className="min-h-[40px] rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-sm text-white focus:border-red-400/40 focus:outline-none focus:ring-1 focus:ring-red-400/40"
+                    />
+                  </div>
+                  {(dateFrom || dateTo) && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setDateFrom("");
+                        setDateTo("");
+                      }}
+                      className="min-h-[40px] rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-sm text-gray-400 hover:text-white transition-colors"
+                      aria-label={t("transactionHistory.dateRange.clear")}
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
+              </fieldset>
+            </div>
+
             <div className="mt-5 flex flex-col gap-3 border-t border-white/10 pt-4 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex flex-wrap items-center gap-2">
                 <span className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-500">
-                  Active
+                  {t("transactionHistory.activeFilters.label")}
                 </span>
                 {activeFilterCount === 0 ? (
                   <span className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1.5 text-xs text-gray-400">
-                    No filters applied
+                    {t("transactionHistory.activeFilters.none")}
                   </span>
                 ) : (
                   <>
-                    {normalizeQuery(searchQuery).length > 0 && (
+                    {normalizeQuery(debouncedSearch).length > 0 && (
                       <ActivePill
-                        label={`Search: ${searchQuery}`}
+                        label={t("transactionHistory.activeFilters.search").replace(
+                          "{{query}}",
+                          debouncedSearch
+                        )}
                         onRemove={() => setSearchQuery("")}
                       />
                     )}
                     {selectedTypes.map((type) => (
                       <ActivePill
                         key={type}
-                        label={`Type: ${type}`}
+                        label={t("transactionHistory.activeFilters.type").replace(
+                          "{{type}}",
+                          type
+                        )}
                         onRemove={() => toggleType(type)}
                       />
                     ))}
                     {selectedStatuses.map((status) => (
                       <ActivePill
                         key={status}
-                        label={`Status: ${status}`}
+                        label={t("transactionHistory.activeFilters.status").replace(
+                          "{{status}}",
+                          status
+                        )}
                         onRemove={() => toggleStatus(status)}
                       />
                     ))}
+                    {(dateFrom || dateTo) && (
+                      <ActivePill
+                        label={`${dateFrom || "..."} \u2013 ${dateTo || "..."}`}
+                        onRemove={() => {
+                          setDateFrom("");
+                          setDateTo("");
+                        }}
+                      />
+                    )}
                   </>
                 )}
               </div>
@@ -576,37 +664,44 @@ export default function TransactionsPage() {
                 disabled={activeFilterCount === 0}
                 className="inline-flex min-h-[40px] items-center justify-center rounded-xl border border-white/10 px-3 py-2 text-sm font-medium text-gray-300 transition hover:border-white/20 hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300 disabled:cursor-not-allowed disabled:text-gray-600 disabled:hover:bg-transparent"
               >
-                Clear all
+                {t("transactionHistory.activeFilters.clearAll")}
               </button>
             </div>
           </section>
 
           <div className="mt-8">
             {!hasTransactions && (
-              <StateCard
-                title="No transaction history yet"
-                body="Completed transfers, splits, bill payments, and insurance activity will appear here once you make your first transaction."
+              <WidgetEmptyState
+                icon={Inbox}
+                title={t("transactionHistory.emptyState.title")}
+                description={t("transactionHistory.emptyState.description")}
+                ctaLabel={t("transactionHistory.emptyState.cta")}
+                ctaHref="/send"
               />
             )}
 
             {hasNoResults && (
-              <StateCard
-                title="No matching transactions"
-                body="Try clearing a chip, widening the status selection, or searching by recipient, ID, amount, or transaction type."
-                actionLabel="Clear filters"
+              <WidgetEmptyState
+                icon={SearchX}
+                title={t("transactionHistory.noResults.title")}
+                description={t("transactionHistory.noResults.description")}
+                ctaLabel={t("transactionHistory.noResults.clearFilters")}
                 onAction={clearAllFilters}
               />
             )}
 
             {filteredTransactions.length > 0 && (
               <div className={density === "compact" ? "space-y-7" : "space-y-8"}>
-                {(["today", "this-week", "earlier"] as GroupKey[]).map(
+                {(["today", "yesterday", "earlier"] as GroupKey[]).map(
                   (groupKey) => {
                     const transactions = groupedTransactions[groupKey];
                     if (transactions.length === 0) return null;
 
                     return (
-                      <section key={groupKey} aria-labelledby={`${groupKey}-heading`}>
+                      <section
+                        key={groupKey}
+                        aria-labelledby={`${groupKey}-heading`}
+                      >
                         <div className="mb-3 flex flex-col gap-1 border-b border-white/10 pb-3 sm:flex-row sm:items-end sm:justify-between">
                           <div>
                             <h2
@@ -621,7 +716,15 @@ export default function TransactionsPage() {
                           </div>
                           <p className="text-xs font-medium text-gray-400">
                             {transactions.length}{" "}
-                            {transactions.length === 1 ? "result" : "results"}
+                            {transactions.length === 1
+                              ? t("transactionHistory.results_one").replace(
+                                  "{{count}}",
+                                  "1"
+                                )
+                              : t("transactionHistory.results_many").replace(
+                                  "{{count}}",
+                                  String(transactions.length)
+                                )}
                           </p>
                         </div>
                         <div
@@ -714,38 +817,5 @@ function ActivePill({
         <X className="h-3.5 w-3.5" />
       </button>
     </span>
-  );
-}
-
-function StateCard({
-  actionLabel,
-  body,
-  onAction,
-  title,
-}: {
-  actionLabel?: string;
-  body: string;
-  onAction?: () => void;
-  title: string;
-}) {
-  return (
-    <div className="rounded-2xl border border-white/10 bg-white/[0.04] px-5 py-10 text-center sm:px-8">
-      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl border border-red-400/20 bg-red-500/10 text-red-200">
-        <Info className="h-5 w-5" />
-      </div>
-      <h2 className="mt-4 text-lg font-semibold text-white">{title}</h2>
-      <p className="mx-auto mt-2 max-w-md text-sm leading-6 text-gray-400">
-        {body}
-      </p>
-      {actionLabel && onAction && (
-        <button
-          type="button"
-          onClick={onAction}
-          className="mt-5 inline-flex min-h-[44px] items-center justify-center rounded-xl border border-white/10 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300"
-        >
-          {actionLabel}
-        </button>
-      )}
-    </div>
   );
 }

--- a/components/ui/WidgetEmptyState.tsx
+++ b/components/ui/WidgetEmptyState.tsx
@@ -1,23 +1,45 @@
-import Link from 'next/link'
-import { LucideIcon } from 'lucide-react'
+"use client";
 
-interface WidgetEmptyStateProps {
-  icon: LucideIcon
-  title: string
-  description: string
-  ctaLabel: string
-  ctaHref: string
+import Link from "next/link";
+import { type LucideIcon } from "lucide-react";
+
+interface WidgetEmptyStateBaseProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
 }
 
-export default function WidgetEmptyState({
-  icon: Icon,
-  title,
-  description,
-  ctaLabel,
-  ctaHref,
-}: WidgetEmptyStateProps) {
+type WidgetEmptyStateWithLink = WidgetEmptyStateBaseProps & {
+  ctaLabel: string;
+  ctaHref: string;
+  onAction?: never;
+};
+
+type WidgetEmptyStateWithAction = WidgetEmptyStateBaseProps & {
+  ctaLabel: string;
+  onAction: () => void;
+  ctaHref?: never;
+};
+
+type WidgetEmptyStateNoCTA = WidgetEmptyStateBaseProps & {
+  ctaLabel?: never;
+  ctaHref?: never;
+  onAction?: never;
+};
+
+type WidgetEmptyStateProps =
+  | WidgetEmptyStateWithLink
+  | WidgetEmptyStateWithAction
+  | WidgetEmptyStateNoCTA;
+
+export default function WidgetEmptyState(props: WidgetEmptyStateProps) {
+  const { icon: Icon, title, description, ctaLabel, ctaHref, onAction } = props;
+
   return (
-    <div className="flex flex-col items-center justify-center gap-4 py-10 text-center">
+    <div
+      role="status"
+      className="flex flex-col items-center justify-center gap-4 py-10 text-center"
+    >
       <span className="flex h-12 w-12 items-center justify-center rounded-full border border-[#DC2626]/30 bg-[#DC2626]/10 text-[#DC2626]">
         <Icon className="h-6 w-6" aria-hidden="true" />
       </span>
@@ -25,12 +47,23 @@ export default function WidgetEmptyState({
         <p className="text-sm font-semibold text-white">{title}</p>
         <p className="text-xs text-white/50">{description}</p>
       </div>
-      <Link
-        href={ctaHref}
-        className="rounded-lg bg-[#DC2626] px-4 py-2 text-xs font-semibold text-white transition-opacity hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#DC2626]"
-      >
-        {ctaLabel}
-      </Link>
+      {ctaLabel && ctaHref && (
+        <Link
+          href={ctaHref}
+          className="rounded-lg bg-[#DC2626] px-4 py-2 text-xs font-semibold text-white transition-opacity hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#DC2626]"
+        >
+          {ctaLabel}
+        </Link>
+      )}
+      {ctaLabel && onAction && (
+        <button
+          type="button"
+          onClick={onAction}
+          className="rounded-lg bg-[#DC2626] px-4 py-2 text-xs font-semibold text-white transition-opacity hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#DC2626]"
+        >
+          {ctaLabel}
+        </button>
+      )}
     </div>
-  )
+  );
 }

--- a/lib/hooks/useDebounce.ts
+++ b/lib/hooks/useDebounce.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Returns a debounced version of the given value.
+ * The returned value only updates after `delay` ms of inactivity.
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -30,11 +30,16 @@
   },
   "transactionHistory": {
     "title": "Transaction History",
+    "titleStandalone": "Transaction History",
+    "subtitleStandalone": "Search, filter, and review payment, split, bill, and insurance activity with grouped results by date.",
     "resultsCount": "{{count}} transactions found",
     "resultsCountZero": "No transactions found",
     "searchPlaceholder": "Search by transaction hash, address, or memo...",
     "searchPlaceholderMobile": "Search transactions...",
+    "searchStandalonePlaceholder": "Search ID, recipient, type, status, amount",
     "filters": "Filter Results",
+    "filtersHeading": "Filter transactions",
+    "filtersHelper": "Search combines with every selected type and status chip.",
     "export": "Export History",
     "tabs": {
       "all": "All Transactions",
@@ -42,8 +47,69 @@
       "pending": "Pending Review",
       "failed": "Needs Attention"
     },
+    "typeFilterLabel": "Type",
+    "statusFilterLabel": "Status",
+    "typeFilter": {
+      "all": "All types",
+      "send": "Send",
+      "split": "Split",
+      "bill": "Bills",
+      "insurance": "Insurance",
+      "savings": "Savings",
+      "family": "Family",
+      "received": "Received"
+    },
+    "statusFilter": {
+      "all": "All statuses",
+      "completed": "Completed",
+      "pending": "Pending",
+      "failed": "Failed"
+    },
+    "dateRange": {
+      "label": "Date range",
+      "from": "From date",
+      "to": "To date",
+      "clear": "Clear dates"
+    },
+    "dateGroups": {
+      "today": "Today",
+      "todayHelper": "Transactions from today",
+      "yesterday": "Yesterday",
+      "yesterdayHelper": "Transactions from yesterday",
+      "earlier": "Earlier",
+      "earlierHelper": "Older activity kept in chronological order"
+    },
+    "activeFilters": {
+      "label": "Active",
+      "none": "No filters applied",
+      "search": "Search: {{query}}",
+      "type": "Type: {{type}}",
+      "status": "Status: {{status}}",
+      "clearAll": "Clear all",
+      "clearSearch": "Clear transaction search",
+      "removeFilter": "Remove {{label}} filter"
+    },
     "empty": "No transactions matched your search.",
+    "noResults": {
+      "title": "No matching transactions",
+      "description": "Try clearing a filter, widening the status selection, or searching by recipient, ID, amount, or transaction type.",
+      "clearFilters": "Clear filters"
+    },
+    "emptyState": {
+      "title": "No transaction history yet",
+      "description": "Completed transfers, splits, bill payments, and insurance activity will appear here once you make your first transaction.",
+      "cta": "Send Money"
+    },
+    "resultsAriaLive": {
+      "one": "1 transaction found",
+      "many": "{{count}} transactions found",
+      "none": "No transactions found"
+    },
     "loadMore": "Load More Results",
+    "showing": "Showing {{count}} of {{total}} transactions",
+    "results_one": "{{count}} result",
+    "results_many": "{{count}} results",
+    "clearSearch": "Clear search",
     "alerts": {
       "filtersSoon": "Filter functionality coming soon!",
       "exportSoon": "Export functionality coming soon!",

--- a/lib/i18n/locales/es.json
+++ b/lib/i18n/locales/es.json
@@ -30,11 +30,16 @@
   },
   "transactionHistory": {
     "title": "Historial de transacciones",
+    "titleStandalone": "Historial de transacciones",
+    "subtitleStandalone": "Busca, filtra y revisa actividad de pagos, divisiones, facturas y seguros con resultados agrupados por fecha.",
     "resultsCount": "{{count}} transacciones encontradas",
     "resultsCountZero": "No se encontraron transacciones",
     "searchPlaceholder": "Busca por hash de transaccion, direccion o memo...",
     "searchPlaceholderMobile": "Busca transacciones...",
+    "searchStandalonePlaceholder": "Busca ID, destinatario, tipo, estado, monto",
     "filters": "Filtrar resultados",
+    "filtersHeading": "Filtrar transacciones",
+    "filtersHelper": "La busqueda se combina con cada chip de tipo y estado seleccionado.",
     "export": "Exportar historial",
     "tabs": {
       "all": "Todas las transacciones",
@@ -42,8 +47,69 @@
       "pending": "Pendientes de revision",
       "failed": "Requieren atencion"
     },
+    "typeFilterLabel": "Tipo",
+    "statusFilterLabel": "Estado",
+    "typeFilter": {
+      "all": "Todos los tipos",
+      "send": "Enviar",
+      "split": "Dividir",
+      "bill": "Facturas",
+      "insurance": "Seguro",
+      "savings": "Ahorros",
+      "family": "Familia",
+      "received": "Recibido"
+    },
+    "statusFilter": {
+      "all": "Todos los estados",
+      "completed": "Completado",
+      "pending": "Pendiente",
+      "failed": "Fallido"
+    },
+    "dateRange": {
+      "label": "Rango de fechas",
+      "from": "Fecha desde",
+      "to": "Fecha hasta",
+      "clear": "Limpiar fechas"
+    },
+    "dateGroups": {
+      "today": "Hoy",
+      "todayHelper": "Transacciones de hoy",
+      "yesterday": "Ayer",
+      "yesterdayHelper": "Transacciones de ayer",
+      "earlier": "Anteriores",
+      "earlierHelper": "Actividad mas antigua en orden cronologico"
+    },
+    "activeFilters": {
+      "label": "Activos",
+      "none": "Sin filtros aplicados",
+      "search": "Busqueda: {{query}}",
+      "type": "Tipo: {{type}}",
+      "status": "Estado: {{status}}",
+      "clearAll": "Limpiar todo",
+      "clearSearch": "Limpiar busqueda de transacciones",
+      "removeFilter": "Eliminar filtro {{label}}"
+    },
     "empty": "Ninguna transaccion coincide con tu busqueda.",
+    "noResults": {
+      "title": "Sin transacciones coincidentes",
+      "description": "Intenta limpiar un filtro, ampliar la seleccion de estado, o buscar por destinatario, ID, monto o tipo de transaccion.",
+      "clearFilters": "Limpiar filtros"
+    },
+    "emptyState": {
+      "title": "Aun no hay historial de transacciones",
+      "description": "Las transferencias completadas, divisiones, pagos de facturas y actividad de seguros apareceran aqui una vez que hagas tu primera transaccion.",
+      "cta": "Enviar dinero"
+    },
+    "resultsAriaLive": {
+      "one": "1 transaccion encontrada",
+      "many": "{{count}} transacciones encontradas",
+      "none": "No se encontraron transacciones"
+    },
     "loadMore": "Cargar mas resultados",
+    "showing": "Mostrando {{count}} de {{total}} transacciones",
+    "results_one": "{{count}} resultado",
+    "results_many": "{{count}} resultados",
+    "clearSearch": "Limpiar busqueda",
     "alerts": {
       "filtersSoon": "La funcion de filtros estara disponible pronto.",
       "exportSoon": "La exportacion estara disponible pronto.",


### PR DESCRIPTION
close #476 

Adds status/type/date-range filters, debounced recipient/hash search, and Today/Yesterday/Earlier date grouping with WidgetEmptyState no-results state.

- Dashboard page: full rewrite with debounced search, direction/status/date filters, date grouping, WidgetEmptyState empty/no-results, aria-live announcements, CSV export
- Standalone transactions page: debounced search, date-range filter, Yesterday grouping, i18n via useClientTranslator, WidgetEmptyState replaces StateCard
- WidgetEmptyState: extended to support button actions (onAction) alongside links
- API: returns userAddress for direction detection
- i18n: ~30 new keys in en.json and es.json for filters, date groups, empty states
- New useDebounce hook (300ms)