### PR TITLE
feat(split): make Smart Money Split sliders interactive with live 100…

### DIFF
--- a/app/split/page.tsx
+++ b/app/split/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import Link from "next/link";
-import { Save, ShieldCheck, Wallet, Clock3, Layers3 } from "lucide-react";
+import { Loader2, Save, ShieldCheck, Wallet, Clock3, Layers3 } from "lucide-react";
 import SmartMoneySplitHeader from "@/components/SmartMoneySplitHeader";
 import HowItWorks from "@/components/HowItWorksModal";
 import AsyncOperationsPanel from "@/components/AsyncOperationsPanel";
 import AsyncSubmissionStatus from "@/components/AsyncSubmissionStatus";
+import { DEFAULT_SPLIT_CONFIG, type SplitConfig } from "@/lib/remittance/split";
+import { validatePercentages } from "@/lib/validation/percentages";
 
 const splitStages = [
 	{
@@ -66,7 +69,53 @@ const splitQueue = [
 	},
 ];
 
+type AllocationKey = keyof SplitConfig;
+
+function computeTotal(alloc: SplitConfig): number {
+	return alloc.spending + alloc.savings + alloc.bills + alloc.insurance;
+}
+
 export default function SplitConfiguration() {
+	const [allocation, setAllocation] = useState<SplitConfig>(DEFAULT_SPLIT_CONFIG);
+	const [pending, setPending] = useState(false);
+	const [submissionError, setSubmissionError] = useState<string | undefined>();
+	const [submissionSuccess, setSubmissionSuccess] = useState<string | undefined>();
+
+	const validationResult = useMemo(() => {
+		try {
+			validatePercentages(allocation);
+			return { valid: true, message: undefined };
+		} catch (e) {
+			return {
+				valid: false,
+				message: e instanceof Error ? e.message : "Allocation must sum to 100%",
+			};
+		}
+	}, [allocation]);
+
+	const total = computeTotal(allocation);
+	const isValid = validationResult.valid;
+
+	const handleChange = (key: AllocationKey, value: number) => {
+		setAllocation((prev) => ({ ...prev, [key]: value }));
+		setSubmissionError(undefined);
+		setSubmissionSuccess(undefined);
+	};
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		if (!isValid || pending) return;
+
+		setPending(true);
+		setSubmissionError(undefined);
+		setSubmissionSuccess(undefined);
+
+		// No contract submission in this phase — simulate async round-trip
+		await new Promise((resolve) => setTimeout(resolve, 800));
+		setPending(false);
+		setSubmissionSuccess("Split configuration saved. Changes will apply to your next remittance.");
+	};
+
 	return (
 		<div className='min-h-screen bg-[#010101] safari-safe-bottom'>
 			<SmartMoneySplitHeader />
@@ -92,51 +141,99 @@ export default function SplitConfiguration() {
 							Allocation changes are saved as a USDC smart contract action. The payload is prepared in-app and the wallet signs it locally.
 						</p>
 
-						<form className='mt-6 space-y-5 375:space-y-6'>
+						<form
+							className='mt-6 space-y-5 375:space-y-6'
+							onSubmit={handleSubmit}
+							noValidate
+							aria-label='Smart money split configuration'
+						>
 							<SplitInput
 								label='Daily Spending'
 								description='For immediate family expenses'
-								value={50}
+								value={allocation.spending}
 								color='bg-blue-500'
+								onChange={(v) => handleChange("spending", v)}
 							/>
 							<SplitInput
 								label='Savings'
 								description='Allocated to savings goals'
-								value={30}
+								value={allocation.savings}
 								color='bg-green-500'
+								onChange={(v) => handleChange("savings", v)}
 							/>
 							<SplitInput
 								label='Bills'
 								description='Automated bill payments'
-								value={15}
+								value={allocation.bills}
 								color='bg-yellow-500'
+								onChange={(v) => handleChange("bills", v)}
 							/>
 							<SplitInput
 								label='Insurance'
 								description='Micro-insurance premiums'
-								value={5}
+								value={allocation.insurance}
 								color='bg-violet-500'
+								onChange={(v) => handleChange("insurance", v)}
 							/>
 
-							<div className='rounded-2xl border border-white/[0.08] bg-[#141414] p-4 375:p-5'>
+							{/* Live total with inline validation */}
+							<div
+								className={`rounded-2xl border p-4 375:p-5 transition-colors duration-200 ${
+									isValid
+										? "border-emerald-500/30 bg-emerald-500/[0.06]"
+										: total > 100
+											? "border-red-500/30 bg-red-500/[0.06]"
+											: "border-white/[0.08] bg-[#141414]"
+								}`}
+								aria-live='polite'
+								aria-atomic='true'
+							>
 								<div className='flex items-center justify-between gap-4'>
-									<div>
+									<div className='min-w-0'>
 										<p className='text-sm font-medium text-gray-300'>Total</p>
-										<p className='mt-1 text-xs 375:text-sm text-gray-500'>
-											Every contract build should block submission until this is
-											exactly 100%.
-										</p>
+										{isValid ? (
+											<p className='mt-1 text-xs 375:text-sm text-emerald-400'>
+												Ready to submit
+											</p>
+										) : (
+											<p
+												className='mt-1 text-xs 375:text-sm text-amber-400'
+												role='alert'
+											>
+												{validationResult.message}
+											</p>
+										)}
 									</div>
-									<span className='text-2xl 375:text-3xl font-semibold text-white'>100%</span>
+									<span
+										className={`flex-shrink-0 text-2xl 375:text-3xl font-semibold tabular-nums transition-colors duration-200 ${
+											isValid
+												? "text-emerald-400"
+												: total > 100
+													? "text-red-400"
+													: "text-white"
+										}`}
+										aria-label={`Total allocation: ${total} percent`}
+									>
+										{total}%
+									</span>
 								</div>
 							</div>
 
 							<AsyncSubmissionStatus
-								pending={false}
-								idleTitle='Contract submission placement'
-								idleDescription='Keep validation and build feedback inline with the form. Reserve stacked status cards for submit and confirmation so they can persist after navigation.'
+								pending={pending}
+								error={submissionError}
+								success={submissionSuccess}
+								idleTitle={isValid ? "Ready to save" : "Adjust your allocation"}
+								idleDescription={
+									isValid
+										? "All percentages sum to 100%. Click Save Allocation to commit this configuration."
+										: "Keep the percentage check inline with the sliders so errors resolve before a contract build starts."
+								}
 								pendingTitle='Building contract request'
-								pendingDescription='Show the user that the remittance_split payload is being prepared before the wallet step opens.'
+								pendingDescription='The remittance_split payload is being prepared before the wallet step opens.'
+								successTitle='Configuration saved'
+								successDescription={submissionSuccess}
+								errorTitle='Submission failed'
 							/>
 
 							<HowItWorks />
@@ -150,9 +247,20 @@ export default function SplitConfiguration() {
 								<button
 									type='submit'
 									className='touch-target-wide flex flex-1 items-center justify-center gap-2 rounded-2xl bg-gradient-to-b from-red-600 to-red-700 px-6 py-3.5 text-sm 375:text-base font-semibold text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#101010] disabled:cursor-not-allowed disabled:opacity-60'
-									disabled>
-									<Save className='h-5 w-5' />
-									<span>Connect Contract First</span>
+									disabled={!isValid || pending}
+									aria-disabled={!isValid || pending}
+								>
+									{pending ? (
+										<>
+											<Loader2 className='h-5 w-5 animate-spin' aria-hidden='true' />
+											<span>Saving…</span>
+										</>
+									) : (
+										<>
+											<Save className='h-5 w-5' aria-hidden='true' />
+											<span>Save Allocation</span>
+										</>
+									)}
 								</button>
 							</div>
 						</form>
@@ -181,33 +289,74 @@ function SplitInput({
 	description,
 	value,
 	color,
+	onChange,
 }: {
 	label: string;
 	description: string;
 	value: number;
 	color: string;
+	onChange: (value: number) => void;
 }) {
+	const handleSlider = (e: React.ChangeEvent<HTMLInputElement>) => {
+		onChange(Number(e.target.value));
+	};
+
+	const handleNumber = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const raw = parseInt(e.target.value, 10);
+		if (!Number.isFinite(raw)) return;
+		onChange(Math.min(100, Math.max(0, raw)));
+	};
+
+	const inputId = `split-${label.toLowerCase().replace(/\s+/g, "-")}`;
+
 	return (
 		<div className='rounded-2xl border border-white/[0.08] bg-black/20 p-4 375:p-5 transition-colors hover:bg-white/[0.02]'>
 			<div className='mb-3 flex items-center justify-between gap-4'>
-				<div>
-					<label className='block text-sm 375:text-base font-medium text-white'>{label}</label>
+				<div className='min-w-0'>
+					<label
+						htmlFor={inputId}
+						className='block text-sm 375:text-base font-medium text-white'
+					>
+						{label}
+					</label>
 					<p className='mt-0.5 text-xs 375:text-sm text-gray-500'>{description}</p>
 				</div>
-				<div className='text-xl 375:text-2xl font-semibold text-white'>{value}%</div>
+				<div className='flex flex-shrink-0 items-center gap-0.5'>
+					<input
+						type='number'
+						min='0'
+						max='100'
+						step='1'
+						value={value}
+						onChange={handleNumber}
+						className='w-14 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-right text-xl 375:text-2xl font-semibold text-white focus:outline-none focus:ring-2 focus:ring-red-500 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none'
+						aria-label={`${label} percentage`}
+					/>
+					<span className='text-xl 375:text-2xl font-semibold text-white' aria-hidden='true'>
+						%
+					</span>
+				</div>
 			</div>
-			<div className='mb-4 h-2 w-full rounded-full bg-white/10'>
+			<div className='mb-4 h-2 w-full rounded-full bg-white/10' aria-hidden='true'>
 				<div
-					className={`${color} h-2 rounded-full shadow-[0_0_10px_rgba(0,0,0,0.5)]`}
-					style={{ width: `${value}%` }}></div>
+					className={`${color} h-2 rounded-full shadow-[0_0_10px_rgba(0,0,0,0.5)] transition-all duration-150`}
+					style={{ width: `${value}%` }}
+				/>
 			</div>
 			<input
+				id={inputId}
 				type='range'
 				min='0'
 				max='100'
+				step='1'
 				value={value}
+				onChange={handleSlider}
 				className='h-11 w-full accent-red-600 touch-target'
-				disabled
+				aria-label={`${label} slider`}
+				aria-valuetext={`${value} percent`}
+				aria-valuenow={value}
+				aria-valuemin={0}
+				aria-valuemax={100}
 			/>
 		</div>
 	);

--- a/tests/unit/split/split-config.test.ts
+++ b/tests/unit/split/split-config.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_SPLIT_CONFIG,
+  computeAllocation,
+  type SplitConfig,
+} from '../../../lib/remittance/split'
+import {
+  validatePercentages,
+  ValidationError,
+  type SplitPercentages,
+} from '../../../lib/validation/percentages'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const valid100: SplitPercentages = { spending: 50, savings: 30, bills: 15, insurance: 5 }
+
+function makePercentages(overrides: Partial<SplitPercentages> = {}): SplitPercentages {
+  return { ...valid100, ...overrides }
+}
+
+// ---------------------------------------------------------------------------
+// DEFAULT_SPLIT_CONFIG
+// ---------------------------------------------------------------------------
+
+describe('DEFAULT_SPLIT_CONFIG', () => {
+  it('sums to exactly 100', () => {
+    const { spending, savings, bills, insurance } = DEFAULT_SPLIT_CONFIG
+    expect(spending + savings + bills + insurance).toBe(100)
+  })
+
+  it('has no negative values', () => {
+    for (const v of Object.values(DEFAULT_SPLIT_CONFIG)) {
+      expect(v).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  it('matches the SplitConfig shape (spending, savings, bills, insurance)', () => {
+    const keys = Object.keys(DEFAULT_SPLIT_CONFIG).sort()
+    expect(keys).toEqual(['bills', 'insurance', 'savings', 'spending'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validatePercentages — valid cases
+// ---------------------------------------------------------------------------
+
+describe('validatePercentages — valid input', () => {
+  it('does not throw when percentages sum to exactly 100', () => {
+    expect(() => validatePercentages(valid100)).not.toThrow()
+  })
+
+  it('does not throw for equal 25/25/25/25 split', () => {
+    expect(() =>
+      validatePercentages({ spending: 25, savings: 25, bills: 25, insurance: 25 })
+    ).not.toThrow()
+  })
+
+  it('does not throw when one category takes the full 100', () => {
+    expect(() =>
+      validatePercentages({ spending: 100, savings: 0, bills: 0, insurance: 0 })
+    ).not.toThrow()
+  })
+
+  it('accepts DEFAULT_SPLIT_CONFIG values', () => {
+    expect(() => validatePercentages(DEFAULT_SPLIT_CONFIG as SplitPercentages)).not.toThrow()
+  })
+
+  it('tolerates tiny floating-point deviation (≤ 0.01)', () => {
+    // 33.34 + 33.33 + 33.33 = 100.00 — common rounding scenario
+    expect(() =>
+      validatePercentages({ spending: 33.34, savings: 33.33, bills: 33.33, insurance: 0 })
+    ).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validatePercentages — invalid: sum < 100
+// ---------------------------------------------------------------------------
+
+describe('validatePercentages — sum under 100', () => {
+  it('throws ValidationError when total is under 100', () => {
+    expect(() => validatePercentages(makePercentages({ spending: 0 }))).toThrow(ValidationError)
+  })
+
+  it('thrown message references the actual sum', () => {
+    // total = 0+30+15+5 = 50
+    try {
+      validatePercentages(makePercentages({ spending: 0 }))
+      expect.fail('expected throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(ValidationError)
+      expect((e as ValidationError).message).toMatch(/50/)
+    }
+  })
+
+  it('throws when all values are zero', () => {
+    expect(() =>
+      validatePercentages({ spending: 0, savings: 0, bills: 0, insurance: 0 })
+    ).toThrow(ValidationError)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validatePercentages — invalid: sum > 100
+// ---------------------------------------------------------------------------
+
+describe('validatePercentages — sum over 100', () => {
+  it('throws ValidationError when total exceeds 100', () => {
+    expect(() => validatePercentages(makePercentages({ spending: 60 }))).toThrow(ValidationError)
+  })
+
+  it('thrown message references the actual sum', () => {
+    // total = 60+30+15+5 = 110
+    try {
+      validatePercentages(makePercentages({ spending: 60 }))
+      expect.fail('expected throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(ValidationError)
+      expect((e as ValidationError).message).toMatch(/110/)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validatePercentages — invalid: negative values
+// ---------------------------------------------------------------------------
+
+describe('validatePercentages — negative values', () => {
+  it('throws ValidationError for negative spending', () => {
+    expect(() => validatePercentages(makePercentages({ spending: -5 }))).toThrow(ValidationError)
+  })
+
+  it('throws ValidationError for negative savings', () => {
+    expect(() => validatePercentages(makePercentages({ savings: -1 }))).toThrow(ValidationError)
+  })
+
+  it('thrown error name is "ValidationError"', () => {
+    try {
+      validatePercentages(makePercentages({ spending: -10 }))
+      expect.fail('expected throw')
+    } catch (e) {
+      expect((e as ValidationError).name).toBe('ValidationError')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeAllocation — gating on valid split config
+// ---------------------------------------------------------------------------
+
+describe('computeAllocation', () => {
+  it('returns amounts that sum to the input amount', () => {
+    const { spending, savings, bills, insurance } = computeAllocation(1000)
+    expect(spending + savings + bills + insurance).toBe(1000)
+  })
+
+  it('distributes according to DEFAULT_SPLIT_CONFIG proportions', () => {
+    const result = computeAllocation(200, { spending: 50, savings: 25, bills: 25, insurance: 0 })
+    expect(result.spending).toBe(100)
+    expect(result.savings).toBe(50)
+    expect(result.bills).toBe(50)
+    expect(result.insurance).toBe(0)
+  })
+
+  it('throws when config does not sum to 100', () => {
+    const badConfig: SplitConfig = { spending: 10, savings: 10, bills: 10, insurance: 10 }
+    expect(() => computeAllocation(100, badConfig)).toThrow()
+  })
+
+  it('handles zero amount gracefully (all allocations are 0)', () => {
+    const result = computeAllocation(0)
+    expect(result.spending + result.savings + result.bills + result.insurance).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Submit-button gating invariant (pure logic mirror of the page component)
+// ---------------------------------------------------------------------------
+
+describe('submit button gating logic', () => {
+  function isSubmitEnabled(alloc: SplitPercentages, pending = false): boolean {
+    try {
+      validatePercentages(alloc)
+      return !pending
+    } catch {
+      return false
+    }
+  }
+
+  it('is enabled when total is 100 and not pending', () => {
+    expect(isSubmitEnabled(valid100)).toBe(true)
+  })
+
+  it('is disabled when total is under 100', () => {
+    expect(isSubmitEnabled(makePercentages({ spending: 0 }))).toBe(false)
+  })
+
+  it('is disabled when total is over 100', () => {
+    expect(isSubmitEnabled(makePercentages({ spending: 80 }))).toBe(false)
+  })
+
+  it('is disabled when valid but pending', () => {
+    expect(isSubmitEnabled(valid100, true)).toBe(false)
+  })
+
+  it('remains disabled across all invalid combinations', () => {
+    const cases: SplitPercentages[] = [
+      { spending: 0, savings: 0, bills: 0, insurance: 0 },
+      { spending: 100, savings: 1, bills: 0, insurance: 0 },
+      { spending: -1, savings: 50, bills: 25, insurance: 26 },
+    ]
+    for (const c of cases) {
+      expect(isSubmitEnabled(c)).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION


Closes #457

- Convert SplitConfiguration to manage allocation state via useState, initialized from DEFAULT_SPLIT_CONFIG (spending 50, savings 30, bills 15, insurance 5)
- Remove disabled attribute from all four range sliders; add onChange handler and controlled number input per slider for keyboard access
- Live total computed inline; validatePercentages() called on every change via useMemo
- Total card colour-codes green (100%), amber (under), red (over) with aria-live region for screen-reader announcements
- Inline validation message shown under total when sum != 100
- Submit button (Save Allocation) disabled and aria-disabled while total != 100 or submission is pending
- AsyncSubmissionStatus wired to real pending/success/error state; idle copy reflects current validation result
- Loader2 spinner shown in button during pending state
- Full keyboard + aria-valuetext accessibility on sliders
- Add tests/unit/split/split-config.test.ts covering validatePercentages, computeAllocation, DEFAULT_SPLIT_CONFIG, and submit-button gating logic