### PR TITLE
Add Sentry monitoring with PII scrubbing and CI source map uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,3 +97,30 @@ ALLOWED_ORIGINS=https://app.remitwise.com,http://localhost:3000
 # ============================================
 # Log level: debug, info, warn, error (default: info)
 LOG_LEVEL=info
+
+# ============================================
+# Sentry Error Monitoring
+# ============================================
+# Get these from https://sentry.io → Settings → Projects → <your project> → SDK Setup
+
+# Public DSN — exposed to the browser (safe to commit as NEXT_PUBLIC_)
+NEXT_PUBLIC_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
+
+# Server-side DSN (same value, kept separate for clarity)
+SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
+
+# Sentry org/project slugs (find in your Sentry project URL)
+SENTRY_ORG=your-org-slug
+SENTRY_PROJECT=your-project-slug
+
+# Auth token for source map uploads (CI only — never commit a real value)
+# Generate at: https://sentry.io/settings/account/api/auth-tokens/
+# Required scopes: project:releases, org:read
+SENTRY_AUTH_TOKEN=your-sentry-auth-token-here
+
+# Release identifier — set automatically in CI (e.g. git SHA or semver tag)
+# In CI: SENTRY_RELEASE=$(git rev-parse --short HEAD)
+SENTRY_RELEASE=
+
+# App environment — controls sample rates (development | staging | production)
+NEXT_PUBLIC_APP_ENV=development

--- a/README.md
+++ b/README.md
@@ -27,6 +27,24 @@ The frontend includes placeholder pages and components for:
 
 Dashboard, Bills, and Insights now use route-level skeleton screens built from `components/ui/Skeleton.tsx` so primary panels load with stable layout blocks instead of ad-hoc spinners.
 
+## Sentry
+
+Sentry is wired through the client, server, and edge config files with separate environment variables for each runtime:
+
+- `NEXT_PUBLIC_SENTRY_DSN` is used by the browser bundle.
+- `SENTRY_DSN` and `SENTRY_RELEASE` are used on the server and edge runtimes.
+- `SENTRY_ORG`, `SENTRY_PROJECT`, and `SENTRY_AUTH_TOKEN` are required for source map uploads in CI.
+- `NEXT_PUBLIC_APP_ENV` drives sampling behavior, with higher collection in development and lower rates in production.
+- The Sentry tunnel route is `/monitoring`, which keeps requests working through ad blockers.
+
+PII scrubbing is applied before events leave the app:
+
+- Client events scrub Stellar public keys and amount strings.
+- Server events use the same scrubbing plus `iron-session` token redaction.
+- Edge events stay minimal and do not attach replay or extra scrubbing.
+
+Keep the auth token out of the repo and store it only in CI secrets.
+
 ## Getting Started
 
 ### Environment Configuration
@@ -726,7 +744,35 @@ Example environment variables:
 
 RemitWise exposes an OpenAPI discovery endpoint:
 
-/api/.well-known/openapi
+ /api/.well-known/openapi
 
 This allows integrators and wallets to automatically discover
 the RemitWise API specification.
+
+## Sentry
+
+Sentry error monitoring is integrated for client, server, and edge runtimes.
+
+**Required environment variables** (see `.env.example`):
+- `NEXT_PUBLIC_SENTRY_DSN` — public DSN for browser and client
+- `SENTRY_DSN` — server/edge DSN (same value)
+- `SENTRY_ORG`, `SENTRY_PROJECT` — project identifiers for source map uploads
+- `SENTRY_AUTH_TOKEN` — CI-only token (never commit); store as secret in CI
+- `SENTRY_RELEASE` — release id (git SHA or tag), set automatically in CI
+- `NEXT_PUBLIC_APP_ENV` — `development` | `staging` | `production`
+
+**Sample rates**:
+- `NEXT_PUBLIC_APP_ENV=production` sets lower rates: `tracesSampleRate: 0.1`, `replaysSessionSampleRate: 0.05`
+- Non-production uses higher rates for visibility
+
+**Tunnel route**:
+- All Sentry requests are proxied through `/monitoring` (configured in `next.config.js`) to avoid ad blockers.
+
+**PII scrubbing**:
+- Client (`scrubStellarPII`): Stellar addresses (`G[A-Z2-7]{55}`) and amounts (`\d+ XLM|USDC|USD`) are replaced before send.
+- Server (`scrubServerPII`): same + `iron-session` tokens are redacted.
+- Scrubbers live inside each config file for edge compatibility.
+
+**Source maps**:
+- Uploaded during build when `SENTRY_AUTH_TOKEN` and CI are present.
+- `hideSourceMaps: true` prevents browser exposure.

--- a/next.config.js
+++ b/next.config.js
@@ -1,27 +1,34 @@
+const { withSentryConfig } = require("@sentry/nextjs");
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+};
 
-// Keep legacy `/api/*` routes working as v1 to avoid breaking existing clients.
-// When v2 is introduced, add a new `/api/v2/*` namespace and update rewrites as needed.
 const rewrites = async () => {
   return [
     {
-      source: '/api/:path*',
-      destination: '/api/v1/:path*',
+      source: "/api/:path*",
+      destination: "/api/v1/:path*",
     },
-  ]
-}
+  ];
+};
 
-module.exports = {
-  ...nextConfig,
-  rewrites,
-}
+const sentryWebpackPluginOptions = {
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+  authToken: process.env.SENTRY_AUTH_TOKEN,
 
-// /** @type {import('next').NextConfig} */
-// const nextConfig = {
-//   reactStrictMode: true,
-// }
+  silent: !process.env.CI,
 
-// module.exports = nextConfig
+  tunnelRoute: "/monitoring",
+
+  hideSourceMaps: true,
+
+  disableLogger: true,
+};
+
+module.exports = withSentryConfig(
+  { ...nextConfig, rewrites },
+  sentryWebpackPluginOptions
+);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "swagger-ui-react": "^5.31.2",
     "tailwind-merge": "^3.4.0",
     "yaml": "^2.8.2",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "@sentry/nextjs": "^8.55.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,0 +1,28 @@
+import * as Sentry from "@sentry/nextjs";
+
+const STELLAR_ADDRESS_REGEX = /G[A-Z2-7]{55}/g;
+const AMOUNT_REGEX = /\b\d+(\.\d+)?\s*(XLM|USDC|USD)\b/gi;
+
+function scrubStellarPII(event: Sentry.Event): Sentry.Event {
+  const str = JSON.stringify(event);
+  const scrubbed = str
+    .replace(STELLAR_ADDRESS_REGEX, "[STELLAR_ADDRESS]")
+    .replace(AMOUNT_REGEX, "[AMOUNT]");
+  return JSON.parse(scrubbed);
+}
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment: process.env.NEXT_PUBLIC_APP_ENV ?? "development",
+  release: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
+
+  tracesSampleRate: process.env.NEXT_PUBLIC_APP_ENV === "production" ? 0.1 : 1.0,
+  replaysSessionSampleRate: process.env.NEXT_PUBLIC_APP_ENV === "production" ? 0.05 : 0.5,
+  replaysOnErrorSampleRate: 1.0,
+
+  integrations: [Sentry.replayIntegration()],
+
+  beforeSend(event) {
+    return scrubStellarPII(event);
+  },
+});

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,0 +1,9 @@
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.NEXT_PUBLIC_APP_ENV ?? "development",
+  release: process.env.SENTRY_RELEASE,
+
+  tracesSampleRate: process.env.NEXT_PUBLIC_APP_ENV === "production" ? 0.05 : 0.5,
+});

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,0 +1,26 @@
+import * as Sentry from "@sentry/nextjs";
+
+const STELLAR_ADDRESS_REGEX = /G[A-Z2-7]{55}/g;
+const AMOUNT_REGEX = /\b\d+(\.\d+)?\s*(XLM|USDC|USD)\b/gi;
+const SESSION_TOKEN_REGEX = /"iron-session[^"]*":\s*"[^"]+"/gi;
+
+function scrubServerPII(event: Sentry.Event): Sentry.Event {
+  const str = JSON.stringify(event);
+  const scrubbed = str
+    .replace(STELLAR_ADDRESS_REGEX, "[STELLAR_ADDRESS]")
+    .replace(AMOUNT_REGEX, "[AMOUNT]")
+    .replace(SESSION_TOKEN_REGEX, '"iron-session":"[REDACTED]"');
+  return JSON.parse(scrubbed);
+}
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.NEXT_PUBLIC_APP_ENV ?? "development",
+  release: process.env.SENTRY_RELEASE,
+
+  tracesSampleRate: process.env.NEXT_PUBLIC_APP_ENV === "production" ? 0.1 : 1.0,
+
+  beforeSend(event) {
+    return scrubServerPII(event);
+  },
+});


### PR DESCRIPTION
Closes #17

This PR adds Sentry across the Next.js app for client, server, and edge runtimes, with environment-specific config and source map upload support in CI.

What changed:
- Added `sentry.client.config.ts`, `sentry.server.config.ts`, and `sentry.edge.config.ts`
- Wired the client to use `NEXT_PUBLIC_SENTRY_DSN`
- Wired server and edge runtimes to use `SENTRY_DSN` and `SENTRY_RELEASE`
- Added replay support on the client
- Added PII scrubbing for Stellar addresses and amounts on the client and server
- Added `iron-session` token redaction on the server
- Wrapped `next.config.js` with `withSentryConfig`
- Enabled the `/monitoring` tunnel route
- Kept source maps hidden from the browser and logger output disabled
- Moved `@sentry/nextjs` into `dependencies`
- Documented the Sentry setup in `README.md`
- Added the required env vars to `.env.example`

Notes:
- `SENTRY_AUTH_TOKEN` should stay in CI secrets only
- Client and server sample rates are driven by `NEXT_PUBLIC_APP_ENV`
- Edge config stays minimal by design
