### PR TITLE
refactor(send): extract useStellarAddressValidation hook + tests

### DIFF
--- a/app/emergency-transfer/page.tsx
+++ b/app/emergency-transfer/page.tsx
@@ -3,6 +3,9 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useToast } from "@/lib/context/ToastContext";
+import useStellarAddressValidation, {
+  normalizeStellarAddress,
+} from "@/lib/hooks/useStellarAddressValidation";
 import {
   ArrowLeft,
   AlertTriangle,
@@ -33,9 +36,10 @@ export default function EmergencyTransferPage() {
 
   const priorityFee = speed === "emergency" ? 2.0 : 0.0;
   const total = amount + priorityFee;
+  const validation = useStellarAddressValidation(recipientAddress);
 
   const handleRecipientContinue = () => {
-    if (recipientName && recipientAddress) {
+    if (recipientName && validation.isValid) {
       setStep("amount");
     }
   };
@@ -212,10 +216,24 @@ export default function EmergencyTransferPage() {
                   <input
                     type="text"
                     value={recipientAddress}
-                    onChange={(e) => setRecipientAddress(e.target.value)}
+                    onChange={(e) => setRecipientAddress(normalizeStellarAddress(e.target.value))}
                     placeholder="GXXXXXXXXXXXXXXXXXXXXXXXX"
                     className="w-full rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4 text-white placeholder:text-zinc-600 focus:border-red-500/50 focus:ring-1 focus:ring-red-500/50 outline-none transition-all font-mono"
                   />
+                  {recipientAddress && (
+                    <p
+                      className={`mt-2 text-sm ${
+                        validation.tone === 'success'
+                          ? 'text-emerald-400'
+                          : validation.tone === 'error'
+                            ? 'text-red-400'
+                            : 'text-zinc-400'
+                      }`}
+                      aria-live="polite"
+                    >
+                      {validation.message}
+                    </p>
+                  )}
                 </div>
               </div>
 
@@ -228,7 +246,7 @@ export default function EmergencyTransferPage() {
                 </Link>
                 <button
                   onClick={handleRecipientContinue}
-                  disabled={!recipientName || !recipientAddress}
+                  disabled={!recipientName || !validation.isValid}
                   className="flex-1 flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-b from-red-600 to-red-700 px-6 py-3 font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   Continue

--- a/app/send/components/RecipientAddressInput.tsx
+++ b/app/send/components/RecipientAddressInput.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useEffect, useId, useMemo, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { CheckCircle2, Copy, ClipboardPaste, QrCode, AlertCircle } from "lucide-react";
-import { StrKey } from "@stellar/stellar-sdk";
+import useStellarAddressValidation, {
+  normalizeStellarAddress,
+} from "@/lib/hooks/useStellarAddressValidation";
 
 interface RecipientAddressInputProps {
   onAddressChange?: (address: string) => void;
@@ -24,7 +26,7 @@ export default function RecipientAddressInput({
   const inputId = useId();
   const hintId = `${inputId}-hint`;
   const statusId = `${inputId}-status`;
-  const [address, setAddress] = useState(initialAddress);
+  const [address, setAddress] = useState(() => normalizeStellarAddress(initialAddress));
   const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
   const [pasteState, setPasteState] = useState<"idle" | "pasted" | "error">("idle");
 
@@ -46,61 +48,16 @@ export default function RecipientAddressInput({
     return () => window.clearTimeout(timer);
   }, [pasteState]);
 
-  const normalizeAddress = (value: string) => value.toUpperCase().replace(/\s+/g, "").trim();
-
-  const validation = useMemo(() => {
-    if (!address) {
-      return {
-        tone: "idle" as const,
-        message: "Paste a Stellar wallet address to verify its checksum before sending.",
-      };
-    }
-
-    const normalizedAddress = normalizeAddress(address);
-
-    if (!normalizedAddress.startsWith("G")) {
-      return {
-        tone: "error" as const,
-        message: "Recipient address must start with G.",
-      };
-    }
-
-    if (normalizedAddress.length !== 56) {
-      return {
-        tone: "error" as const,
-        message: `Recipient address must be 56 characters. ${normalizedAddress.length}/56 entered.`,
-      };
-    }
-
-    if (!/^[A-Z2-7]+$/.test(normalizedAddress)) {
-      return {
-        tone: "error" as const,
-        message: "Recipient address contains unsupported characters.",
-      };
-    }
-
-    if (!StrKey.isValidEd25519PublicKey(normalizedAddress)) {
-      return {
-        tone: "error" as const,
-        message: "Checksum failed. Double-check the address before sending.",
-      };
-    }
-
-    return {
-      tone: "success" as const,
-      message: "Checksum verified. This is a valid Stellar public key.",
-    };
-  }, [address]);
-
+  const validation = useStellarAddressValidation(address);
   const isInvalid = validation.tone === "error";
-  const isValid = validation.tone === "success";
+  const isValid = validation.isValid;
 
   const handleRecentClick = (recentAddress: string) => {
-    setAddress(normalizeAddress(recentAddress));
+    setAddress(normalizeStellarAddress(recentAddress));
   };
 
   const handleInputChange = (value: string) => {
-    setAddress(normalizeAddress(value));
+    setAddress(normalizeStellarAddress(value));
   };
 
   const handlePasteFromClipboard = async () => {
@@ -111,7 +68,7 @@ export default function RecipientAddressInput({
         return;
       }
 
-      setAddress(normalizeAddress(clipboardText));
+      setAddress(normalizeStellarAddress(clipboardText));
       setPasteState("pasted");
     } catch (error) {
       console.error("Failed to paste address from clipboard:", error);
@@ -131,7 +88,7 @@ export default function RecipientAddressInput({
     }
   };
 
-  const isContinueEnabled = address !== "" && isValid;
+  const isContinueEnabled = validation.isValid;
 
   return (
     <div className="mx-auto relative overflow-hidden bg-[#0c0c0c] border border-white/5 rounded-[2rem] p-8 sm:p-10 mb-8 shadow-2xl">

--- a/lib/hooks/useStellarAddressValidation.test.ts
+++ b/lib/hooks/useStellarAddressValidation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { Keypair } from '@stellar/stellar-sdk';
+import { getStellarAddressValidationResult } from './useStellarAddressValidation';
+
+describe('getStellarAddressValidationResult', () => {
+  it('returns idle state for empty input', () => {
+    expect(getStellarAddressValidationResult('')).toEqual({
+      tone: 'idle',
+      message: 'Paste a Stellar wallet address to verify its checksum before sending.',
+      normalized: '',
+      isValid: false,
+    });
+  });
+
+  it('normalizes whitespace and lowercase input before validating', () => {
+    const validAddress = Keypair.random().publicKey();
+    const result = getStellarAddressValidationResult(`  ${validAddress.toLowerCase()}  `);
+
+    expect(result).toMatchObject({
+      normalized: validAddress,
+      isValid: true,
+      tone: 'success',
+    });
+  });
+
+  it('reports the correct length errors for too-short and too-long inputs', () => {
+    const validAddress = Keypair.random().publicKey();
+    const tooShort = validAddress.slice(0, 55);
+    const tooLong = `${validAddress}A`;
+
+    expect(getStellarAddressValidationResult(tooShort)).toMatchObject({
+      tone: 'error',
+      message: 'Recipient address must be 56 characters. 55/56 entered.',
+      isValid: false,
+    });
+
+    expect(getStellarAddressValidationResult(tooLong)).toMatchObject({
+      tone: 'error',
+      message: 'Recipient address must be 56 characters. 57/56 entered.',
+      isValid: false,
+    });
+  });
+
+  it('reports unsupported characters for non-base32 values', () => {
+    const result = getStellarAddressValidationResult(`G${'A'.repeat(54)}-`);
+
+    expect(result).toMatchObject({
+      tone: 'error',
+      message: 'Recipient address contains unsupported characters.',
+      isValid: false,
+    });
+  });
+
+  it('reports checksum failures for structurally valid but bad keys', () => {
+    const validAddress = Keypair.random().publicKey();
+    const invalidChecksumAddress = `${validAddress.slice(0, -1)}${validAddress.at(-1) === 'A' ? 'B' : 'A'}`;
+
+    const result = getStellarAddressValidationResult(invalidChecksumAddress);
+
+    expect(result).toMatchObject({
+      tone: 'error',
+      message: 'Checksum failed. Double-check the address before sending.',
+      isValid: false,
+    });
+  });
+});

--- a/lib/hooks/useStellarAddressValidation.ts
+++ b/lib/hooks/useStellarAddressValidation.ts
@@ -1,0 +1,79 @@
+import { useMemo } from 'react';
+import { StrKey } from '@stellar/stellar-sdk';
+
+export type StellarAddressValidationTone = 'idle' | 'error' | 'success';
+
+export interface StellarAddressValidationResult {
+  tone: StellarAddressValidationTone;
+  message: string;
+  normalized: string;
+  isValid: boolean;
+}
+
+export const normalizeStellarAddress = (value: string) =>
+  value.toUpperCase().replace(/\s+/g, '').trim();
+
+export const getStellarAddressValidationResult = (
+  rawInput: string
+): StellarAddressValidationResult => {
+  const normalized = normalizeStellarAddress(rawInput);
+
+  if (!normalized) {
+    return {
+      tone: 'idle',
+      message: 'Paste a Stellar wallet address to verify its checksum before sending.',
+      normalized: '',
+      isValid: false,
+    };
+  }
+
+  if (!normalized.startsWith('G')) {
+    return {
+      tone: 'error',
+      message: 'Recipient address must start with G.',
+      normalized,
+      isValid: false,
+    };
+  }
+
+  if (normalized.length !== 56) {
+    return {
+      tone: 'error',
+      message: `Recipient address must be 56 characters. ${normalized.length}/56 entered.`,
+      normalized,
+      isValid: false,
+    };
+  }
+
+  if (!/^[A-Z2-7]+$/.test(normalized)) {
+    return {
+      tone: 'error',
+      message: 'Recipient address contains unsupported characters.',
+      normalized,
+      isValid: false,
+    };
+  }
+
+  if (!StrKey.isValidEd25519PublicKey(normalized)) {
+    return {
+      tone: 'error',
+      message: 'Checksum failed. Double-check the address before sending.',
+      normalized,
+      isValid: false,
+    };
+  }
+
+  return {
+    tone: 'success',
+    message: 'Checksum verified. This is a valid Stellar public key.',
+    normalized,
+    isValid: true,
+  };
+};
+
+export default function useStellarAddressValidation(rawInput: string) {
+  return useMemo(
+    () => getStellarAddressValidationResult(rawInput),
+    [rawInput]
+  );
+}

--- a/lib/validation/percentages.ts
+++ b/lib/validation/percentages.ts
@@ -1,5 +1,7 @@
 // Validation utilities for split percentages
 
+import { StrKey } from '@stellar/stellar-sdk';
+
 export interface SplitPercentages {
   spending: number;
   savings: number;
@@ -47,8 +49,10 @@ export function validatePercentages(percentages: SplitPercentages): void {
   }
 }
 
+const STELLAR_ADDRESS_REGEX = /^G[A-Z2-7]{55}$/;
+
 /**
- * Validates Stellar address format
+ * Validates Stellar address format and checksum.
  * @throws {ValidationError} if address is invalid
  */
 export function validateStellarAddress(address: string): void {
@@ -56,8 +60,13 @@ export function validateStellarAddress(address: string): void {
     throw new ValidationError('Address must be a non-empty string');
   }
 
-  // Basic Stellar address validation (starts with G and is 56 characters)
-  if (!address.match(/^G[A-Z0-9]{55}$/)) {
+  const normalizedAddress = address.trim().toUpperCase();
+
+  if (!STELLAR_ADDRESS_REGEX.test(normalizedAddress)) {
     throw new ValidationError('Invalid Stellar address format');
+  }
+
+  if (!StrKey.isValidEd25519PublicKey(normalizedAddress)) {
+    throw new ValidationError('Invalid Stellar address checksum');
   }
 }


### PR DESCRIPTION
Closes #465 
This PR centralizes Stellar recipient address validation into a shared hook and reuses it across the Send and Emergency Transfer flows. It also updates the server-side validation path to align with the same format/checksum rules and adds unit tests for valid/invalid edge cases.