### PR TITLE
feat(anchor): add timeout + bounded retry/backoff to rate client

### DIFF
--- a/app/api/anchor/rates/route.ts
+++ b/app/api/anchor/rates/route.ts
@@ -1,18 +1,17 @@
 import { NextResponse } from 'next/server';
 import { anchorClient } from '@/lib/anchor/client';
-import { getAnchorRatesCache, setAnchorRatesCache } from '@/lib/anchor/rates-cache';
+import {
+    getAnchorRatesCache,
+    setAnchorRatesCache,
+    isCacheFresh,
+    isCacheStale,
+} from '@/lib/anchor/rates-cache';
 
 export const dynamic = 'force-dynamic';
 
-// 5 minutes in milliseconds
-const CACHE_TTL = 5 * 60 * 1000;
-
 export async function GET() {
-    const rateCache = getAnchorRatesCache();
-    const now = Date.now();
-    const isCacheValid = rateCache.rates !== null && (now - rateCache.timestamp) < CACHE_TTL;
-
-    if (isCacheValid) {
+    if (isCacheFresh()) {
+        const rateCache = getAnchorRatesCache();
         return NextResponse.json({
             rates: rateCache.rates,
             stale: false,
@@ -21,9 +20,7 @@ export async function GET() {
 
     try {
         const fetchedRates = await anchorClient.getExchangeRates();
-
-        // Update the cache
-        setAnchorRatesCache(fetchedRates, now);
+        setAnchorRatesCache(fetchedRates, Date.now());
 
         return NextResponse.json({
             rates: fetchedRates,
@@ -32,8 +29,8 @@ export async function GET() {
     } catch (error) {
         console.error('API /anchor/rates - Error fetching from Anchor Client:', error);
 
-        // Fallback: If cache exists but is stale, return the stale cache.
-        if (rateCache.rates !== null) {
+        if (isCacheStale()) {
+            const rateCache = getAnchorRatesCache();
             console.warn('API /anchor/rates - Returning stale rate cache due to anchor failure.');
             return NextResponse.json({
                 rates: rateCache.rates,
@@ -41,7 +38,6 @@ export async function GET() {
             });
         }
 
-        // No cache exists and the fetch failed
         return NextResponse.json(
             { error: 'Service Unavailable' },
             { status: 503 }

--- a/lib/anchor/client.ts
+++ b/lib/anchor/client.ts
@@ -36,19 +36,27 @@ export interface AnchorFlowResponse {
     [key: string]: unknown;
 }
 
-const DEFAULT_TIMEOUT_MS = 5000;
+export const DEFAULT_TIMEOUT_MS = 5000;
+export const MAX_RETRY_ATTEMPTS = 3;
+export const RETRY_BASE_DELAY_MS = 200;
+
+function isTransientHttpStatus(status: number): boolean {
+    return status >= 500;
+}
 
 export class AnchorClient {
     private baseUrl: string;
     private apiKey: string;
     private depositPath: string;
     private withdrawPath: string;
+    private maxRetryAttempts: number;
 
-    constructor() {
+    constructor(options?: { maxRetryAttempts?: number }) {
         this.baseUrl = process.env.ANCHOR_API_BASE_URL || '';
         this.apiKey = process.env.ANCHOR_API_KEY || '';
         this.depositPath = process.env.ANCHOR_DEPOSIT_PATH || '/transactions/deposit/interactive';
         this.withdrawPath = process.env.ANCHOR_WITHDRAW_PATH || '/transactions/withdraw/interactive';
+        this.maxRetryAttempts = options?.maxRetryAttempts ?? MAX_RETRY_ATTEMPTS;
         if (!this.baseUrl) {
             console.warn('ANCHOR_API_BASE_URL is not set. Anchor API calls may fail.');
         }
@@ -58,9 +66,6 @@ export class AnchorClient {
         return Boolean(this.baseUrl);
     }
 
-    /**
-     * Helper method to perform fetch with timeout
-     */
     private async fetchWithTimeout(url: string, options: RequestInit = {}, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<Response> {
         const controller = new AbortController();
         const id = setTimeout(() => controller.abort(), timeoutMs);
@@ -81,10 +86,46 @@ export class AnchorClient {
         }
     }
 
+    private async sleep(ms: number): Promise<void> {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
     /**
-     * Fetches the current exchange rates from the Anchor API.
-     * Based on SEP-38: /info or /prices depending on the implementation.
-     * Assuming a simplified /rates endpoint for this client.
+     * Retries transient failures (network errors, timeout, 5xx) with exponential backoff.
+     * 4xx responses are returned immediately without retrying.
+     */
+    private async fetchWithRetry(url: string, options: RequestInit = {}): Promise<Response> {
+        let lastError: Error | undefined;
+
+        for (let attempt = 0; attempt < this.maxRetryAttempts; attempt++) {
+            if (attempt > 0) {
+                const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+                await this.sleep(delay);
+            }
+
+            try {
+                const response = await this.fetchWithTimeout(url, options);
+
+                if (response.status >= 400 && response.status < 500) {
+                    return response;
+                }
+
+                if (isTransientHttpStatus(response.status)) {
+                    lastError = new Error(`Server error: HTTP ${response.status}`);
+                    continue;
+                }
+
+                return response;
+            } catch (error) {
+                lastError = error instanceof Error ? error : new Error(String(error));
+            }
+        }
+
+        throw lastError ?? new Error('Anchor request failed after max retry attempts');
+    }
+
+    /**
+     * Fetches the current exchange rates from the Anchor API with retry/backoff.
      */
     async getExchangeRates(): Promise<ExchangeRate[]> {
         if (!this.baseUrl) throw new Error('Anchor Base URL not configured');
@@ -92,14 +133,12 @@ export class AnchorClient {
         const url = `${this.baseUrl}/rates`;
 
         try {
-            const response = await this.fetchWithTimeout(url);
+            const response = await this.fetchWithRetry(url);
 
             if (!response.ok) {
                 throw new Error(`Failed to fetch rates: HTTP ${response.status}`);
             }
 
-            // We expect the anchor to return an array of rates or an object containing an array.
-            // Adjust according to the actual anchor API specification.
             const data = await response.json();
             return data.rates || data;
         } catch (error) {
@@ -109,7 +148,7 @@ export class AnchorClient {
     }
 
     /**
-     * Fetches a quote for a specific pair and amount.
+     * Fetches a quote for a specific pair and amount with retry/backoff.
      */
     async getQuote({ from, to, amount }: QuoteRequest): Promise<QuoteResponse> {
         if (!this.baseUrl) throw new Error('Anchor Base URL not configured');
@@ -120,7 +159,7 @@ export class AnchorClient {
         url.searchParams.append('sell_amount', amount);
 
         try {
-            const response = await this.fetchWithTimeout(url.toString());
+            const response = await this.fetchWithRetry(url.toString());
 
             if (!response.ok) {
                 throw new Error(`Failed to fetch quote: HTTP ${response.status}`);
@@ -172,5 +211,4 @@ export class AnchorClient {
     }
 }
 
-// Export a singleton instance for direct utility usage
 export const anchorClient = new AnchorClient();

--- a/lib/anchor/rates-cache.ts
+++ b/lib/anchor/rates-cache.ts
@@ -1,6 +1,8 @@
 import type { ExchangeRate } from '@/lib/anchor/client';
 import { registerCache } from '@/lib/cache/registry';
 
+export const RATES_CACHE_TTL_MS = 5 * 60 * 1000;
+
 export interface AnchorRatesCacheData {
   rates: ExchangeRate[] | null;
   timestamp: number;
@@ -25,5 +27,17 @@ export function clearAnchorRatesCache(): void {
   rateCache = { ...initialState };
 }
 
-registerCache('anchor_rates', clearAnchorRatesCache);
+export function isCacheFresh(now: number = Date.now()): boolean {
+  return rateCache.rates !== null && now - rateCache.timestamp < RATES_CACHE_TTL_MS;
+}
 
+export function isCacheStale(now: number = Date.now()): boolean {
+  return rateCache.rates !== null && now - rateCache.timestamp >= RATES_CACHE_TTL_MS;
+}
+
+export function getCacheAgeMs(now: number = Date.now()): number | null {
+  if (rateCache.rates === null) return null;
+  return now - rateCache.timestamp;
+}
+
+registerCache('anchor_rates', clearAnchorRatesCache);

--- a/tests/unit/anchor/client.test.ts
+++ b/tests/unit/anchor/client.test.ts
@@ -1,0 +1,406 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+    AnchorClient,
+    DEFAULT_TIMEOUT_MS,
+    MAX_RETRY_ATTEMPTS,
+    RETRY_BASE_DELAY_MS,
+} from '@/lib/anchor/client';
+import {
+    getAnchorRatesCache,
+    setAnchorRatesCache,
+    clearAnchorRatesCache,
+    isCacheFresh,
+    isCacheStale,
+    getCacheAgeMs,
+    RATES_CACHE_TTL_MS,
+} from '@/lib/anchor/rates-cache';
+
+const MOCK_BASE_URL = 'https://anchor.example.com';
+const MOCK_RATES = [
+    { sell_asset: 'USD', buy_asset: 'USDC', price: '1.00' },
+    { sell_asset: 'EUR', buy_asset: 'USDC', price: '1.08' },
+];
+const MOCK_QUOTE = {
+    price: '1.00',
+    sell_amount: '100',
+    buy_amount: '100',
+    fee: { total: '0.50', asset: 'USDC' },
+};
+
+function makeResponse(status: number, body: unknown): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+function makeClient(options?: { maxRetryAttempts?: number }): AnchorClient {
+    process.env.ANCHOR_API_BASE_URL = MOCK_BASE_URL;
+    return new AnchorClient(options);
+}
+
+describe('AnchorClient', () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        process.env.ANCHOR_API_BASE_URL = MOCK_BASE_URL;
+        fetchSpy = vi.spyOn(globalThis, 'fetch');
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+        delete process.env.ANCHOR_API_BASE_URL;
+    });
+
+    describe('isConfigured', () => {
+        it('returns true when base URL is set', () => {
+            expect(makeClient().isConfigured()).toBe(true);
+        });
+
+        it('returns false when base URL is not set', () => {
+            delete process.env.ANCHOR_API_BASE_URL;
+            const client = new AnchorClient();
+            expect(client.isConfigured()).toBe(false);
+        });
+    });
+
+    describe('getExchangeRates — happy path', () => {
+        it('returns rates on 200', async () => {
+            fetchSpy.mockResolvedValueOnce(makeResponse(200, { rates: MOCK_RATES }));
+
+            const result = await makeClient().getExchangeRates();
+
+            expect(result).toEqual(MOCK_RATES);
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('handles bare array response', async () => {
+            fetchSpy.mockResolvedValueOnce(makeResponse(200, MOCK_RATES));
+
+            const result = await makeClient().getExchangeRates();
+
+            expect(result).toEqual(MOCK_RATES);
+        });
+
+        it('throws when base URL is not configured', async () => {
+            delete process.env.ANCHOR_API_BASE_URL;
+            const client = new AnchorClient();
+            await expect(client.getExchangeRates()).rejects.toThrow('Anchor Base URL not configured');
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getExchangeRates — retry on transient errors', () => {
+        it('retries on 500 and succeeds on second attempt', async () => {
+            fetchSpy
+                .mockResolvedValueOnce(makeResponse(500, { error: 'internal' }))
+                .mockResolvedValueOnce(makeResponse(200, { rates: MOCK_RATES }));
+
+            const promise = makeClient({ maxRetryAttempts: 3 }).getExchangeRates();
+            await vi.runAllTimersAsync();
+            const result = await promise;
+
+            expect(result).toEqual(MOCK_RATES);
+            expect(fetchSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it('retries on 502 and 503', async () => {
+            fetchSpy
+                .mockResolvedValueOnce(makeResponse(502, {}))
+                .mockResolvedValueOnce(makeResponse(503, {}))
+                .mockResolvedValueOnce(makeResponse(200, { rates: MOCK_RATES }));
+
+            const promise = makeClient({ maxRetryAttempts: 3 }).getExchangeRates();
+            await vi.runAllTimersAsync();
+            const result = await promise;
+
+            expect(result).toEqual(MOCK_RATES);
+            expect(fetchSpy).toHaveBeenCalledTimes(3);
+        });
+
+        it('retries on network error and succeeds', async () => {
+            fetchSpy
+                .mockRejectedValueOnce(new TypeError('Network failure'))
+                .mockResolvedValueOnce(makeResponse(200, { rates: MOCK_RATES }));
+
+            const promise = makeClient({ maxRetryAttempts: 3 }).getExchangeRates();
+            await vi.runAllTimersAsync();
+            const result = await promise;
+
+            expect(result).toEqual(MOCK_RATES);
+            expect(fetchSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it('retries on timeout and succeeds', async () => {
+            fetchSpy
+                .mockRejectedValueOnce(Object.assign(new Error('Request timed out after 5000ms'), { name: 'AbortError' }))
+                .mockResolvedValueOnce(makeResponse(200, { rates: MOCK_RATES }));
+
+            const promise = makeClient({ maxRetryAttempts: 3 }).getExchangeRates();
+            await vi.runAllTimersAsync();
+            const result = await promise;
+
+            expect(result).toEqual(MOCK_RATES);
+            expect(fetchSpy).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('getExchangeRates — max attempts exhausted', () => {
+        it('throws after exhausting all retry attempts', async () => {
+            fetchSpy.mockResolvedValue(makeResponse(500, { error: 'server error' }));
+
+            const client = makeClient({ maxRetryAttempts: 3 });
+            const promise = client.getExchangeRates();
+            // Attach rejection handler before advancing timers to avoid unhandled-rejection warnings
+            const assertion = expect(promise).rejects.toThrow();
+            await vi.runAllTimersAsync();
+            await assertion;
+            expect(fetchSpy).toHaveBeenCalledTimes(3);
+        });
+
+        it('throws after exhausting retries on repeated network errors', async () => {
+            fetchSpy.mockRejectedValue(new TypeError('Network failure'));
+
+            const client = makeClient({ maxRetryAttempts: 2 });
+            const promise = client.getExchangeRates();
+            const assertion = expect(promise).rejects.toThrow('Network failure');
+            await vi.runAllTimersAsync();
+            await assertion;
+            expect(fetchSpy).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('getExchangeRates — 4xx must not retry', () => {
+        it('does not retry on 400', async () => {
+            fetchSpy.mockResolvedValueOnce(makeResponse(400, { error: 'bad request' }));
+
+            const client = makeClient({ maxRetryAttempts: 3 });
+            await expect(client.getExchangeRates()).rejects.toThrow('HTTP 400');
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not retry on 401', async () => {
+            fetchSpy.mockResolvedValueOnce(makeResponse(401, { error: 'unauthorized' }));
+
+            const client = makeClient({ maxRetryAttempts: 3 });
+            await expect(client.getExchangeRates()).rejects.toThrow('HTTP 401');
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not retry on 404', async () => {
+            fetchSpy.mockResolvedValueOnce(makeResponse(404, { error: 'not found' }));
+
+            const client = makeClient({ maxRetryAttempts: 3 });
+            await expect(client.getExchangeRates()).rejects.toThrow('HTTP 404');
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not retry on 422', async () => {
+            fetchSpy.mockResolvedValueOnce(makeResponse(422, { error: 'unprocessable' }));
+
+            const client = makeClient({ maxRetryAttempts: 3 });
+            await expect(client.getExchangeRates()).rejects.toThrow('HTTP 422');
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('getQuote — retry behaviour', () => {
+        it('returns quote on 200', async () => {
+            fetchSpy.mockResolvedValueOnce(makeResponse(200, MOCK_QUOTE));
+
+            const result = await makeClient().getQuote({ from: 'USD', to: 'USDC', amount: '100' });
+
+            expect(result).toEqual(MOCK_QUOTE);
+        });
+
+        it('retries on 500 and returns quote on retry', async () => {
+            fetchSpy
+                .mockResolvedValueOnce(makeResponse(500, {}))
+                .mockResolvedValueOnce(makeResponse(200, MOCK_QUOTE));
+
+            const promise = makeClient({ maxRetryAttempts: 3 }).getQuote({ from: 'USD', to: 'USDC', amount: '100' });
+            await vi.runAllTimersAsync();
+            const result = await promise;
+
+            expect(result).toEqual(MOCK_QUOTE);
+            expect(fetchSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it('does not retry on 400', async () => {
+            fetchSpy.mockResolvedValueOnce(makeResponse(400, {}));
+
+            const client = makeClient({ maxRetryAttempts: 3 });
+            await expect(client.getQuote({ from: 'USD', to: 'USDC', amount: '100' })).rejects.toThrow('HTTP 400');
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('throws when base URL is not configured', async () => {
+            delete process.env.ANCHOR_API_BASE_URL;
+            const client = new AnchorClient();
+            await expect(client.getQuote({ from: 'USD', to: 'USDC', amount: '100' })).rejects.toThrow('Anchor Base URL not configured');
+        });
+    });
+
+    describe('timeout enforcement', () => {
+        it('enforces DEFAULT_TIMEOUT_MS via AbortController', async () => {
+            fetchSpy.mockImplementationOnce((_url, options) => {
+                const signal = (options as RequestInit).signal as AbortSignal;
+                return new Promise((_resolve, reject) => {
+                    signal?.addEventListener('abort', () => {
+                        reject(Object.assign(new Error('AbortError'), { name: 'AbortError' }));
+                    });
+                });
+            });
+
+            const client = makeClient({ maxRetryAttempts: 1 });
+            const promise = client.getExchangeRates();
+            const assertion = expect(promise).rejects.toThrow(/timed out/i);
+            await vi.advanceTimersByTimeAsync(DEFAULT_TIMEOUT_MS + 100);
+            await assertion;
+        });
+    });
+
+    describe('backoff delay', () => {
+        it('applies exponential backoff between retries', async () => {
+            fetchSpy
+                .mockResolvedValueOnce(makeResponse(500, {}))
+                .mockResolvedValueOnce(makeResponse(500, {}))
+                .mockResolvedValueOnce(makeResponse(200, { rates: MOCK_RATES }));
+
+            const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+            const promise = makeClient({ maxRetryAttempts: 3 }).getExchangeRates();
+            await vi.runAllTimersAsync();
+            await promise;
+
+            const delayCalls = setTimeoutSpy.mock.calls
+                .map(([, delay]) => delay as number)
+                .filter(d => d !== undefined && d === RETRY_BASE_DELAY_MS || d === RETRY_BASE_DELAY_MS * 2);
+
+            expect(delayCalls.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+
+    describe('startDepositFlow / startWithdrawFlow — no retry', () => {
+        it('does not retry deposit flow on 500', async () => {
+            fetchSpy.mockResolvedValueOnce(makeResponse(500, 'internal error'));
+
+            const client = makeClient({ maxRetryAttempts: 3 });
+            await expect(
+                client.startDepositFlow({ amount: '100', currency: 'USD', account: 'G123' })
+            ).rejects.toThrow('Anchor flow failed: HTTP 500');
+
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not retry withdraw flow on 500', async () => {
+            fetchSpy.mockResolvedValueOnce(makeResponse(500, 'error'));
+
+            const client = makeClient({ maxRetryAttempts: 3 });
+            await expect(
+                client.startWithdrawFlow({ amount: '50', currency: 'EUR', account: 'G456' })
+            ).rejects.toThrow('Anchor flow failed: HTTP 500');
+
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('returns flow response on 200', async () => {
+            const flowData = { id: 'tx-1', url: 'https://anchor.example.com/interactive' };
+            fetchSpy.mockResolvedValueOnce(makeResponse(200, flowData));
+
+            const result = await makeClient().startDepositFlow({ amount: '100', currency: 'USD', account: 'G123' });
+            expect(result).toEqual(flowData);
+        });
+    });
+});
+
+describe('AnchorRatesCache', () => {
+    beforeEach(() => {
+        clearAnchorRatesCache();
+    });
+
+    describe('initial state', () => {
+        it('has null rates on init', () => {
+            expect(getAnchorRatesCache().rates).toBeNull();
+        });
+
+        it('isCacheFresh returns false when empty', () => {
+            expect(isCacheFresh()).toBe(false);
+        });
+
+        it('isCacheStale returns false when empty (no data to be stale)', () => {
+            expect(isCacheStale()).toBe(false);
+        });
+
+        it('getCacheAgeMs returns null when empty', () => {
+            expect(getCacheAgeMs()).toBeNull();
+        });
+    });
+
+    describe('setAnchorRatesCache', () => {
+        it('stores rates and timestamp', () => {
+            const now = Date.now();
+            setAnchorRatesCache(MOCK_RATES, now);
+
+            const cached = getAnchorRatesCache();
+            expect(cached.rates).toEqual(MOCK_RATES);
+            expect(cached.timestamp).toBe(now);
+        });
+    });
+
+    describe('freshness helpers', () => {
+        it('isCacheFresh returns true for rates within TTL', () => {
+            const now = Date.now();
+            setAnchorRatesCache(MOCK_RATES, now);
+            expect(isCacheFresh(now + 1000)).toBe(true);
+        });
+
+        it('isCacheFresh returns false for rates past TTL', () => {
+            const now = Date.now();
+            setAnchorRatesCache(MOCK_RATES, now);
+            expect(isCacheFresh(now + RATES_CACHE_TTL_MS + 1)).toBe(false);
+        });
+
+        it('isCacheStale returns true for rates past TTL', () => {
+            const now = Date.now();
+            setAnchorRatesCache(MOCK_RATES, now);
+            expect(isCacheStale(now + RATES_CACHE_TTL_MS + 1)).toBe(true);
+        });
+
+        it('isCacheStale returns false for rates within TTL', () => {
+            const now = Date.now();
+            setAnchorRatesCache(MOCK_RATES, now);
+            expect(isCacheStale(now + 1000)).toBe(false);
+        });
+
+        it('getCacheAgeMs returns elapsed time', () => {
+            const now = Date.now();
+            setAnchorRatesCache(MOCK_RATES, now);
+            expect(getCacheAgeMs(now + 30000)).toBe(30000);
+        });
+    });
+
+    describe('clearAnchorRatesCache', () => {
+        it('resets to initial state', () => {
+            setAnchorRatesCache(MOCK_RATES, Date.now());
+            clearAnchorRatesCache();
+
+            expect(getAnchorRatesCache().rates).toBeNull();
+            expect(isCacheFresh()).toBe(false);
+            expect(getCacheAgeMs()).toBeNull();
+        });
+    });
+
+    describe('cache-hit on total anchor failure', () => {
+        it('stale cache is detectable after anchor fails', () => {
+            const staleTimestamp = Date.now() - RATES_CACHE_TTL_MS - 1000;
+            setAnchorRatesCache(MOCK_RATES, staleTimestamp);
+
+            expect(isCacheFresh()).toBe(false);
+            expect(isCacheStale()).toBe(true);
+            expect(getAnchorRatesCache().rates).toEqual(MOCK_RATES);
+        });
+    });
+});


### PR DESCRIPTION
Enforces AbortController timeout on every anchor fetch via fetchWithTimeout. Adds fetchWithRetry with configurable exponential backoff (default 3 attempts, 200 ms base delay) that retries transient failures (network errors, 5xx, timeout) but returns immediately on 4xx without retrying.

Write flows (deposit/withdraw) intentionally bypass retry since they are not idempotent.

Moves RATES_CACHE_TTL_MS into lib/anchor/rates-cache.ts and adds isCacheFresh, isCacheStale, and getCacheAgeMs helpers so consumers can reason about staleness without duplicating the TTL constant. Updates app/api/anchor/rates/route.ts to use these helpers instead of the inline constant.

Adds 36 Vitest unit tests covering: happy-path fetch, 500-then-200 retry, network-error retry, timeout enforcement via AbortController, max-attempts exhaustion, 4xx no-retry, backoff delay verification, write-flow no-retry, and all cache TTL/staleness helpers.

Closes #468