### PR TITLE
test(cache): cover registry register/clear-all/selective-invalidate f…

### DIFF
--- a/lib/cache/registry.ts
+++ b/lib/cache/registry.ts
@@ -5,35 +5,122 @@ const cacheClearers = new Map<string, CacheClearer>();
 /**
  * Registers a cache clearance function under a unique name.
  * Registered clearers are invoked during bulk cache clearing operations.
- * 
+ *
+ * If a name is already registered, the previous clearer is silently overwritten.
+ * This prevents memory leaks from duplicate registrations while allowing
+ * hot-replacement in development.
+ *
  * @param name - The unique identifier/key of the cache to register.
- * @param clearer - The synchronous or asynchronous function that clears the specific cache.
+ *               Must be a non-empty string.
+ * @param clearer - The synchronous or asynchronous function that clears
+ *                  the specific cache.
+ * @throws {Error} If name is empty or not a string.
+ *
+ * @example
+ * ```typescript
+ * import { registerCache } from '@/lib/cache/registry';
+ * import { clearCache } from '@/lib/cache/contract-cache';
+ *
+ * registerCache('contract_cache', clearCache);
+ * ```
  */
 export function registerCache(name: string, clearer: CacheClearer): void {
+  if (!name || typeof name !== 'string') {
+    throw new Error('Cache name must be a non-empty string');
+  }
+  if (typeof clearer !== 'function') {
+    throw new Error('Cache clearer must be a function');
+  }
   cacheClearers.set(name, clearer);
 }
 
 /**
- * Clears all registered caches sequentially by invoking their registered clearance functions.
- * 
- * @returns A promise that resolves to an array of names of the caches that were cleared.
+ * Clears all registered caches sequentially by invoking their registered
+ * clearance functions.
+ *
+ * Iterates over every entry in the registry and awaits each clearer.
+ * If a clearer throws, the error is caught, logged, and the iteration
+ * continues so that one failing cache does not block others.
+ *
+ * @returns A promise that resolves to an array of names of the caches
+ *          that were successfully cleared.
+ *
+ * @example
+ * ```typescript
+ * const cleared = await clearRegisteredCaches();
+ * console.log('Cleared caches:', cleared);
+ * ```
  */
 export async function clearRegisteredCaches(): Promise<string[]> {
   const cleared: string[] = [];
   for (const [name, clearer] of cacheClearers.entries()) {
-    await clearer();
-    cleared.push(name);
+    try {
+      await clearer();
+      cleared.push(name);
+    } catch (error) {
+      // Log but continue — one failing cache must not block the fan-out
+      console.error(`Cache clearer "${name}" threw during clear-all:`, error);
+    }
   }
   return cleared;
 }
 
 /**
+ * Clears a single registered cache by name.
+ *
+ * This is the selective-invalidate counterpart to {@link clearRegisteredCaches}.
+ * It targets exactly one cache subsystem, leaving all others untouched.
+ *
+ * @param name - The unique identifier of the cache to invalidate.
+ * @returns `true` if the cache was found and its clearer invoked successfully;
+ *          `false` if no cache is registered under that name.
+ * @throws {Error} If the registered clearer throws.
+ *
+ * @example
+ * ```typescript
+ * const ok = await invalidateCache('anchor_rates');
+ * if (!ok) console.warn('No cache named anchor_rates');
+ * ```
+ */
+export async function invalidateCache(name: string): Promise<boolean> {
+  if (!name || typeof name !== 'string') {
+    throw new Error('Cache name must be a non-empty string');
+  }
+  const clearer = cacheClearers.get(name);
+  if (!clearer) {
+    return false;
+  }
+  await clearer();
+  return true;
+}
+
+/**
  * Lists the names of all currently registered caches.
- * 
- * @returns An array of registered cache names.
+ *
+ * @returns An array of registered cache names. The order is insertion order
+ *          (Map iteration order).
+ *
+ * @example
+ * ```typescript
+ * const names = listRegisteredCaches();
+ * // ['contract_cache', 'anchor_rates']
+ * ```
  */
 export function listRegisteredCaches(): string[] {
   return Array.from(cacheClearers.keys());
+}
+
+/**
+ * Resets the registry by removing all registered caches.
+ *
+ * **Intended for testing only.** In production this would break the
+ * admin clear/invalidate fan-out because live caches would no longer
+ * be registered.
+ *
+ * @internal
+ */
+export function resetRegistry(): void {
+  cacheClearers.clear();
 }
 
 

--- a/tests/unit/cache-registry.test.ts
+++ b/tests/unit/cache-registry.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Unit tests for the central cache registry fan-out.
+ *
+ * Covers:
+ * - registerCache: adds caches, validates inputs, handles double-registration
+ * - clearRegisteredCaches: fan-out to all registered clearers, error isolation
+ * - invalidateCache: selective single-cache invalidation, unknown names
+ * - listRegisteredCaches: snapshot of registered names
+ * - resetRegistry: test-only cleanup
+ *
+ * Run: npx vitest run tests/unit/cache-registry.test.ts
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  registerCache,
+  clearRegisteredCaches,
+  invalidateCache,
+  listRegisteredCaches,
+  resetRegistry,
+} from "@/lib/cache/registry";
+
+describe("Cache Registry", () => {
+  beforeEach(() => {
+    resetRegistry();
+  });
+
+  afterEach(() => {
+    resetRegistry();
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // registerCache
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe("registerCache", () => {
+    it("should register a cache clearer under a unique name", () => {
+      const clearer = vi.fn();
+      registerCache("test_cache", clearer);
+
+      expect(listRegisteredCaches()).toContain("test_cache");
+    });
+
+    it("should reject empty name", () => {
+      const clearer = vi.fn();
+      expect(() => registerCache("", clearer)).toThrow("non-empty string");
+    });
+
+    it("should reject non-string name", () => {
+      const clearer = vi.fn();
+      expect(() => registerCache(123 as unknown as string, clearer)).toThrow(
+        "non-empty string"
+      );
+    });
+
+    it("should reject non-function clearer", () => {
+      expect(() => registerCache("bad", "not-a-function" as unknown as () => void)).toThrow(
+        "must be a function"
+      );
+    });
+
+    it("should overwrite on double-registration (no memory leak)", () => {
+      const clearer1 = vi.fn();
+      const clearer2 = vi.fn();
+
+      registerCache("dup", clearer1);
+      registerCache("dup", clearer2);
+
+      expect(listRegisteredCaches()).toEqual(["dup"]);
+      expect(listRegisteredCaches()).toHaveLength(1);
+    });
+
+    it("should call the most recent clearer after double-registration", async () => {
+      const clearer1 = vi.fn();
+      const clearer2 = vi.fn();
+
+      registerCache("dup", clearer1);
+      registerCache("dup", clearer2);
+
+      await clearRegisteredCaches();
+
+      expect(clearer1).not.toHaveBeenCalled();
+      expect(clearer2).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // clearRegisteredCaches (fan-out)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe("clearRegisteredCaches", () => {
+    it("should return empty array when no caches are registered", async () => {
+      const cleared = await clearRegisteredCaches();
+      expect(cleared).toEqual([]);
+    });
+
+    it("should invoke every registered cache clearer (fan-out)", async () => {
+      const contractClear = vi.fn();
+      const ratesClear = vi.fn();
+      const billClear = vi.fn();
+
+      registerCache("contract_cache", contractClear);
+      registerCache("anchor_rates", ratesClear);
+      registerCache("bill_cache", billClear);
+
+      const cleared = await clearRegisteredCaches();
+
+      expect(contractClear).toHaveBeenCalledTimes(1);
+      expect(ratesClear).toHaveBeenCalledTimes(1);
+      expect(billClear).toHaveBeenCalledTimes(1);
+      expect(cleared).toEqual(["contract_cache", "anchor_rates", "bill_cache"]);
+    });
+
+    it("should await async clearers", async () => {
+      let resolved = false;
+      const asyncClear = vi.fn(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+        resolved = true;
+      });
+
+      registerCache("async_cache", asyncClear);
+      await clearRegisteredCaches();
+
+      expect(resolved).toBe(true);
+      expect(asyncClear).toHaveBeenCalledTimes(1);
+    });
+
+    it("should continue fan-out when one clearer throws (error isolation)", async () => {
+      const goodClear = vi.fn();
+      const badClear = vi.fn(() => {
+        throw new Error("Cache clear failed");
+      });
+      const anotherGood = vi.fn();
+
+      registerCache("good", goodClear);
+      registerCache("bad", badClear);
+      registerCache("another_good", anotherGood);
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const cleared = await clearRegisteredCaches();
+      consoleSpy.mockRestore();
+
+      expect(goodClear).toHaveBeenCalledTimes(1);
+      expect(badClear).toHaveBeenCalledTimes(1);
+      expect(anotherGood).toHaveBeenCalledTimes(1);
+      // Only successful clears are returned
+      expect(cleared).toEqual(["good", "another_good"]);
+    });
+
+    it("should log errors for failed clearers", async () => {
+      const badClear = vi.fn(() => {
+        throw new Error("Boom");
+      });
+      registerCache("explodes", badClear);
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      await clearRegisteredCaches();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("explodes"),
+        expect.any(Error)
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("should be idempotent (clearing twice yields same result)", async () => {
+      const clear = vi.fn();
+      registerCache("idempotent", clear);
+
+      const first = await clearRegisteredCaches();
+      const second = await clearRegisteredCaches();
+
+      expect(clear).toHaveBeenCalledTimes(2);
+      expect(first).toEqual(second);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // invalidateCache (selective)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe("invalidateCache", () => {
+    it("should clear only the named cache", async () => {
+      const targetClear = vi.fn();
+      const otherClear = vi.fn();
+
+      registerCache("target", targetClear);
+      registerCache("other", otherClear);
+
+      const ok = await invalidateCache("target");
+
+      expect(ok).toBe(true);
+      expect(targetClear).toHaveBeenCalledTimes(1);
+      expect(otherClear).not.toHaveBeenCalled();
+    });
+
+    it("should return false for unknown cache name", async () => {
+      const ok = await invalidateCache("nonexistent");
+      expect(ok).toBe(false);
+    });
+
+    it("should reject empty name", async () => {
+      await expect(invalidateCache("")).rejects.toThrow("non-empty string");
+    });
+
+    it("should reject non-string name", async () => {
+      await expect(invalidateCache(123 as unknown as string)).rejects.toThrow(
+        "non-empty string"
+      );
+    });
+
+    it("should propagate clearer errors (unlike clear-all)", async () => {
+      const badClear = vi.fn(() => {
+        throw new Error("Selective clear failed");
+      });
+      registerCache("bad_selective", badClear);
+
+      await expect(invalidateCache("bad_selective")).rejects.toThrow(
+        "Selective clear failed"
+      );
+    });
+
+    it("should await async selective clearer", async () => {
+      let resolved = false;
+      const asyncClear = vi.fn(async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        resolved = true;
+      });
+
+      registerCache("selective_async", asyncClear);
+      const ok = await invalidateCache("selective_async");
+
+      expect(ok).toBe(true);
+      expect(resolved).toBe(true);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // listRegisteredCaches
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe("listRegisteredCaches", () => {
+    it("should return empty array when no caches registered", () => {
+      expect(listRegisteredCaches()).toEqual([]);
+    });
+
+    it("should return names in insertion order", () => {
+      registerCache("first", vi.fn());
+      registerCache("second", vi.fn());
+      registerCache("third", vi.fn());
+
+      expect(listRegisteredCaches()).toEqual(["first", "second", "third"]);
+    });
+
+    it("should reflect the latest state after double-registration", () => {
+      registerCache("a", vi.fn());
+      registerCache("b", vi.fn());
+      registerCache("a", vi.fn()); // overwrite
+
+      expect(listRegisteredCaches()).toEqual(["a", "b"]);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // resetRegistry (test-only)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe("resetRegistry", () => {
+    it("should remove all registered caches", () => {
+      registerCache("one", vi.fn());
+      registerCache("two", vi.fn());
+
+      resetRegistry();
+
+      expect(listRegisteredCaches()).toEqual([]);
+    });
+
+    it("should make clearRegisteredCaches return empty after reset", async () => {
+      registerCache("gone", vi.fn());
+      resetRegistry();
+
+      const cleared = await clearRegisteredCaches();
+      expect(cleared).toEqual([]);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Integration: admin route fan-out simulation
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe("admin clear route fan-out (simulated)", () => {
+    it("should trigger all registered caches when admin route calls clearRegisteredCaches", async () => {
+      // Simulate the caches that real subsystems would register
+      const contractCacheClear = vi.fn();
+      const ratesCacheClear = vi.fn();
+      const billCacheClear = vi.fn();
+
+      // These mirror the real registrations in the codebase:
+      // lib/cache/contract-cache.ts → registerCache('contract_cache', clearCache)
+      // lib/anchor/rates-cache.ts   → registerCache('anchor_rates', clearAnchorRatesCache)
+      registerCache("contract_cache", contractCacheClear);
+      registerCache("anchor_rates", ratesCacheClear);
+      registerCache("bill_cache", billCacheClear);
+
+      // Simulate what app/api/admin/cache/clear/route.ts does
+      const cleared = await clearRegisteredCaches();
+
+      expect(cleared).toHaveLength(3);
+      expect(cleared).toContain("contract_cache");
+      expect(cleared).toContain("anchor_rates");
+      expect(cleared).toContain("bill_cache");
+
+      expect(contractCacheClear).toHaveBeenCalledTimes(1);
+      expect(ratesCacheClear).toHaveBeenCalledTimes(1);
+      expect(billCacheClear).toHaveBeenCalledTimes(1);
+    });
+
+    it("should allow selective invalidation via admin route", async () => {
+      const contractClear = vi.fn();
+      const ratesClear = vi.fn();
+
+      registerCache("contract_cache", contractClear);
+      registerCache("anchor_rates", ratesClear);
+
+      // Simulate selective invalidation (e.g., after rates update)
+      const ok = await invalidateCache("anchor_rates");
+
+      expect(ok).toBe(true);
+      expect(ratesClear).toHaveBeenCalledTimes(1);
+      expect(contractClear).not.toHaveBeenCalled();
+    });
+
+    it("should handle a real-world failure scenario gracefully", async () => {
+      // Simulate: contract cache is healthy, rates cache is broken
+      const contractClear = vi.fn();
+      const ratesClear = vi.fn(() => {
+        throw new Error("Redis connection lost");
+      });
+
+      registerCache("contract_cache", contractClear);
+      registerCache("anchor_rates", ratesClear);
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const cleared = await clearRegisteredCaches();
+      consoleSpy.mockRestore();
+
+      // contract_cache still clears despite rates_cache failing
+      expect(contractClear).toHaveBeenCalledTimes(1);
+      expect(cleared).toEqual(["contract_cache"]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #530 

## Summary
The central cache registry (lib/cache/registry.ts) is the backbone of the admin cache-clear fan-out. Subsystems like contract-cache and rates-cache register their clearers so app/api/admin/cache/clear/route.ts can wipe everything with one call. Until now, the registry itself was untested — a silent failure in the fan-out would mean an admin "clear cache" does nothing for that subsystem.
This PR:
1. Hardens the registry with input validation, error isolation, and a new invalidateCache(name) selective-invalidate API.
2. Adds comprehensive unit tests covering fan-out, selective invalidation, edge cases, and admin-route simulation.
3. Documents the registry contract with TSDoc.

## Changes
Modified Files
| File                                | Change                                                                                                                                                                                                |
| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `lib/cache/registry.ts`             | Added `invalidateCache()` for selective invalidation; added input validation; added error isolation in `clearRegisteredCaches()`; added `resetRegistry()` for testability; added TSDoc on all exports |
| `tests/unit/cache-registry.test.ts` | **New** — 25+ test cases covering register, clear-all, selective invalidate, list, reset, and admin-route fan-out simulation                                                                          |

## Registry API
registerCache(name, clearer)     // Register a cache (overwrites on dup)
clearRegisteredCaches()          // Fan-out: clear ALL registered caches
invalidateCache(name)              // Selective: clear ONE named cache
listRegisteredCaches()             // List all registered names
resetRegistry()                    // Test-only: wipe registry state


## Test Coverage
| Category                   | Cases | Key Behaviors                                                                                                                                              |
| -------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **registerCache**          | 6     | Valid registration, empty name, non-string name, non-function clearer, double-registration overwrite, double-reg calls latest                              |
| **clearRegisteredCaches**  | 6     | Empty registry, fan-out to 3 caches, awaits async clearers, error isolation (one fail doesn't block others), error logging, idempotency                    |
| **invalidateCache**        | 6     | Selective single cache, unknown name returns `false`, empty name rejected, non-string rejected, propagates errors (unlike clear-all), awaits async clearer |
| **listRegisteredCaches**   | 3     | Empty, insertion order, reflects overwrites                                                                                                                |
| **resetRegistry**          | 2     | Removes all, makes clear-all return empty                                                                                                                  |
| **Admin route simulation** | 3     | Full fan-out with 3 mock caches, selective invalidation, graceful degradation when one cache fails                                                         |
Total: 26 test cases, ≥95% branch coverage.

## Edge Cases Handled
| Edge Case                             | Behavior                                   |
| ------------------------------------- | ------------------------------------------ |
| Empty registry clear-all              | Returns `[]`, no errors                    |
| Unknown name selective invalidate     | Returns `false`, no throw                  |
| Double-register same name             | Silently overwrites (prevents memory leak) |
| One cache throws during clear-all     | Caught, logged, others still clear         |
| Async clearer                         | Properly awaited before returning          |
| Selective vs clear-all error handling | Selective propagates; clear-all isolates   |


## Bug Found & Fixed
Before: clearRegisteredCaches() did not catch errors from individual clearers. If one cache subsystem threw (e.g., Redis connection lost), the entire fan-out would fail and remaining caches would stay stale.

After: Each clearer is wrapped in try/catch. Failures are logged to console.error and the iteration continues. The returned array only includes successfully cleared caches, giving the admin route visibility into partial failures.

## Validation
npm run lint          # ✅
npx tsc --noEmit      # ✅
npm run test:coverage # ✅  (registry at ≥95% branches)
npm run build         # ✅