### PR TITLE
ci: make lint test and e2e gates enforcing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# CI: lint + unit tests + optional integration tests.
+# CI: enforcing lint, unit tests, integration tests, typecheck, and build.
 # Runs on push/PR to main and dev. Loads .env.test when present; TEST_* can also come from GitHub Secrets.
 name: CI
 
@@ -13,7 +13,7 @@ env:
 
 jobs:
   lint-and-test:
-    name: Lint and test
+    name: Lint, test, typecheck, and build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,8 +26,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci || true
-        continue-on-error: true
+        run: npm ci
 
       - name: Load .env.test
         run: |
@@ -39,21 +38,25 @@ jobs:
               echo "${name}=${value}" >> "$GITHUB_ENV"
             done < .env.test
           fi
-        shell: bash || true
-        continue-on-error: true
+        shell: bash
 
       - name: Run lint
-        run: npm run lint || true
-        continue-on-error: true
+        run: npm run lint
 
       - name: Run unit tests
-        run: npm run test || true
-        continue-on-error: true
+        run: npm run test
 
       - name: Run integration tests
-        run: npm run test:integration || true
-        continue-on-error: true
+        run: npm run test:integration
         env:
           # Optional: set in GitHub Secrets to override or supply when .env.test is not committed
-          TEST_SOROBAN_RPC_URL: ${{ secrets.TEST_SOROBAN_RPC_URL }}
-          TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+          TEST_SOROBAN_RPC_URL: $
+{{ secrets.TEST_SOROBAN_RPC_URL }}
+          TEST_DATABASE_URL: $
+{{ secrets.TEST_DATABASE_URL }}
+
+      - name: Run typecheck
+        run: npx tsc --noEmit
+
+      - name: Run build
+        run: npm run build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,6 @@ jobs:
     env:
       TEST_WALLET_ADDRESS: "GDEMOXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
       TEST_SIGNATURE: "mock-signature"
-      # --- ADDED MOCK ENV VARS FOR CI ---
       SESSION_PASSWORD: "dummy-test-session-password-must-be-32-chars"
       SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org"
       SOROBAN_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
@@ -32,20 +31,16 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: npm ci || true
-        continue-on-error: true
+        run: npm ci
 
       - name: Run Unit Tests
-        run: npm run test || true
-        continue-on-error: true
+        run: npm run test
 
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium || true
-        continue-on-error: true
+        run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        run: npm run test:e2e || true
-        continue-on-error: true
+        run: npm run test:e2e
 
       - name: Upload test results
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,10 +123,11 @@ npm run test:e2e   # Playwright — requires the dev server to be running
 2. **One concern per PR** — keep scope tight; large PRs stall in review.
 3. **Lint must pass** — run `npm run lint` locally before pushing. CI will reject lint failures.
 4. **Build must pass** — run `npm run build` to catch TypeScript errors early.
-5. **Tests** — add or update tests that cover your change. Prefer the existing runner for the file type (`.cjs` → node:test, `.ts` → Vitest).
-6. **PR description** — summarise what changed and why. Link the issue (`Closes #NNN`).
-7. **No commented-out code** — remove dead code rather than commenting it out.
-8. **i18n** — any user-visible string must use the i18n system (see [Adding an i18n Key](#adding-an-i18n-key)).
+5. **Tests** — add or update tests that cover your change. Prefer the existing runner for the file type (`.cjs` -> node:test, `.ts` -> Vitest).
+6. **CI gate** — CI is enforcing: install, lint, unit, integration, typecheck, build, and Playwright failures must fail GitHub Actions. Keep Playwright report upload on `if: always()` for debugging artifacts, but do not mask failed commands with `continue-on-error` or `|| true` unless the step is explicitly optional and documented.
+7. **PR description** — summarise what changed and why. Link the issue (`Closes #NNN`).
+8. **No commented-out code** — remove dead code rather than commenting it out.
+9. **i18n** — any user-visible string must use the i18n system (see [Adding an i18n Key](#adding-an-i18n-key)).
 
 Example commit message style used in this repo:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -225,24 +225,14 @@ not just the headline percentage.
 
 ## The CI gate
 
-Before opening a PR, run the same checks CI runs (see
-[.github/workflows/ci.yml](../.github/workflows/ci.yml) and
-[.github/workflows/e2e.yml](../.github/workflows/e2e.yml)):
+The GitHub Actions workflows are enforcing gates: `npm ci`, lint, unit tests,
+integration tests, `npx tsc --noEmit`, `npm run build`, and Playwright e2e should fail
+the job when they fail. Do not add blanket `continue-on-error` to install, lint, test,
+typecheck, build, or e2e steps. If a genuinely optional diagnostic step is added later,
+limit `continue-on-error` to that single step and explain why in a YAML comment.
 
-```bash
-npm run lint            # ESLint must pass
-npx tsc --noEmit        # type-check (npm run build runs this as part of next build)
-npm run test            # unit suites
-npm run test:integration# integration suites (needs DATABASE_URL)
-npm run test:e2e        # Playwright (CI installs chromium first)
-```
-
-For local development the fast loop is `npm run lint && npx tsc --noEmit && npm run test`;
-run `npm run test:coverage`, `test:integration`, and `test:e2e` before pushing anything
-that touches API routes, validation, or user flows.
-
----
-
+Playwright report upload is the exception: it keeps `if: always()` so failed e2e runs
+still publish artifacts for debugging, but it does not hide the failed test step.
 ## How to add a test
 
 A minimal recipe per runner. Copy the matching existing example, then adapt.


### PR DESCRIPTION
Closes #574.

## Summary
- Removes blanket `continue-on-error` and `|| true` masking from CI install/lint/test steps.
- Adds enforcing `npx tsc --noEmit` and `npm run build` steps to the CI workflow.
- Makes the Playwright workflow fail on install/unit/browser/e2e failures while keeping artifact upload on `if: always()`.
- Documents the enforcing CI gate expectations in testing/contributor docs.

## Validation
- Static review of `.github/workflows/ci.yml`, `.github/workflows/e2e.yml`, `docs/testing.md`, and `CONTRIBUTING.md`.
- GitHub compare confirms only the intended workflow/docs files changed.