### PR TITLE
refactor(remittance): centralize recurring store and test ownership rules

### DIFF
--- a/app/api/remittance/recurring/[id]/route.ts
+++ b/app/api/remittance/recurring/[id]/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { updateRecurringRemittance, deleteRecurringRemittance } from '@/lib/mockdata/recurringRemittances';
+import { recurringStore } from '@/lib/remittance/recurring-store';
 import { requireAuth } from '@/lib/session';
-import { StrKey } from '@stellar/stellar-sdk';
 
 // PATCH /api/remittance/recurring/[id]
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -13,24 +12,22 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     if (res instanceof Response) return res;
     throw res;
   }
-  const updates = await req.json();
-  // Validate recipientAddress if present
-  if (updates.recipientAddress && !StrKey.isValidEd25519PublicKey(updates.recipientAddress)) {
-    return NextResponse.json({ error: 'Invalid recipientAddress' }, { status: 400 });
+
+  const existing = await recurringStore.get(id);
+  if (!existing) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
-  if (updates.amount && (typeof updates.amount !== 'number' || updates.amount <= 0)) {
-    return NextResponse.json({ error: 'Invalid amount' }, { status: 400 });
+  if (existing.userAddress !== auth.address) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
-  if (updates.currency && typeof updates.currency !== 'string') {
-    return NextResponse.json({ error: 'Invalid currency' }, { status: 400 });
+
+  try {
+    const updates = await req.json();
+    const updated = await recurringStore.update(id, updates);
+    return NextResponse.json(updated);
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || 'Invalid request input' }, { status: 400 });
   }
-  if (updates.frequency && !['weekly','biweekly','monthly'].includes(updates.frequency)) {
-    return NextResponse.json({ error: 'Invalid frequency' }, { status: 400 });
-  }
-  // Only allow update if schedule belongs to user
-  const updated = updateRecurringRemittance(id, updates);
-  if (!updated || updated.userAddress !== auth.address) return NextResponse.json({ error: 'Not found or forbidden' }, { status: 404 });
-  return NextResponse.json(updated);
 }
 
 // DELETE /api/remittance/recurring/[id]
@@ -43,10 +40,18 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
     if (res instanceof Response) return res;
     throw res;
   }
-  // Only allow delete if schedule belongs to user
-  const updated = updateRecurringRemittance(id, {});
-  if (!updated || updated.userAddress !== auth.address) return NextResponse.json({ error: 'Not found or forbidden' }, { status: 404 });
-  const deleted = deleteRecurringRemittance(id);
-  if (!deleted) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  const existing = await recurringStore.get(id);
+  if (!existing) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  if (existing.userAddress !== auth.address) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const deleted = await recurringStore.delete(id);
+  if (!deleted) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
   return NextResponse.json({ success: true });
 }

--- a/app/api/remittance/recurring/route.ts
+++ b/app/api/remittance/recurring/route.ts
@@ -1,10 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import {
-  createRecurringRemittance,
-  getRecurringRemittances,
-} from '@/lib/mockdata/recurringRemittances';
+import { recurringStore } from '@/lib/remittance/recurring-store';
 import { requireAuth } from '@/lib/session';
-import { StrKey } from '@stellar/stellar-sdk';
 
 // POST /api/remittance/recurring
 export async function POST(req: NextRequest) {
@@ -15,22 +11,35 @@ export async function POST(req: NextRequest) {
     if (res instanceof Response) return res;
     throw res;
   }
-  const { recipientAddress, amount, currency, frequency } = await req.json();
-  // Validation
-  if (!recipientAddress || !StrKey.isValidEd25519PublicKey(recipientAddress)) {
-    return NextResponse.json({ error: 'Invalid recipientAddress' }, { status: 400 });
+
+  try {
+    const { recipientAddress, amount, currency, frequency } = await req.json();
+
+    // Check presence of required parameters
+    if (!recipientAddress) {
+      return NextResponse.json({ error: 'Invalid recipientAddress' }, { status: 400 });
+    }
+    if (amount === undefined) {
+      return NextResponse.json({ error: 'Invalid amount' }, { status: 400 });
+    }
+    if (!currency) {
+      return NextResponse.json({ error: 'Invalid currency' }, { status: 400 });
+    }
+    if (!frequency) {
+      return NextResponse.json({ error: 'Invalid frequency' }, { status: 400 });
+    }
+
+    const remittance = await recurringStore.create({
+      userAddress: auth.address,
+      recipientAddress,
+      amount,
+      currency,
+      frequency,
+    });
+    return NextResponse.json(remittance);
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || 'Invalid request input' }, { status: 400 });
   }
-  if (typeof amount !== 'number' || amount <= 0) {
-    return NextResponse.json({ error: 'Invalid amount' }, { status: 400 });
-  }
-  if (!currency || typeof currency !== 'string') {
-    return NextResponse.json({ error: 'Invalid currency' }, { status: 400 });
-  }
-  if (!['weekly','biweekly','monthly'].includes(frequency)) {
-    return NextResponse.json({ error: 'Invalid frequency' }, { status: 400 });
-  }
-  const remittance = createRecurringRemittance({ userAddress: auth.address, recipientAddress, amount, currency, frequency });
-  return NextResponse.json(remittance);
 }
 
 // GET /api/remittance/recurring
@@ -42,6 +51,6 @@ export async function GET(req: NextRequest) {
     if (res instanceof Response) return res;
     throw res;
   }
-  const remittances = getRecurringRemittances(auth.address);
+  const remittances = await recurringStore.list(auth.address);
   return NextResponse.json(remittances);
 }

--- a/lib/remittance/recurring-store.ts
+++ b/lib/remittance/recurring-store.ts
@@ -1,0 +1,147 @@
+import { RecurringRemittance } from '@/utils/types/recurringRemittance.types';
+import { StrKey } from '@stellar/stellar-sdk';
+
+/**
+ * Interface representing a database-swap-ready contract for recurring remittance schedules.
+ */
+export interface IRecurringRemittanceStore {
+  create(data: {
+    userAddress: string;
+    recipientAddress: string;
+    amount: number;
+    currency: string;
+    frequency: 'weekly' | 'biweekly' | 'monthly';
+  }): Promise<RecurringRemittance>;
+
+  list(userAddress: string): Promise<RecurringRemittance[]>;
+
+  get(id: string): Promise<RecurringRemittance | null>;
+
+  update(
+    id: string,
+    updates: {
+      recipientAddress?: string;
+      amount?: number;
+      currency?: string;
+      frequency?: 'weekly' | 'biweekly' | 'monthly';
+    }
+  ): Promise<RecurringRemittance | null>;
+
+  delete(id: string): Promise<boolean>;
+
+  clear(): Promise<void>;
+}
+
+/**
+ * Centralized input validation for recurring remittance schedules.
+ */
+export function validateRecurringRemittanceInput(data: {
+  recipientAddress?: string;
+  amount?: number;
+  currency?: string;
+  frequency?: string;
+}) {
+  if (data.recipientAddress !== undefined && !StrKey.isValidEd25519PublicKey(data.recipientAddress)) {
+    throw new Error('Invalid recipientAddress');
+  }
+  if (data.amount !== undefined && (typeof data.amount !== 'number' || data.amount <= 0)) {
+    throw new Error('Invalid amount');
+  }
+  if (data.currency !== undefined && (!data.currency || typeof data.currency !== 'string')) {
+    throw new Error('Invalid currency');
+  }
+  if (data.frequency !== undefined && !['weekly', 'biweekly', 'monthly'].includes(data.frequency)) {
+    throw new Error('Invalid frequency');
+  }
+}
+
+function computeNextRunAt(from: Date, frequency: 'weekly' | 'biweekly' | 'monthly'): Date {
+  const next = new Date(from);
+  if (frequency === 'weekly') next.setDate(next.getDate() + 7);
+  else if (frequency === 'biweekly') next.setDate(next.getDate() + 14);
+  else if (frequency === 'monthly') next.setMonth(next.getMonth() + 1);
+  return next;
+}
+
+/**
+ * In-memory implementation of the recurring remittance store.
+ * Marked clearly as in-memory to differentiate from future persistent databases.
+ */
+export class InMemoryRecurringRemittanceStore implements IRecurringRemittanceStore {
+  private schedules: RecurringRemittance[] = [];
+
+  async create(data: {
+    userAddress: string;
+    recipientAddress: string;
+    amount: number;
+    currency: string;
+    frequency: 'weekly' | 'biweekly' | 'monthly';
+  }): Promise<RecurringRemittance> {
+    validateRecurringRemittanceInput(data);
+
+    const id = crypto.randomUUID();
+    const createdAt = new Date();
+    const nextRunAt = computeNextRunAt(createdAt, data.frequency);
+
+    const schedule: RecurringRemittance = {
+      ...data,
+      id,
+      createdAt,
+      nextRunAt,
+    };
+
+    this.schedules.push(schedule);
+    return schedule;
+  }
+
+  async list(userAddress: string): Promise<RecurringRemittance[]> {
+    return this.schedules.filter(s => s.userAddress === userAddress);
+  }
+
+  async get(id: string): Promise<RecurringRemittance | null> {
+    const found = this.schedules.find(s => s.id === id);
+    return found ? { ...found } : null;
+  }
+
+  async update(
+    id: string,
+    updates: {
+      recipientAddress?: string;
+      amount?: number;
+      currency?: string;
+      frequency?: 'weekly' | 'biweekly' | 'monthly';
+    }
+  ): Promise<RecurringRemittance | null> {
+    validateRecurringRemittanceInput(updates);
+
+    const idx = this.schedules.findIndex(s => s.id === id);
+    if (idx === -1) return null;
+
+    const updated = {
+      ...this.schedules[idx],
+      ...updates,
+    };
+
+    if (updates.frequency) {
+      updated.nextRunAt = computeNextRunAt(new Date(), updates.frequency);
+    }
+
+    this.schedules[idx] = updated;
+    return { ...updated };
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const idx = this.schedules.findIndex(s => s.id === id);
+    if (idx === -1) return false;
+
+    this.schedules.splice(idx, 1);
+    return true;
+  }
+
+  async clear(): Promise<void> {
+    this.schedules = [];
+  }
+}
+
+// Export a single canonical store instance
+export const recurringStore: IRecurringRemittanceStore = new InMemoryRecurringRemittanceStore();

--- a/tests/integration/api/recurring.test.ts
+++ b/tests/integration/api/recurring.test.ts
@@ -1,0 +1,384 @@
+import { vi, expect, describe, it, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { cookies as cookiesImport } from 'next/headers';
+import { POST, GET } from '@/app/api/remittance/recurring/route';
+import { PATCH, DELETE } from '@/app/api/remittance/recurring/[id]/route';
+import { recurringStore } from '@/lib/remittance/recurring-store';
+import { createSession } from '@/lib/session';
+
+// Mock Next.js cookies
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}));
+
+const cookies = vi.mocked(cookiesImport) as any;
+
+describe('Recurring Remittance API Integration Tests', () => {
+  const userA = 'GBKX7K254X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X';
+  const userB = 'GB2K7K254X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4X4Y';
+  const recipient = 'GAJSJLYXJQ3RNEKUXNPHFGLB645U2E762UNIP454EXJCD2WUYP3G6Y45';
+
+  let sessionA: string;
+  let sessionB: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.SESSION_PASSWORD = 'test-password-at-least-32-characters-long';
+    process.env.SESSION_MAX_AGE = '604800'; // 7 days
+
+    await recurringStore.clear();
+
+    sessionA = await createSession(userA);
+    sessionB = await createSession(userB);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Unauthenticated Requests (401)', () => {
+    beforeEach(() => {
+      // Simulate no session cookie
+      cookies.mockResolvedValue({
+        get: vi.fn().mockReturnValue(undefined),
+      });
+    });
+
+    it('POST /api/remittance/recurring should return 401', async () => {
+      const req = new NextRequest('http://localhost/api/remittance/recurring', {
+        method: 'POST',
+        body: JSON.stringify({
+          recipientAddress: recipient,
+          amount: 100,
+          currency: 'USD',
+          frequency: 'weekly',
+        }),
+      });
+
+      const response = await POST(req);
+      expect(response.status).toBe(401);
+    });
+
+    it('GET /api/remittance/recurring should return 401', async () => {
+      const req = new NextRequest('http://localhost/api/remittance/recurring', {
+        method: 'GET',
+      });
+
+      const response = await GET(req);
+      expect(response.status).toBe(401);
+    });
+
+    it('PATCH /api/remittance/recurring/[id] should return 401', async () => {
+      const req = new NextRequest('http://localhost/api/remittance/recurring/some-id', {
+        method: 'PATCH',
+        body: JSON.stringify({ amount: 150 }),
+      });
+
+      const response = await PATCH(req, { params: Promise.resolve({ id: 'some-id' }) });
+      expect(response.status).toBe(401);
+    });
+
+    it('DELETE /api/remittance/recurring/[id] should return 401', async () => {
+      const req = new NextRequest('http://localhost/api/remittance/recurring/some-id', {
+        method: 'DELETE',
+      });
+
+      const response = await DELETE(req, { params: Promise.resolve({ id: 'some-id' }) });
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('Authenticated Operations', () => {
+    const mockCookieStore = (sessionToken: string) => {
+      cookies.mockResolvedValue({
+        get: vi.fn().mockImplementation((name) => {
+          if (name === 'remitwise_session') {
+            return { value: sessionToken };
+          }
+          return undefined;
+        }),
+      });
+    };
+
+    describe('Creation (POST) and Validation (400)', () => {
+      beforeEach(() => {
+        mockCookieStore(sessionA);
+      });
+
+      it('should create a valid recurring remittance schedule', async () => {
+        const req = new NextRequest('http://localhost/api/remittance/recurring', {
+          method: 'POST',
+          body: JSON.stringify({
+            recipientAddress: recipient,
+            amount: 100,
+            currency: 'USD',
+            frequency: 'weekly',
+          }),
+        });
+
+        const response = await POST(req);
+        expect(response.status).toBe(200);
+
+        const data = await response.json();
+        expect(data.id).toBeDefined();
+        expect(data.userAddress).toBe(userA);
+        expect(data.recipientAddress).toBe(recipient);
+        expect(data.amount).toBe(100);
+        expect(data.currency).toBe('USD');
+        expect(data.frequency).toBe('weekly');
+      });
+
+      it('should return 400 for invalid recipient address format', async () => {
+        const req = new NextRequest('http://localhost/api/remittance/recurring', {
+          method: 'POST',
+          body: JSON.stringify({
+            recipientAddress: 'invalid-address',
+            amount: 100,
+            currency: 'USD',
+            frequency: 'weekly',
+          }),
+        });
+
+        const response = await POST(req);
+        expect(response.status).toBe(400);
+      });
+
+      it('should return 400 for negative/zero amount', async () => {
+        const req = new NextRequest('http://localhost/api/remittance/recurring', {
+          method: 'POST',
+          body: JSON.stringify({
+            recipientAddress: recipient,
+            amount: 0,
+            currency: 'USD',
+            frequency: 'weekly',
+          }),
+        });
+
+        const response = await POST(req);
+        expect(response.status).toBe(400);
+      });
+
+      it('should return 400 for invalid frequency', async () => {
+        const req = new NextRequest('http://localhost/api/remittance/recurring', {
+          method: 'POST',
+          body: JSON.stringify({
+            recipientAddress: recipient,
+            amount: 100,
+            currency: 'USD',
+            frequency: 'yearly',
+          }),
+        });
+
+        const response = await POST(req);
+        expect(response.status).toBe(400);
+      });
+
+      it('should return 400 for missing fields', async () => {
+        const req = new NextRequest('http://localhost/api/remittance/recurring', {
+          method: 'POST',
+          body: JSON.stringify({
+            recipientAddress: recipient,
+            amount: 100,
+          }),
+        });
+
+        const response = await POST(req);
+        expect(response.status).toBe(400);
+      });
+    });
+
+    describe('Listing (GET)', () => {
+      it('should return only the schedules belonging to the caller', async () => {
+        // Create schedule for User A
+        mockCookieStore(sessionA);
+        const reqCreateA = new NextRequest('http://localhost/api/remittance/recurring', {
+          method: 'POST',
+          body: JSON.stringify({
+            recipientAddress: recipient,
+            amount: 50,
+            currency: 'XLM',
+            frequency: 'monthly',
+          }),
+        });
+        await POST(reqCreateA);
+
+        // Create schedule for User B
+        mockCookieStore(sessionB);
+        const reqCreateB = new NextRequest('http://localhost/api/remittance/recurring', {
+          method: 'POST',
+          body: JSON.stringify({
+            recipientAddress: recipient,
+            amount: 75,
+            currency: 'USDC',
+            frequency: 'biweekly',
+          }),
+        });
+        await POST(reqCreateB);
+
+        // User A lists schedules
+        mockCookieStore(sessionA);
+        const reqListA = new NextRequest('http://localhost/api/remittance/recurring', {
+          method: 'GET',
+        });
+        const resListA = await GET(reqListA);
+        expect(resListA.status).toBe(200);
+        const dataA = await resListA.json();
+        expect(dataA.length).toBe(1);
+        expect(dataA[0].userAddress).toBe(userA);
+        expect(dataA[0].amount).toBe(50);
+
+        // User B lists schedules
+        mockCookieStore(sessionB);
+        const reqListB = new NextRequest('http://localhost/api/remittance/recurring', {
+          method: 'GET',
+        });
+        const resListB = await GET(reqListB);
+        expect(resListB.status).toBe(200);
+        const dataB = await resListB.json();
+        expect(dataB.length).toBe(1);
+        expect(dataB[0].userAddress).toBe(userB);
+        expect(dataB[0].amount).toBe(75);
+      });
+    });
+
+    describe('Updating (PATCH) & Ownership (403/404)', () => {
+      let scheduleId: string;
+
+      beforeEach(async () => {
+        // Create a schedule for User A
+        mockCookieStore(sessionA);
+        const reqCreate = new NextRequest('http://localhost/api/remittance/recurring', {
+          method: 'POST',
+          body: JSON.stringify({
+            recipientAddress: recipient,
+            amount: 100,
+            currency: 'USD',
+            frequency: 'weekly',
+          }),
+        });
+        const res = await POST(reqCreate);
+        const data = await res.json();
+        scheduleId = data.id;
+      });
+
+      it('should allow owner (User A) to update their own schedule', async () => {
+        mockCookieStore(sessionA);
+        const reqUpdate = new NextRequest(`http://localhost/api/remittance/recurring/${scheduleId}`, {
+          method: 'PATCH',
+          body: JSON.stringify({
+            amount: 250,
+            frequency: 'monthly',
+          }),
+        });
+
+        const response = await PATCH(reqUpdate, { params: Promise.resolve({ id: scheduleId }) });
+        expect(response.status).toBe(200);
+
+        const data = await response.json();
+        expect(data.amount).toBe(250);
+        expect(data.frequency).toBe('monthly');
+      });
+
+      it('should return 403 Forbidden when User B tries to update User A\'s schedule', async () => {
+        mockCookieStore(sessionB);
+        const reqUpdate = new NextRequest(`http://localhost/api/remittance/recurring/${scheduleId}`, {
+          method: 'PATCH',
+          body: JSON.stringify({
+            amount: 500,
+          }),
+        });
+
+        const response = await PATCH(reqUpdate, { params: Promise.resolve({ id: scheduleId }) });
+        expect(response.status).toBe(403);
+      });
+
+      it('should return 404 Not Found when updating a nonexistent schedule', async () => {
+        mockCookieStore(sessionA);
+        const reqUpdate = new NextRequest('http://localhost/api/remittance/recurring/nonexistent-id', {
+          method: 'PATCH',
+          body: JSON.stringify({
+            amount: 500,
+          }),
+        });
+
+        const response = await PATCH(reqUpdate, { params: Promise.resolve({ id: 'nonexistent-id' }) });
+        expect(response.status).toBe(404);
+      });
+
+      it('should return 400 Bad Request for validation failures on update fields', async () => {
+        mockCookieStore(sessionA);
+        const reqUpdate = new NextRequest(`http://localhost/api/remittance/recurring/${scheduleId}`, {
+          method: 'PATCH',
+          body: JSON.stringify({
+            amount: -10,
+          }),
+        });
+
+        const response = await PATCH(reqUpdate, { params: Promise.resolve({ id: scheduleId }) });
+        expect(response.status).toBe(400);
+      });
+    });
+
+    describe('Deletion (DELETE) & Ownership (403/404)', () => {
+      let scheduleId: string;
+
+      beforeEach(async () => {
+        // Create a schedule for User A
+        mockCookieStore(sessionA);
+        const reqCreate = new NextRequest('http://localhost/api/remittance/recurring', {
+          method: 'POST',
+          body: JSON.stringify({
+            recipientAddress: recipient,
+            amount: 100,
+            currency: 'USD',
+            frequency: 'weekly',
+          }),
+        });
+        const res = await POST(reqCreate);
+        const data = await res.json();
+        scheduleId = data.id;
+      });
+
+      it('should allow owner (User A) to delete their own schedule', async () => {
+        mockCookieStore(sessionA);
+        const reqDelete = new NextRequest(`http://localhost/api/remittance/recurring/${scheduleId}`, {
+          method: 'DELETE',
+        });
+
+        const response = await DELETE(reqDelete, { params: Promise.resolve({ id: scheduleId }) });
+        expect(response.status).toBe(200);
+
+        const data = await response.json();
+        expect(data.success).toBe(true);
+
+        // Verify it is deleted
+        const reqGet = new NextRequest('http://localhost/api/remittance/recurring', {
+          method: 'GET',
+        });
+        const resGet = await GET(reqGet);
+        const listData = await resGet.json();
+        expect(listData.length).toBe(0);
+      });
+
+      it('should return 403 Forbidden when User B tries to delete User A\'s schedule', async () => {
+        mockCookieStore(sessionB);
+        const reqDelete = new NextRequest(`http://localhost/api/remittance/recurring/${scheduleId}`, {
+          method: 'DELETE',
+        });
+
+        const response = await DELETE(reqDelete, { params: Promise.resolve({ id: scheduleId }) });
+        expect(response.status).toBe(403);
+      });
+
+      it('should return 404 Not Found when deleting a nonexistent schedule', async () => {
+        mockCookieStore(sessionA);
+        const reqDelete = new NextRequest('http://localhost/api/remittance/recurring/nonexistent-id', {
+          method: 'DELETE',
+        });
+
+        const response = await DELETE(reqDelete, { params: Promise.resolve({ id: 'nonexistent-id' }) });
+        expect(response.status).toBe(404);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR extracts a single canonical recurring-schedules store module, centralizes validation and ownership checks, and adds a comprehensive integration test suite.

### Key Changes
1. **Canonical Store Module (`lib/remittance/recurring-store.ts`):**
   - Created the `IRecurringRemittanceStore` interface and `InMemoryRecurringRemittanceStore` implementation to be DB-swap-ready.
   - Centralized validation rules (`validateRecurringRemittanceInput`) for Stellar address format, amount validity, currency types, and allowed frequencies.

2. **Route Updates:**
   - Refactored `app/api/remittance/recurring/route.ts` and `app/api/remittance/recurring/[id]/route.ts` to utilize the new `recurringStore` and centralized validation.
   - Enforced proper error responses: `400 Bad Request` for validation failures, `404 Not Found` for nonexistent schedules, and `403 Forbidden` for cross-user/unauthorized modifications.

3. **Integration Test Suite (`tests/integration/api/recurring.test.ts`):**
   - Added comprehensive integration tests covering creation, listing, updating, deletion, ownership rules (A vs B), validation failures, and unauthenticated rejections (401).

Closes #588