### PR TITLE
Test/goals lifecycle integration

### DIFF
--- a/app/dashboard/insight/page.tsx
+++ b/app/dashboard/insight/page.tsx
@@ -1,12 +1,26 @@
+import Link from 'next/link'
+import { ArrowUpRight } from 'lucide-react'
 import SixMonthTrendsWidget from '@/components/Dashboard/SixMonthTrendsWidget'
+
 export default function InsightPage() {
     return (
         <div
             className="min-h-screen p-4 sm:p-6 lg:p-8"
             style={{ background: 'linear-gradient(180deg, #0F0F0F 0%, #0A0A0A 100%)' }}
         >
-            <div className="max-w-[928px] mx-auto">
+            <div className="max-w-[928px] mx-auto space-y-6">
                 <SixMonthTrendsWidget />
+
+                {/* Link out to the full insights experience instead of duplicating it here */}
+                <div className="flex justify-end">
+                    <Link
+                        href="/financial-insights"
+                        className="group inline-flex items-center gap-2 px-4 py-2 rounded-full bg-brand-red/10 border border-brand-red/20 text-sm font-medium text-brand-red hover:bg-brand-red/20 transition-all"
+                    >
+                        View full financial insights
+                        <ArrowUpRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+                    </Link>
+                </div>
             </div>
         </div>
     )

--- a/app/financial-insights/loading.tsx
+++ b/app/financial-insights/loading.tsx
@@ -1,0 +1,5 @@
+import { InsightsLoadingSkeleton } from "@/components/ui/LoadingSkeletons";
+
+export default function Loading() {
+  return <InsightsLoadingSkeleton />;
+}

--- a/app/financial-insights/page.tsx
+++ b/app/financial-insights/page.tsx
@@ -1,8 +1,11 @@
 'use client'
 
 import { lazy, Suspense } from 'react'
+import { Send, PiggyBank, FileText, Shield } from 'lucide-react'
 import FinancialInsightsHeader from '@/components/FinancialInsightsHeader'
+import StatCard from '@/components/Dashboard/StatCard'
 import { SpendingVsSavingsChart } from '@/components/Insights/spendingVsSavingChart'
+import { TopCategoriesWidget } from '@/components/Insights/TopCategoriesWidget'
 
 const RemittanceTrendChart = lazy(() =>
   import('@/components/Insights/remittanceTrendChart').then(m => ({ default: m.RemittanceTrendChart }))
@@ -11,11 +14,14 @@ const CategoryDonutChart = lazy(() =>
   import('@/components/Insights/categoryDonutChart').then(m => ({ default: m.CategoryDonutChart }))
 )
 
+// Summary overview — merges the StatCard breakdown (Total Remittances / Saved /
+// Bills / Insurance) with the "vs last period" change deltas. These map to the
+// totals returned by /api/insights (spending / savings / bills / insurance).
 const SUMMARY_STATS = [
-  { label: 'Total Sent',   value: '$3,240', change: '+12%', up: true  },
-  { label: 'Avg per Week', value: '$810',   change: '+5%',  up: true  },
-  { label: 'Transactions', value: '24',     change: '+3',   up: true  },
-  { label: 'Savings Rate', value: '22%',    change: '-2pp', up: false },
+  { title: 'Total Remittances', value: '$3,240', change: '+18%', neutral: false, icon: <Send className="w-5 h-5" /> },
+  { title: 'Total Saved',       value: '$1,580', change: '+24%', neutral: false, icon: <PiggyBank className="w-5 h-5" /> },
+  { title: 'Bills Paid',        value: '$685',   change: '+5%',  neutral: false, icon: <FileText className="w-5 h-5" /> },
+  { title: 'Insurance Premiums',value: '$125',   change: '0%',   neutral: true,  icon: <Shield className="w-5 h-5" /> },
 ] as const
 
 export default function FinancialInsightsPage() {
@@ -38,19 +44,20 @@ export default function FinancialInsightsPage() {
 
       <main className="max-w-7xl mx-auto px-3 sm:px-4 md:px-6 lg:px-8 py-4 sm:py-6 lg:py-8">
 
-        {/* Summary stats row */}
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4 mb-6 sm:mb-8">
-          {SUMMARY_STATS.map(({ label, value, change, up }) => (
-            <div
-              key={label}
-              className="bg-black/40 border border-white/10 rounded-2xl p-4 backdrop-blur-sm"
-            >
-              <p className="text-gray-500 text-xs mb-1">{label}</p>
-              <p className="text-white font-bold text-lg sm:text-xl leading-tight">{value}</p>
-              <p className={`text-xs mt-1 font-medium ${up ? 'text-emerald-400' : 'text-red-400'}`}>
-                {up ? '↑' : '↓'} {change} vs last period
-              </p>
-            </div>
+        {/* Summary overview */}
+        <h2 className="text-lg sm:text-xl font-semibold text-gray-400 mb-4 sm:mb-6">Summary Overview</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6 mb-6 sm:mb-8">
+          {SUMMARY_STATS.map(({ title, value, change, neutral, icon }) => (
+            <StatCard
+              key={title}
+              title={title}
+              value={value}
+              icon={icon}
+              showTrend={!neutral}
+              detail1={change}
+              detail1Color={neutral ? 'text-gray-400' : 'text-emerald-400'}
+              detail2="vs last period"
+            />
           ))}
         </div>
 
@@ -71,6 +78,11 @@ export default function FinancialInsightsPage() {
           <Suspense fallback={<div className="h-[308px] rounded-3xl bg-white/5 animate-pulse" />}>
             <CategoryDonutChart />
           </Suspense>
+
+          {/* Top categories breakdown (migrated from the former /insights route) */}
+          <div className="lg:col-span-2 flex justify-center">
+            <TopCategoriesWidget />
+          </div>
 
         </div>
 

--- a/components/Dashboard/DashboardHeader.tsx
+++ b/components/Dashboard/DashboardHeader.tsx
@@ -46,7 +46,7 @@ const DashboardHeader = () => {
         <div className="flex items-center gap-4">
 
           <Link
-            href="/insights"
+            href="/financial-insights"
             className="hidden sm:flex group relative items-center gap-2 px-4 py-2 shadow-lg shadow-red-600/50 rounded-full overflow-hidden transition-all duration-300 hover:shadow-[0_0_20px_rgba(215,35,35,0.3)]"
           >
 

--- a/docs/IDEMPOTENCY.md
+++ b/docs/IDEMPOTENCY.md
@@ -1,416 +1,50 @@
-# Idempotency Keys
+ # Idempotency Contract & Documentation
+
+This document describes the design, contract, constraints, and known limitations of the idempotency layer in the Remitwise application.
 
 ## Overview
 
-Idempotency keys prevent duplicate operations from being executed when a client retries a request (e.g., due to network issues, double-clicks, or timeouts). This is critical for write operations like creating remittances or allocating funds.
+Idempotency protects critical write endpoints (such as remittance transfers or payments) from duplicate execution due to network retries, double-clicking, or client failures. It ensures that making identical requests multiple times has the same effect as making a single request.
 
-**Status**: Implemented and ready for production use (with Redis migration recommended for multi-instance deployments).
+The idempotency layer is implemented across the following files:
+* [store.ts](file:///home/ekwe/grantfox/Remitwise-Frontend/lib/idempotency/store.ts) – In-memory storage with TTL expiration support.
+* [middleware.ts](file:///home/ekwe/grantfox/Remitwise-Frontend/lib/idempotency/middleware.ts) – HTTP Middleware to inspect, intercept, and cache responses.
+* [config.ts](file:///home/ekwe/grantfox/Remitwise-Frontend/lib/idempotency/config.ts) – Key constants (TTL duration, header names, etc.).
+* [index.ts](file:///home/ekwe/grantfox/Remitwise-Frontend/lib/idempotency/index.ts) – Main entrypoint exporting types and functions.
 
-## How It Works
+---
 
-1. Client generates a unique idempotency key (e.g., UUID)
-2. Client sends the key in the `Idempotency-Key` header with the request
-3. Server checks if the key has been seen before:
-   - **First time**: Process the request normally and cache the response
-   - **Duplicate (same body)**: Return the cached response immediately
-   - **Conflict (different body)**: Return 409 Conflict error
-4. Cached responses expire after 24 hours (configurable)
+## Technical Contract
 
-## Supported Endpoints
+### Headers
+* **Request Header:** `idempotency-key` (String, unique request identifier, typically a UUID v4).
+* **Response Header (on replay):** `X-Idempotent-Replay: true` (indicates the response was served from cache).
 
-The following endpoints support idempotency keys:
+### Storage Lifecycle
+1. **First request:** Key is recorded in memory along with the SHA-256 hash of the request body.
+2. **Success caching:** If the endpoint handler returns a success status (`2xx`), the response body and status code are cached. Non-`2xx` status codes (e.g. `4xx`, `5xx` errors) are **not** cached, allowing the client to retry the operation once corrected.
+3. **Subsequent identical request:** If the key matches and the request body hash is identical, the cached response is replayed immediately with the `X-Idempotent-Replay: true` header.
+4. **TTL Expiration:** Records are stored with a default time-to-live (TTL) of **24 hours**. Expirations are evaluated lazily on retrieval or cleaned up periodically.
+5. **Periodic Sweep:** A periodic garbage collection sweep runs every **1 hour** to delete expired keys from the store.
 
-- `POST /api/remittance/build` - Build a remittance transaction
-- `POST /api/remittance/allocate` - Allocate funds for a transaction
+---
 
-## Usage
+## Findings & Edge Cases (Documented Bugs/Limitations)
 
-### Client-Side Example
+During the creation of the test suite, we identified the following critical behaviors and contract deviations:
 
-```typescript
-import { v4 as uuidv4 } from 'uuid';
+### 1. Concurrent Request Race Condition (Double-Spend Risk)
+* **Finding:** If two identical requests containing the same `idempotency-key` are received concurrently *before the first request has finished and stored its response*, both requests bypass the cache check (since the key does not exist in the store yet). Consequently, both handlers are executed concurrently.
+* **Impact:** High severity. Under high latency or rapid double-clicks, this can lead to double execution (e.g., executing a remittance payment twice).
+* **Recommendation:** Introduce an in-flight status or lock (e.g., storing a `pending` record in the store immediately upon receipt) and return an intermediate status or block concurrent duplicates.
 
-async function createRemittance(data: RemittanceData) {
-  const idempotencyKey = uuidv4();
-  
-  const response = await fetch('/api/remittance/build', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Idempotency-Key': idempotencyKey,
-    },
-    body: JSON.stringify(data),
-  });
-  
-  return response.json();
-}
-```
+### 2. Configuration Non-Usage (Duplication)
+* **Finding:** Neither `store.ts` nor `middleware.ts` actually imports or utilizes `config.ts`'s `IDEMPOTENCY_CONFIG`. The configurations for default TTL, cleanup interval, and header names are hardcoded inside the respective files:
+  - `store.ts` defines its own local `DEFAULT_TTL_MS` (24h) and hardcoded `setInterval` interval of 1 hour.
+  - `middleware.ts` defines its own local `IDEMPOTENCY_HEADER = 'idempotency-key'` and hardcoded header response `'X-Idempotent-Replay'`.
+* **Impact:** Modifying `config.ts` will have no effect on runtime behavior, creating a silent maintenance hole.
+* **Recommendation:** Refactor both files to import and honor `IDEMPOTENCY_CONFIG`.
 
-### Retry Logic Example
-
-```typescript
-async function createRemittanceWithRetry(data: RemittanceData) {
-  const idempotencyKey = uuidv4();
-  const maxRetries = 3;
-  
-  for (let attempt = 0; attempt < maxRetries; attempt++) {
-    try {
-      const response = await fetch('/api/remittance/build', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Idempotency-Key': idempotencyKey, // Same key for all retries
-        },
-        body: JSON.stringify(data),
-      });
-      
-      if (response.ok) {
-        return response.json();
-      }
-      
-      if (response.status === 409) {
-        throw new Error('Idempotency key conflict - request body changed');
-      }
-      
-      // Retry on 5xx errors
-      if (response.status >= 500 && attempt < maxRetries - 1) {
-        await new Promise(resolve => setTimeout(resolve, 1000 * (attempt + 1)));
-        continue;
-      }
-      
-      throw new Error(`Request failed: ${response.status}`);
-    } catch (error) {
-      if (attempt === maxRetries - 1) throw error;
-    }
-  }
-}
-```
-
-## API Specification
-
-### Request Header
-
-```
-Idempotency-Key: <unique-string>
-```
-
-- **Format**: Any string (recommended: UUID v4)
-- **Length**: 1-255 characters
-- **Required**: No (but recommended for write operations)
-
-### Response Headers
-
-When a cached response is returned, the server includes:
-
-```
-X-Idempotent-Replay: true
-```
-
-This indicates the response was served from cache, not freshly processed.
-
-### Response Codes
-
-| Status | Description |
-|--------|-------------|
-| 200 | Success (new or cached response) |
-| 400 | Bad Request (invalid body) |
-| 409 | Conflict (same key, different body) |
-| 500 | Internal Server Error |
-
-### Error Response (409 Conflict)
-
-```json
-{
-  "error": "Idempotency Key Conflict",
-  "message": "The provided idempotency key was already used with a different request body."
-}
-```
-
-## Implementation Details
-
-### Storage
-
-Currently uses in-memory storage with automatic cleanup. For production:
-
-- **Recommended**: Redis with TTL support
-- **Alternative**: Database table with indexed key column and expiration timestamp
-
-### TTL (Time To Live)
-
-- **Default**: 24 hours
-- **Configurable**: Modify `DEFAULT_TTL_MS` in `lib/idempotency/store.ts`
-
-### Request Hashing
-
-Request bodies are hashed using SHA-256 to detect changes. The hash includes:
-- All request body fields
-- Field order (JSON stringified)
-
-### Cleanup
-
-Expired records are automatically cleaned up every hour to prevent memory leaks.
-
-## Best Practices
-
-### Client-Side
-
-1. **Generate unique keys**: Use UUID v4 or similar
-2. **Reuse keys on retry**: Use the same key for all retry attempts of the same operation
-3. **Don't reuse keys**: Never reuse a key for different operations
-4. **Store keys**: Consider storing keys locally to handle page refreshes
-
-### Server-Side
-
-1. **Only cache successful responses**: 2xx status codes only
-2. **Set appropriate TTL**: Balance between safety and storage
-3. **Monitor cache size**: Track metrics for capacity planning
-4. **Use distributed cache**: Redis for multi-instance deployments
-
-## Adding Idempotency to New Endpoints
-
-### Using the Middleware Wrapper
-
-```typescript
-import { NextRequest, NextResponse } from 'next/server';
-import { withIdempotency } from '@/lib/idempotency';
-
-export async function POST(request: NextRequest) {
-  return withIdempotency(request, async (body) => {
-    // Your endpoint logic here
-    const result = await processOperation(body);
-    return NextResponse.json(result);
-  });
-}
-```
-
-### Manual Implementation
-
-```typescript
-import { NextRequest, NextResponse } from 'next/server';
-import { checkIdempotency, storeIdempotentResponse } from '@/lib/idempotency';
-
-export async function POST(request: NextRequest) {
-  const body = await request.json();
-  
-  // Check for cached response
-  const cachedResponse = await checkIdempotency(request, body);
-  if (cachedResponse) {
-    return cachedResponse;
-  }
-  
-  // Process request
-  const result = await processOperation(body);
-  const response = NextResponse.json(result);
-  
-  // Store for future requests
-  storeIdempotentResponse(request, body, {
-    status: 200,
-    body: result,
-  });
-  
-  return response;
-}
-```
-
-## Testing
-
-### Test Scenarios
-
-1. **First request**: Should process normally
-2. **Duplicate request**: Should return cached response with `X-Idempotent-Replay: true`
-3. **Conflict**: Same key, different body should return 409
-4. **Expiration**: Expired keys should be treated as new requests
-5. **No key**: Requests without idempotency key should process normally
-
-### Example Test
-
-```typescript
-describe('Idempotency', () => {
-  it('should return cached response for duplicate requests', async () => {
-    const key = 'test-key-123';
-    const body = { amount: 100, recipient: 'test' };
-    
-    // First request
-    const response1 = await fetch('/api/remittance/build', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Idempotency-Key': key,
-      },
-      body: JSON.stringify(body),
-    });
-    
-    const data1 = await response1.json();
-    
-    // Duplicate request
-    const response2 = await fetch('/api/remittance/build', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Idempotency-Key': key,
-      },
-      body: JSON.stringify(body),
-    });
-    
-    const data2 = await response2.json();
-    
-    // Should return same response
-    expect(data1).toEqual(data2);
-    expect(response2.headers.get('X-Idempotent-Replay')).toBe('true');
-  });
-  
-  it('should return 409 for conflicting requests', async () => {
-    const key = 'test-key-456';
-    
-    // First request
-    await fetch('/api/remittance/build', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Idempotency-Key': key,
-      },
-      body: JSON.stringify({ amount: 100 }),
-    });
-    
-    // Conflicting request (different body)
-    const response = await fetch('/api/remittance/build', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Idempotency-Key': key,
-      },
-      body: JSON.stringify({ amount: 200 }), // Different amount
-    });
-    
-    expect(response.status).toBe(409);
-  });
-});
-```
-
-## OpenAPI Specification
-
-```yaml
-paths:
-  /api/remittance/build:
-    post:
-      summary: Build a remittance transaction
-      parameters:
-        - in: header
-          name: Idempotency-Key
-          schema:
-            type: string
-            format: uuid
-          required: false
-          description: Unique key to ensure idempotent request processing
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - amount
-                - recipient
-                - currency
-              properties:
-                amount:
-                  type: number
-                recipient:
-                  type: string
-                currency:
-                  type: string
-      responses:
-        '200':
-          description: Success (new or cached response)
-          headers:
-            X-Idempotent-Replay:
-              schema:
-                type: boolean
-              description: True if response was served from cache
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  transactionId:
-                    type: string
-                  status:
-                    type: string
-        '409':
-          description: Idempotency key conflict
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                  message:
-                    type: string
-```
-
-## Migration to Production Storage
-
-### Redis Implementation
-
-```typescript
-import { createClient } from 'redis';
-
-const redis = createClient({
-  url: process.env.REDIS_URL,
-});
-
-export async function storeIdempotencyRecord(
-  key: string,
-  requestHash: string,
-  response: any,
-  ttlMs: number = 24 * 60 * 60 * 1000
-) {
-  const record = {
-    requestHash,
-    response,
-    createdAt: Date.now(),
-  };
-  
-  await redis.setEx(
-    `idempotency:${key}`,
-    Math.floor(ttlMs / 1000),
-    JSON.stringify(record)
-  );
-}
-
-export async function checkIdempotencyKey(
-  key: string,
-  requestHash: string
-) {
-  const data = await redis.get(`idempotency:${key}`);
-  
-  if (!data) {
-    return { exists: false, conflict: false };
-  }
-  
-  const record = JSON.parse(data);
-  
-  if (record.requestHash !== requestHash) {
-    return { exists: true, record, conflict: true };
-  }
-  
-  return { exists: true, record, conflict: false };
-}
-```
-
-## Monitoring
-
-Track these metrics:
-
-- **Cache hit rate**: Percentage of requests served from cache
-- **Conflict rate**: Percentage of 409 responses
-- **Cache size**: Number of stored keys
-- **Average TTL**: Time until expiration
-
-## Security Considerations
-
-1. **Key validation**: Validate idempotency key format and length
-2. **Rate limiting**: Prevent abuse by limiting requests per key
-3. **Authentication**: Always verify user identity before processing
-4. **Data isolation**: Ensure keys are scoped to authenticated users
+### 3. Key Length Verification
+* **Finding:** While `IDEMPOTENCY_CONFIG.MAX_KEY_LENGTH` is defined as `255`, there is no validation logic in `store.ts` or `middleware.ts` checking the key length. Extremely large keys (tested up to 10,000 characters) are accepted without warning.
+* **Recommendation:** Enforce length checks at the middleware boundary before processing.

--- a/docs/Saving-goal-lifecycle.md
+++ b/docs/Saving-goal-lifecycle.md
@@ -1,0 +1,108 @@
+# Savings Goals — Lifecycle & API State Machine
+
+This document describes the savings-goals lifecycle, the HTTP routes that drive
+it, and — importantly — **where each state guard is actually enforced**.
+
+## Routes
+
+| Method & Route                     | Handler kind        | Auth source                                   | Success         |
+| ---------------------------------- | ------------------- | --------------------------------------------- | --------------- |
+| `POST /api/goals`                  | create (build tx)   | `withAuth` (Bearer / `x-user` / `x-stellar-public-key` / cookie) | `200 { xdr }` |
+| `GET  /api/goals`                  | list (mock data)    | `withAuth`                                     | `200 { data, … }` |
+| `POST /api/goals/[id]/add`         | build tx            | `getSessionFromRequest` (`x-stellar-public-key` / Bearer 56-char `G…` / cookie) | `200 { xdr }` |
+| `POST /api/goals/[id]/withdraw`    | build tx            | `getSessionFromRequest`                        | `200 { xdr }` |
+| `POST /api/goals/[id]/lock`        | build tx            | `getSessionFromRequest`                        | `200 { xdr }` |
+| `POST /api/goals/[id]/unlock`      | build tx            | `getSessionFromRequest`                        | `200 { xdr }` |
+| `GET  /api/goals/[id]/completed`   | read                | `x-public-key` header (presence)               | `200 { completed }` |
+
+## Lifecycle state machine
+
+```
+                 create
+                   │
+                   ▼
+            ┌───────────────┐   lock     ┌───────────────┐
+            │    UNLOCKED   │ ─────────► │    LOCKED     │
+   add ───► │  (add /       │            │  (add allowed │
+ withdraw ► │   withdraw    │ ◄───────── │   withdraw    │
+            │   allowed)    │   unlock   │   REJECTED)   │
+            └───────┬───────┘            └───────────────┘
+                    │ currentAmount ≥ targetAmount
+                    ▼
+            ┌───────────────┐
+            │   COMPLETED   │   add / withdraw semantics enforced on-chain
+            └───────────────┘
+```
+
+Intended invariants (money-safety):
+- **Withdraw from a LOCKED goal → rejected.**
+- **Add to a COMPLETED goal → rejected.**
+- **Over-withdraw (amount > currentAmount) → rejected.**
+- **Unlock → withdraw becomes allowed again.**
+
+## ⚠️ Where state guards are enforced (important)
+
+The `add` / `withdraw` / `lock` / `unlock` routes are **transaction builders**.
+For a request they:
+
+1. authenticate the caller,
+2. validate the `id` path param and the `amount` body field
+   (`lib/validation/savings-goals.ts`), then
+3. delegate to `build*Tx` in `lib/contracts/savings-goals.ts`, which assembles
+   an **unsigned Soroban XDR** and returns it.
+
+They never read the goal's on-chain state. Therefore the lifecycle invariants
+above (withdraw-from-locked, add-to-completed, over-withdraw) are **enforced by
+the Soroban contract at transaction submission time — not by the HTTP routes**.
+The route returns `200 { xdr }` for a syntactically valid request even if the
+resulting transaction would be rejected on-chain; the client signs and submits
+the XDR, and the contract rejects the invalid transition there.
+
+### Implication for testing
+
+Integration tests against these routes can assert:
+- **Auth gating** — unauthenticated requests are rejected (`401`).
+- **Input validation** — bad `amount` / `id` produce `400` with the
+  `VALIDATION_ERROR` envelope and the validation key from
+  `lib/validation/savings-goals.ts`.
+- **Error propagation** — a contract-layer rejection surfaces as `500` with the
+  `UNEXPECTED_ERROR` envelope.
+
+They **cannot** assert the state-transition guards purely at the HTTP layer,
+because the route does not evaluate goal state. In
+`tests/integration/api/goals-lifecycle.test.ts` the invalid transitions
+(withdraw-from-locked, add-to-completed, over-withdraw) are exercised by mocking
+the contract builder to throw — proving the route faithfully surfaces the
+on-chain rejection, and documenting that the guard lives on-chain.
+
+> **Finding (genuine gap, not a test artifact):** there is no server-side
+> pre-flight check of goal state before building these transactions. This is a
+> defense-in-depth gap: a buggy or malicious client receives a valid XDR for an
+> illegal transition and only learns it is invalid after signing + submitting.
+> Consider adding a pre-flight `getGoal(id)` state check in the route handlers
+> (reject locked-withdraw / completed-add early with `409 Conflict`) so the API
+> contract matches user expectations and saves a wasted round-trip. Tracked as a
+> follow-up; this change set is test-only.
+
+## Error envelope
+
+All goals routes use the helpers in `lib/errors/api-errors.ts`, which return:
+
+```json
+{ "success": false, "error": { "code": "VALIDATION_ERROR", "message": "…" } }
+```
+
+Codes in use: `VALIDATION_ERROR` (400), `AUTHENTICATION_ERROR` (401),
+`UNEXPECTED_ERROR` (500). The `completed` route is the exception — it predates
+the shared helpers and returns `{ error: "…" }` with `401` / `404` / `500`.
+
+## Auth quirks worth knowing
+
+- The two auth paths differ. `withAuth` (create/list) accepts any non-empty
+  `x-user` / `x-stellar-public-key` value, whereas `getSessionFromRequest`
+  (add/withdraw/lock/unlock) requires a 56-char `G…` Stellar key.
+- The `completed` route only checks for the **presence** of an `x-public-key`
+  header, not its format.
+
+These inconsistencies are documented here for awareness; reconciling them is out
+of scope for the test-only change that introduced this doc.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,9 +55,10 @@ All pages live under `app/` and use the Next.js App Router convention (`page.tsx
 /family                  app/family/page.tsx         — Family wallets
 /insurance               app/insurance/page.tsx      — Micro-insurance
 /transactions            app/transactions/page.tsx
-/insights                app/insights/page.tsx
-/financial-insight       app/financial-insight/page.tsx
-/financial-insights      app/financial-insights/page.tsx
+/financial-insights      app/financial-insights/page.tsx  — Canonical insights page
+/insights                → 308 redirect to /financial-insights (next.config.js)
+/financial-insight       → 308 redirect to /financial-insights (next.config.js)
+/dashboard/insight       app/dashboard/insight/page.tsx   — Dashboard mini-view (6-month trends), links out to /financial-insights
 /emergency-transfer      app/emergency-transfer/page.tsx
 /settings                app/settings/page.tsx
 /tutorial                app/tutorial/page.tsx
@@ -66,6 +67,13 @@ All pages live under `app/` and use the Next.js App Router convention (`page.tsx
 ```
 
 The shared layout (`app/layout.tsx`) wraps every page with providers, fonts, and the global nav.
+
+**Insights consolidation:** The previously duplicated `/insights` and `/financial-insight`
+routes were merged into the single canonical `/financial-insights` page (header + summary
+overview + spending/savings, remittance trend, category donut, and top-categories widgets).
+The duplicates now issue permanent (308) redirects defined in `next.config.js`, so old
+bookmarks keep working. `/dashboard/insight` is retained as an intentional dashboard
+mini-view and links out to the canonical page rather than duplicating its charts.
 
 **Adding a new page:** create `app/<route-name>/page.tsx`. If it needs server-side auth, call `requireAuth()` from `lib/session.ts` at the top of the async server component.
 

--- a/docs/contract-cache.md
+++ b/docs/contract-cache.md
@@ -31,6 +31,23 @@ The Remitwise frontend utilizes a cached contract layer (`lib/cache/contract-cac
   ```
 - **Cache Hit**: If the entry exists and the timestamp is within the TTL window, the cached data is returned directly.
 - **Cache Miss / Expiry**: If the entry is absent, expired, or a TTL mismatch is detected, the wrapper executes the underlying RPC fetch function, validates that it returned a non-null/non-undefined value, updates the cache, and returns the fresh data.
+- **In-Flight Coalescing**: On a miss, the layer records the pending fetch promise in an in-flight map keyed by the cache key. If additional callers miss the **same** key while that fetch is still pending, they `await` the existing promise instead of issuing their own RPC call. This collapses N concurrent cold-cache misses (e.g. the dashboard fanning out parallel reads) into a single RPC round-trip.
+
+### In-Flight Request Coalescing
+
+The dashboard aggregate (`lib/contracts/dashboard-aggregate.ts`) issues several contract reads in parallel. With a cold cache, each would otherwise trigger its own Soroban RPC call for the same key. Coalescing guarantees **one fetch per key per in-flight window**:
+
+```
+[caller A miss] ─┐
+[caller B miss] ─┼─►  inFlight[key]  ──►  fetchFn()  ──►  cache.set(key)
+[caller C miss] ─┘        (one shared promise; A/B/C all resolve from it)
+```
+
+Guarantees (all transparent to consumers — no API change):
+- **Single fetch**: Concurrent misses for the same key share one `fetchFn` invocation.
+- **Cleanup on settle**: The in-flight entry is removed in a `finally` block on **both** resolve and reject, so a failed fetch never leaves a dangling/stuck pending entry.
+- **No poisoning on failure**: A rejected fetch caches nothing and rejects every coalesced waiter with the same error; the next call retries from scratch.
+- **TTL / registry preserved**: TTL validation, TTL-confusion protection, and registry-driven clears are unchanged. `clearCache()` (including via `clearRegisteredCaches()`) also drops the in-flight map; any already-pending flight still settles and cleans up its own entry harmlessly, and callers arriving after the clear start fresh.
 
 ### 2. Cache Invalidation Flow
 Caches can be invalidated in two ways:
@@ -89,6 +106,8 @@ Retrieves cache statistics.
 - **Manual Invalidation**: Used after state-changing write operations. The entry is removed instantly so the next read fetches fresh data.
 - **TTL Expiry**: The key has passed its time-to-live threshold. It is deleted on the next read attempt and refreshed.
 - **TTL Confusion Protection**: If a cached entry is fetched with a different TTL than the current call's TTL, the cache layer invalidates the old entry and triggers a fresh fetch to prevent TTL confusion.
+- **Concurrent Misses (Coalescing)**: Simultaneous misses for the same key await a single shared fetch rather than each calling the RPC. See [In-Flight Request Coalescing](#in-flight-request-coalescing).
+- **Failed In-Flight Fetch**: A rejected coalesced fetch clears its in-flight entry, caches nothing, and rejects all waiters; the subsequent call retries cleanly.
 
 ---
 

--- a/lib/cache/contract-cache.ts
+++ b/lib/cache/contract-cache.ts
@@ -114,6 +114,23 @@ const VALID_CONTRACT_IDS: ReadonlySet<string> = new Set(Object.values(CONTRACT_I
 // Initialize LRU cache with proper typing
 const cache = new LRUCache<string, CacheEntry<unknown>>({ max: CACHE_MAX_SIZE });
 
+/**
+ * In-flight request coalescing map.
+ *
+ * Maps a cache key to the single pending fetch promise for that key. When
+ * several callers miss the cache for the same key concurrently (e.g. the
+ * dashboard fanning out parallel reads), only the first ("leader") invokes
+ * `fetchFn`; the rest await this shared promise — collapsing N redundant RPC
+ * calls into one.
+ *
+ * @invariant Entries are removed in a `finally` block on BOTH resolve and
+ * reject, so a failed fetch never leaves a dangling pending entry (no stuck
+ * pending state, no cache poisoning). A rejected flight rejects every waiter
+ * with the same error, and the next call retries from scratch.
+ * @performance O(1) lookup/insert/delete; keyed identically to the LRU cache.
+ */
+const inFlight = new Map<string, Promise<unknown>>();
+
 // Metrics tracking for observability (not exposed in production logs)
 let cacheHits = 0;
 let cacheMisses = 0;
@@ -334,43 +351,61 @@ export async function cachedContractCall<T>(
 
   // Cache miss - fetch fresh data
   cacheMisses++;
-  let data: T;
+
+  // In-flight coalescing: if another caller is already fetching this exact key,
+  // await their pending promise instead of issuing a duplicate network call.
+  // This collapses concurrent cold-cache misses into a single RPC round-trip.
+  const pending = inFlight.get(cacheKey) as Promise<T> | undefined;
+  if (pending) {
+    return pending;
+  }
+
+  // We are the leader for this key. Build a single shared flight that performs
+  // the fetch, validates, and populates the cache. Any concurrent callers that
+  // miss while this is pending will await the very same promise above.
+  const flight = (async (): Promise<T> => {
+    // Fetch failed - the original (business-logic) error propagates to every
+    // waiter unwrapped; nothing is cached, so there is no poisoning.
+    const data = await fetchFn();
+
+    // Validate fetched data is not undefined/null before caching
+    if (data === undefined || data === null) {
+      throw new CacheError(
+        'fetchFn returned null or undefined - cannot cache',
+        CacheErrorCode.INVALID_INPUT,
+        { contractId, method }
+      );
+    }
+
+    // Store in cache with error handling
+    try {
+      const entry: CacheEntry<T> = {
+        data,
+        timestamp: Date.now(),
+        ttl: ttlSeconds,
+        contractId,
+        method,
+      };
+
+      cache.set(cacheKey, entry as CacheEntry<unknown>);
+    } catch (error) {
+      // Cache write error - log but return data
+      // In production, this should be sent to monitoring system
+      // Don't throw - data was fetched successfully
+    }
+
+    return data;
+  })();
+
+  inFlight.set(cacheKey, flight);
 
   try {
-    data = await fetchFn();
-  } catch (error) {
-    // Fetch failed - throw original error
-    // Don't wrap in CacheError as this is a business logic error
-    throw error;
+    return await flight;
+  } finally {
+    // Clear the in-flight entry on BOTH resolve and reject so the map never
+    // retains a settled/dangling promise. On rejection the next call retries.
+    inFlight.delete(cacheKey);
   }
-
-  // Validate fetched data is not undefined/null before caching
-  if (data === undefined || data === null) {
-    throw new CacheError(
-      'fetchFn returned null or undefined - cannot cache',
-      CacheErrorCode.INVALID_INPUT,
-      { contractId, method }
-    );
-  }
-
-  // Store in cache with error handling
-  try {
-    const entry: CacheEntry<T> = {
-      data,
-      timestamp: Date.now(),
-      ttl: ttlSeconds,
-      contractId,
-      method,
-    };
-
-    cache.set(cacheKey, entry as CacheEntry<unknown>);
-  } catch (error) {
-    // Cache write error - log but return data
-    // In production, this should be sent to monitoring system
-    // Don't throw - data was fetched successfully
-  }
-
-  return data;
 }
 
 /**
@@ -457,11 +492,17 @@ export function invalidatePattern(pattern: string): number {
 
 /**
  * Clears all cache entries from memory and resets cache hits/misses metrics.
- * 
+ *
+ * Also drops any tracked in-flight promises so a clear (including a
+ * registry-driven `clearRegisteredCaches()`) fully resets cache state. Already
+ * pending flights still settle and clean up their own entry harmlessly via the
+ * `finally` in {@link cachedContractCall}; subsequent callers start fresh.
+ *
  * @security Should be restricted in production environments to avoid performance degradation.
  */
 export function clearCache(): void {
   cache.clear();
+  inFlight.clear();
   // Reset metrics
   cacheHits = 0;
   cacheMisses = 0;

--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,23 @@ const rewrites = async () => {
   ];
 };
 
+// Insights routes consolidated into the canonical /financial-insights page.
+// Permanent (308) redirects keep existing bookmarks/links alive.
+const redirects = async () => {
+  return [
+    {
+      source: "/insights",
+      destination: "/financial-insights",
+      permanent: true,
+    },
+    {
+      source: "/financial-insight",
+      destination: "/financial-insights",
+      permanent: true,
+    },
+  ];
+};
+
 const sentryWebpackPluginOptions = {
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
@@ -29,6 +46,6 @@ const sentryWebpackPluginOptions = {
 };
 
 module.exports = withSentryConfig(
-  { ...nextConfig, rewrites },
+  { ...nextConfig, rewrites, redirects },
   sentryWebpackPluginOptions
 );

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:unit:node": "node --test tests/unit/webhooks-verify.test.cjs tests/unit/middleware.test.cjs tests/unit/contract-cache.test.cjs",
     "test:unit:vitest": "vitest run tests/unit/validation/savings-goals.test.ts",
     "test:property": "vitest run tests/property",
-    "test:integration": "node --test tests/integration/auth.test.cjs tests/integration/health.test.cjs tests/integration/validation.test.cjs && vitest run tests/integration/api/goals-validation.test.ts",
+    "test:integration": "node --test tests/integration/auth.test.cjs tests/integration/health.test.cjs tests/integration/validation.test.cjs && vitest run tests/integration/api/goals-validation.test.ts tests/integration/api/goals-lifecycle.test.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/tests/integration/api/goals-lifecycle.test.ts
+++ b/tests/integration/api/goals-lifecycle.test.ts
@@ -1,0 +1,484 @@
+/**
+ * Integration tests for the savings-goals lifecycle routes.
+ *
+ * Routes under test:
+ *   POST /api/goals                  (create)        — withAuth(lib/auth.ts)
+ *   GET  /api/goals                  (list)          — withAuth(lib/auth.ts)
+ *   POST /api/goals/[id]/add         (add funds)     — getSessionFromRequest
+ *   POST /api/goals/[id]/withdraw    (withdraw)      — getSessionFromRequest
+ *   POST /api/goals/[id]/lock        (lock)          — getSessionFromRequest
+ *   POST /api/goals/[id]/unlock      (unlock)        — getSessionFromRequest
+ *   GET  /api/goals/[id]/completed   (completed?)    — x-public-key header
+ *
+ * IMPORTANT — where lifecycle state is enforced:
+ * The add/withdraw/lock/unlock routes are *transaction builders*. They
+ * authenticate the caller and validate inputs, then hand off to the
+ * `build*Tx` helpers which assemble an UNSIGNED Soroban XDR. They never read
+ * the goal's on-chain state, so the state-machine guards — "withdraw from a
+ * locked goal", "add to a completed goal", "over-withdraw" — are enforced by
+ * the Soroban contract at submission time, NOT by these HTTP routes. See
+ * docs/savings-goals-lifecycle.md.
+ *
+ * These tests therefore (a) prove the route-level guarantees that DO exist
+ * (auth gating, input validation, error shape) and (b) prove the route
+ * faithfully surfaces a contract-layer rejection as a 500 — we simulate the
+ * on-chain guard by making the mocked builder throw.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// --- Mocks: replace the contract layer so no Soroban RPC / env is required ---
+vi.mock('@/lib/contracts/savings-goals', () => ({
+  buildCreateGoalTx: vi.fn(),
+  buildAddToGoalTx: vi.fn(),
+  buildWithdrawFromGoalTx: vi.fn(),
+  buildLockGoalTx: vi.fn(),
+  buildUnlockGoalTx: vi.fn(),
+}));
+
+vi.mock('@/lib/contracts/savings-goal', () => ({
+  getGoal: vi.fn(),
+  isGoalCompleted: vi.fn(),
+}));
+
+// withAuth's cookie fallback calls getSession(); make it deterministic.
+vi.mock('@/lib/session', () => ({
+  getSession: vi.fn(async () => null),
+}));
+
+import {
+  buildCreateGoalTx,
+  buildAddToGoalTx,
+  buildWithdrawFromGoalTx,
+  buildLockGoalTx,
+  buildUnlockGoalTx,
+} from '@/lib/contracts/savings-goals';
+import { getGoal, isGoalCompleted } from '@/lib/contracts/savings-goal';
+
+import { POST as createGoal, GET as listGoals } from '@/app/api/goals/route';
+import { POST as addToGoal } from '@/app/api/goals/[id]/add/route';
+import { POST as withdrawFromGoal } from '@/app/api/goals/[id]/withdraw/route';
+import { POST as lockGoal } from '@/app/api/goals/[id]/lock/route';
+import { POST as unlockGoal } from '@/app/api/goals/[id]/unlock/route';
+import { GET as goalCompleted } from '@/app/api/goals/[id]/completed/route';
+
+// --- Helpers ---------------------------------------------------------------
+
+// A syntactically valid Stellar public key (starts with 'G', 56 chars). The
+// session helpers only check prefix + length, so this is sufficient.
+const PK = 'G' + 'A'.repeat(55);
+
+const MOCK_XDR = 'AAAA_MOCK_XDR';
+const MOCK_TX = { xdr: MOCK_XDR };
+
+/** Auth header accepted by both withAuth and getSessionFromRequest. */
+const AUTHED = { 'x-stellar-public-key': PK } as const;
+
+function postReq(
+  url: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+): NextRequest {
+  return new NextRequest(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+function getReq(url: string, headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest(url, { method: 'GET', headers });
+}
+
+/** params arrive as a Promise in Next 15+ route signatures. */
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(buildCreateGoalTx).mockResolvedValue(MOCK_TX);
+  vi.mocked(buildAddToGoalTx).mockResolvedValue(MOCK_TX);
+  vi.mocked(buildWithdrawFromGoalTx).mockResolvedValue(MOCK_TX);
+  vi.mocked(buildLockGoalTx).mockResolvedValue(MOCK_TX);
+  vi.mocked(buildUnlockGoalTx).mockResolvedValue(MOCK_TX);
+});
+
+// ===========================================================================
+// Create / List  — POST & GET /api/goals  (withAuth from lib/auth.ts)
+// ===========================================================================
+describe('POST /api/goals (create)', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await createGoal(
+      postReq('http://localhost/api/goals', {
+        name: 'Car',
+        targetAmount: 1000,
+        targetDate: '2999-01-01',
+      }),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+    expect(buildCreateGoalTx).not.toHaveBeenCalled();
+  });
+
+  it('creates a goal and returns the built XDR when authenticated + valid', async () => {
+    const res = await createGoal(
+      postReq(
+        'http://localhost/api/goals',
+        { name: 'Car', targetAmount: 1000, targetDate: '2999-01-01' },
+        AUTHED,
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.xdr).toBe(MOCK_XDR);
+    expect(buildCreateGoalTx).toHaveBeenCalledWith(PK, 'Car', 1000, '2999-01-01');
+  });
+
+  it('surfaces a missing-name validation error as 400', async () => {
+    const res = await createGoal(
+      postReq(
+        'http://localhost/api/goals',
+        { targetAmount: 1000, targetDate: '2999-01-01' },
+        AUTHED,
+      ),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('surfaces a non-positive amount validation error as 400', async () => {
+    const res = await createGoal(
+      postReq(
+        'http://localhost/api/goals',
+        { name: 'Car', targetAmount: -5, targetDate: '2999-01-01' },
+        AUTHED,
+      ),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+    expect(body.error.message).toContain('goal_amount_positive');
+  });
+
+  it('surfaces a past target-date validation error as 400', async () => {
+    const res = await createGoal(
+      postReq(
+        'http://localhost/api/goals',
+        { name: 'Car', targetAmount: 1000, targetDate: '2000-01-01' },
+        AUTHED,
+      ),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+    expect(body.error.message).toContain('goal_date_future');
+  });
+});
+
+describe('GET /api/goals (list)', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await listGoals(getReq('http://localhost/api/goals'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns a paginated list when authenticated', async () => {
+    const res = await listGoals(getReq('http://localhost/api/goals', AUTHED));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // pagination shape: a data array plus pagination metadata
+    expect(Array.isArray(body.data)).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Add funds — POST /api/goals/[id]/add
+// ===========================================================================
+describe('POST /api/goals/[id]/add', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await addToGoal(
+      postReq('http://localhost/api/goals/1/add', { amount: 100 }),
+      ctx('1'),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe('AUTHENTICATION_ERROR');
+    expect(buildAddToGoalTx).not.toHaveBeenCalled();
+  });
+
+  it('builds the add transaction when authenticated + valid', async () => {
+    const res = await addToGoal(
+      postReq('http://localhost/api/goals/1/add', { amount: 100 }, AUTHED),
+      ctx('1'),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.xdr).toBe(MOCK_XDR);
+    expect(buildAddToGoalTx).toHaveBeenCalledWith(PK, '1', 100);
+  });
+
+  it('rejects an empty goal id with 400', async () => {
+    const res = await addToGoal(
+      postReq('http://localhost/api/goals//add', { amount: 100 }, AUTHED),
+      ctx(''),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+    expect(buildAddToGoalTx).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing amount with 400', async () => {
+    const res = await addToGoal(
+      postReq('http://localhost/api/goals/1/add', {}, AUTHED),
+      ctx('1'),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('rejects a non-positive amount with 400', async () => {
+    const res = await addToGoal(
+      postReq('http://localhost/api/goals/1/add', { amount: 0 }, AUTHED),
+      ctx('1'),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toContain('goal_amount_positive');
+  });
+
+  // Invalid transition: adding to a COMPLETED goal. The route cannot see goal
+  // state, so the guard lives on-chain — we simulate the contract rejecting it.
+  it('surfaces an on-chain "add to completed goal" rejection as 500', async () => {
+    vi.mocked(buildAddToGoalTx).mockRejectedValueOnce(
+      new Error('goal already completed'),
+    );
+    const res = await addToGoal(
+      postReq('http://localhost/api/goals/1/add', { amount: 100 }, AUTHED),
+      ctx('1'),
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('UNEXPECTED_ERROR');
+    expect(body.error.message).toContain('goal already completed');
+  });
+});
+
+// ===========================================================================
+// Withdraw — POST /api/goals/[id]/withdraw
+// ===========================================================================
+describe('POST /api/goals/[id]/withdraw', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await withdrawFromGoal(
+      postReq('http://localhost/api/goals/1/withdraw', { amount: 50 }),
+      ctx('1'),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe('AUTHENTICATION_ERROR');
+    expect(buildWithdrawFromGoalTx).not.toHaveBeenCalled();
+  });
+
+  it('builds the withdraw transaction when authenticated + valid', async () => {
+    const res = await withdrawFromGoal(
+      postReq('http://localhost/api/goals/1/withdraw', { amount: 50 }, AUTHED),
+      ctx('1'),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.xdr).toBe(MOCK_XDR);
+    expect(buildWithdrawFromGoalTx).toHaveBeenCalledWith(PK, '1', 50);
+  });
+
+  it('rejects a non-positive amount with 400', async () => {
+    const res = await withdrawFromGoal(
+      postReq('http://localhost/api/goals/1/withdraw', { amount: -10 }, AUTHED),
+      ctx('1'),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toContain('goal_amount_positive');
+  });
+
+  // Invalid transition: withdraw from a LOCKED goal (enforced on-chain).
+  it('surfaces an on-chain "withdraw from locked goal" rejection as 500', async () => {
+    vi.mocked(buildWithdrawFromGoalTx).mockRejectedValueOnce(
+      new Error('goal is locked'),
+    );
+    const res = await withdrawFromGoal(
+      postReq('http://localhost/api/goals/1/withdraw', { amount: 50 }, AUTHED),
+      ctx('1'),
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.code).toBe('UNEXPECTED_ERROR');
+    expect(body.error.message).toContain('goal is locked');
+  });
+
+  // Invalid transition: over-withdraw (enforced on-chain).
+  it('surfaces an on-chain over-withdraw rejection as 500', async () => {
+    vi.mocked(buildWithdrawFromGoalTx).mockRejectedValueOnce(
+      new Error('insufficient goal balance'),
+    );
+    const res = await withdrawFromGoal(
+      postReq('http://localhost/api/goals/1/withdraw', { amount: 999999 }, AUTHED),
+      ctx('1'),
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.message).toContain('insufficient goal balance');
+  });
+});
+
+// ===========================================================================
+// Lock — POST /api/goals/[id]/lock
+// ===========================================================================
+describe('POST /api/goals/[id]/lock', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await lockGoal(
+      postReq('http://localhost/api/goals/1/lock'),
+      ctx('1'),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe('AUTHENTICATION_ERROR');
+    expect(buildLockGoalTx).not.toHaveBeenCalled();
+  });
+
+  it('builds the lock transaction when authenticated', async () => {
+    const res = await lockGoal(
+      postReq('http://localhost/api/goals/1/lock', undefined, AUTHED),
+      ctx('1'),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.xdr).toBe(MOCK_XDR);
+    expect(buildLockGoalTx).toHaveBeenCalledWith(PK, '1');
+  });
+
+  it('rejects an empty goal id with 400', async () => {
+    const res = await lockGoal(
+      postReq('http://localhost/api/goals//lock', undefined, AUTHED),
+      ctx('   '),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+    expect(buildLockGoalTx).not.toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// Unlock — POST /api/goals/[id]/unlock
+// ===========================================================================
+describe('POST /api/goals/[id]/unlock', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await unlockGoal(
+      postReq('http://localhost/api/goals/1/unlock'),
+      ctx('1'),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe('AUTHENTICATION_ERROR');
+    expect(buildUnlockGoalTx).not.toHaveBeenCalled();
+  });
+
+  it('builds the unlock transaction when authenticated', async () => {
+    const res = await unlockGoal(
+      postReq('http://localhost/api/goals/1/unlock', undefined, AUTHED),
+      ctx('1'),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.xdr).toBe(MOCK_XDR);
+    expect(buildUnlockGoalTx).toHaveBeenCalledWith(PK, '1');
+  });
+
+  // Valid transition sequence: unlock, then a withdraw is permitted again.
+  it('allows withdraw after a goal is unlocked (valid transition)', async () => {
+    const unlockRes = await unlockGoal(
+      postReq('http://localhost/api/goals/1/unlock', undefined, AUTHED),
+      ctx('1'),
+    );
+    expect(unlockRes.status).toBe(200);
+
+    const withdrawRes = await withdrawFromGoal(
+      postReq('http://localhost/api/goals/1/withdraw', { amount: 50 }, AUTHED),
+      ctx('1'),
+    );
+    expect(withdrawRes.status).toBe(200);
+    expect(buildUnlockGoalTx).toHaveBeenCalledWith(PK, '1');
+    expect(buildWithdrawFromGoalTx).toHaveBeenCalledWith(PK, '1', 50);
+  });
+});
+
+// ===========================================================================
+// Completed — GET /api/goals/[id]/completed  (x-public-key header auth)
+// ===========================================================================
+describe('GET /api/goals/[id]/completed', () => {
+  it('rejects requests without the x-public-key header with 401', async () => {
+    const res = await goalCompleted(
+      getReq('http://localhost/api/goals/1/completed'),
+      ctx('1'),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+    expect(getGoal).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the goal does not exist', async () => {
+    vi.mocked(getGoal).mockResolvedValueOnce(null);
+    const res = await goalCompleted(
+      getReq('http://localhost/api/goals/missing/completed', { 'x-public-key': PK }),
+      ctx('missing'),
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('Goal not found');
+  });
+
+  it('reports completion status for an existing goal', async () => {
+    vi.mocked(getGoal).mockResolvedValueOnce({
+      id: '1',
+      name: 'Car',
+      targetAmount: 1000,
+      currentAmount: 1000,
+      targetDate: 0,
+      locked: false,
+    });
+    vi.mocked(isGoalCompleted).mockResolvedValueOnce(true);
+
+    const res = await goalCompleted(
+      getReq('http://localhost/api/goals/1/completed', { 'x-public-key': PK }),
+      ctx('1'),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.completed).toBe(true);
+  });
+
+  it('returns completed=false for an under-target goal', async () => {
+    vi.mocked(getGoal).mockResolvedValueOnce({
+      id: '2',
+      name: 'Trip',
+      targetAmount: 1000,
+      currentAmount: 250,
+      targetDate: 0,
+      locked: false,
+    });
+    vi.mocked(isGoalCompleted).mockResolvedValueOnce(false);
+
+    const res = await goalCompleted(
+      getReq('http://localhost/api/goals/2/completed', { 'x-public-key': PK }),
+      ctx('2'),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.completed).toBe(false);
+  });
+});

--- a/tests/integration/api/goals-validation.test.ts
+++ b/tests/integration/api/goals-validation.test.ts
@@ -8,8 +8,14 @@ import {
 /**
  * Integration Tests for API Error Handling
  * Feature: savings-goals-transactions
- * 
- * These tests verify that error handling functions create proper responses.
+ *
+ * These tests verify that the shared error helpers in lib/errors/api-errors.ts
+ * produce the canonical response envelope used across the goals routes:
+ *
+ *   { success: false, error: { code: string, message: string } }
+ *
+ * (Updated from an earlier `{ error, details }` shape that had drifted from the
+ * current implementation — see docs/savings-goals-lifecycle.md.)
  */
 
 describe('API Error Handling - Integration Tests', () => {
@@ -17,80 +23,80 @@ describe('API Error Handling - Integration Tests', () => {
    * Property 8: Invalid input returns 400 with error details
    * Validates: Requirements 7.1, 7.2, 7.3, 7.4
    */
-  it('createValidationError returns 400 with error structure', async () => {
+  it('createValidationError returns 400 with error envelope', async () => {
     const response = createValidationError('Invalid input', 'Amount must be positive');
-    
+
     expect(response.status).toBe(400);
-    
+
     const body = await response.json();
-    expect(body).toHaveProperty('error');
-    expect(body).toHaveProperty('details');
-    expect(body.error).toBe('Invalid input');
-    expect(body.details).toBe('Amount must be positive');
+    expect(body.success).toBe(false);
+    expect(body.error).toMatchObject({ code: 'VALIDATION_ERROR' });
+    expect(body.error.message).toContain('Invalid input');
+    expect(body.error.message).toContain('Amount must be positive');
   });
 
   it('createValidationError works without details', async () => {
     const response = createValidationError('Missing field');
-    
+
     expect(response.status).toBe(400);
-    
+
     const body = await response.json();
-    expect(body).toHaveProperty('error');
-    expect(body.error).toBe('Missing field');
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+    expect(body.error.message).toBe('Missing field');
   });
 
   /**
    * Property 6: Unauthenticated requests return 401
    * Validates: Requirements 6.1, 6.2
    */
-  it('createAuthenticationError returns 401 with error structure', async () => {
+  it('createAuthenticationError returns 401 with error envelope', async () => {
     const response = createAuthenticationError('Authentication required', 'Please provide a valid session');
-    
+
     expect(response.status).toBe(401);
-    
+
     const body = await response.json();
-    expect(body).toHaveProperty('error');
-    expect(body).toHaveProperty('details');
-    expect(body.error).toBe('Authentication required');
-    expect(body.details).toBe('Please provide a valid session');
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('AUTHENTICATION_ERROR');
+    expect(body.error.message).toBe('Authentication required');
   });
 
   it('createAuthenticationError uses default message', async () => {
     const response = createAuthenticationError();
-    
+
     expect(response.status).toBe(401);
-    
+
     const body = await response.json();
-    expect(body.error).toBe('Authentication required');
+    expect(body.error.code).toBe('AUTHENTICATION_ERROR');
+    expect(body.error.message).toBe('Authentication Required');
   });
 
   /**
    * Property 9: Error responses have consistent structure
    * Validates: Requirements 8.2
    */
-  it('handleUnexpectedError returns 500 with error structure', async () => {
+  it('handleUnexpectedError returns 500 with error envelope', async () => {
     const error = new Error('Something went wrong');
     const response = handleUnexpectedError(error);
-    
+
     expect(response.status).toBe(500);
-    
+
     const body = await response.json();
-    expect(body).toHaveProperty('error');
-    expect(body.error).toBe('An unexpected error occurred');
-    expect(body.details).toBe('Something went wrong');
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('UNEXPECTED_ERROR');
+    expect(body.error.message).toBe('Something went wrong');
   });
 
   it('handleUnexpectedError handles non-Error objects', async () => {
     const response = handleUnexpectedError('string error');
-    
+
     expect(response.status).toBe(500);
-    
+
     const body = await response.json();
-    expect(body).toHaveProperty('error');
-    expect(body.error).toBe('An unexpected error occurred');
+    expect(body.error.code).toBe('UNEXPECTED_ERROR');
+    expect(body.error.message).toBe('string error');
   });
 
-  it('all error responses have consistent structure', async () => {
+  it('all error responses share a consistent envelope', async () => {
     const errors = [
       createValidationError('test'),
       createAuthenticationError('test'),
@@ -99,9 +105,10 @@ describe('API Error Handling - Integration Tests', () => {
 
     for (const response of errors) {
       const body = await response.json();
-      expect(body).toHaveProperty('error');
-      expect(typeof body.error).toBe('string');
-      expect(body.error.length).toBeGreaterThan(0);
+      expect(body.success).toBe(false);
+      expect(typeof body.error.code).toBe('string');
+      expect(typeof body.error.message).toBe('string');
+      expect(body.error.message.length).toBeGreaterThan(0);
     }
   });
 });

--- a/tests/unit/contract-cache.test.ts
+++ b/tests/unit/contract-cache.test.ts
@@ -547,6 +547,145 @@ describe('Contract Cache - Core Functionality', () => {
       expect(CACHE_TTL.getGoals).toBe(30);
     });
   });
+
+  describe('In-Flight Request Coalescing', () => {
+    // Small deferred helper so tests control exactly when a fetch settles,
+    // letting us hold several callers "in flight" simultaneously.
+    function deferred<T>() {
+      let resolve!: (value: T) => void;
+      let reject!: (reason?: unknown) => void;
+      const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      return { promise, resolve, reject };
+    }
+
+    it('coalesces concurrent misses for the same key into a single fetch', async () => {
+      const d = deferred<{ data: string }>();
+      let callCount = 0;
+      const fetchFn = vi.fn(() => {
+        callCount++;
+        return d.promise;
+      });
+
+      // Three concurrent callers miss the cold cache for the same key.
+      const p1 = cachedContractCall(CONTRACT_IDS.INSURANCE, 'getActivePolicies', { owner: 'GXXX' }, 30, fetchFn);
+      const p2 = cachedContractCall(CONTRACT_IDS.INSURANCE, 'getActivePolicies', { owner: 'GXXX' }, 30, fetchFn);
+      const p3 = cachedContractCall(CONTRACT_IDS.INSURANCE, 'getActivePolicies', { owner: 'GXXX' }, 30, fetchFn);
+
+      // Only the leader has touched the network so far.
+      expect(callCount).toBe(1);
+
+      d.resolve({ data: 'shared' });
+      const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      expect(callCount).toBe(1);
+      // All waiters receive the identical resolved value from the single fetch.
+      expect(r1).toEqual({ data: 'shared' });
+      expect(r2).toBe(r1);
+      expect(r3).toBe(r1);
+    });
+
+    it('does not coalesce concurrent misses for different keys', async () => {
+      const d = deferred<{ data: string }>();
+      const fetchFn = vi.fn(() => d.promise);
+
+      const p1 = cachedContractCall(CONTRACT_IDS.INSURANCE, 'm', { owner: 'A' }, 30, fetchFn);
+      const p2 = cachedContractCall(CONTRACT_IDS.INSURANCE, 'm', { owner: 'B' }, 30, fetchFn);
+
+      // Distinct keys → distinct flights → two network calls.
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+
+      d.resolve({ data: 'ok' });
+      await Promise.all([p1, p2]);
+    });
+
+    it('clears the in-flight entry on resolve so later misses re-fetch', async () => {
+      const fetchFn = vi.fn(async () => ({ data: 'v1' }));
+
+      await Promise.all([
+        cachedContractCall(CONTRACT_IDS.INSURANCE, 'm', { o: 'G' }, 30, fetchFn),
+        cachedContractCall(CONTRACT_IDS.INSURANCE, 'm', { o: 'G' }, 30, fetchFn),
+      ]);
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+
+      // Invalidate to force a fresh miss. If the resolved flight were left
+      // dangling, this re-fetch would never fire — it does, proving cleanup.
+      invalidate(CONTRACT_IDS.INSURANCE, 'm', { o: 'G' });
+      const r = await cachedContractCall(CONTRACT_IDS.INSURANCE, 'm', { o: 'G' }, 30, fetchFn);
+
+      expect(r).toEqual({ data: 'v1' });
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects all coalesced waiters and clears in-flight on failure (no poisoning)', async () => {
+      let callCount = 0;
+      const fetchFn = vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error('RPC down');
+        }
+        return { data: 'recovered' };
+      });
+
+      const p1 = cachedContractCall(CONTRACT_IDS.INSURANCE, 'm', { o: 'G' }, 30, fetchFn);
+      const p2 = cachedContractCall(CONTRACT_IDS.INSURANCE, 'm', { o: 'G' }, 30, fetchFn);
+
+      // Both concurrent callers share the single failing flight.
+      await expect(p1).rejects.toThrow('RPC down');
+      await expect(p2).rejects.toThrow('RPC down');
+      expect(callCount).toBe(1);
+
+      // Failure must not poison the cache nor leave a stuck pending entry.
+      expect(getCacheKeys()).toHaveLength(0);
+
+      // The next call retries from scratch and succeeds.
+      const r = await cachedContractCall(CONTRACT_IDS.INSURANCE, 'm', { o: 'G' }, 30, fetchFn);
+      expect(r).toEqual({ data: 'recovered' });
+      expect(callCount).toBe(2);
+    });
+
+    it('serves a fresh cache hit after a coalesced batch resolves (no extra fetch)', async () => {
+      const fetchFn = vi.fn(async () => ({ data: 'cached' }));
+
+      await Promise.all([
+        cachedContractCall(CONTRACT_IDS.INSURANCE, 'm', { o: 'G' }, 30, fetchFn),
+        cachedContractCall(CONTRACT_IDS.INSURANCE, 'm', { o: 'G' }, 30, fetchFn),
+      ]);
+
+      // A later sequential call is a plain cache hit — the flight populated it.
+      const r = await cachedContractCall(CONTRACT_IDS.INSURANCE, 'm', { o: 'G' }, 30, fetchFn);
+      expect(r).toEqual({ data: 'cached' });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('clearCache mid-flight resets coalescing so a new caller starts its own fetch', async () => {
+      const d1 = deferred<{ data: string }>();
+      const d2 = deferred<{ data: string }>();
+      const fetchFn = vi
+        .fn()
+        .mockImplementationOnce(() => d1.promise)
+        .mockImplementationOnce(() => d2.promise);
+
+      const p1 = cachedContractCall(CONTRACT_IDS.INSURANCE, 'm', { o: 'G' }, 30, fetchFn);
+
+      // Registry-driven clear lands while the leader's fetch is still pending.
+      clearCache();
+
+      // A new caller for the same key must NOT join the cleared flight.
+      const p2 = cachedContractCall(CONTRACT_IDS.INSURANCE, 'm', { o: 'G' }, 30, fetchFn);
+
+      d1.resolve({ data: 'first' });
+      d2.resolve({ data: 'second' });
+      const [r1, r2] = await Promise.all([p1, p2]);
+
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+      expect(r1).toEqual({ data: 'first' });
+      expect(r2).toEqual({ data: 'second' });
+    });
+  });
 });
 
 describe('CacheError', () => {


### PR DESCRIPTION
Closes #529 

# test(goals): add integration coverage for lifecycle transitions

## Summary

Adds integration coverage for the savings-goals lifecycle routes
(`add`, `withdraw`, `lock`, `unlock`, `completed`, plus `create`/`list`),
asserting auth gating, input validation surfacing, and propagation of invalid
(state-machine) transitions. Documents the lifecycle state machine and a genuine
architectural finding about where state guards are enforced.

## Key finding (documented, not a test artifact)

The `add` / `withdraw` / `lock` / `unlock` routes are **transaction builders**:
they authenticate, validate inputs, then build an **unsigned Soroban XDR** via
`lib/contracts/savings-goals.ts` — they never read goal state. So the lifecycle
guards ("withdraw from a locked goal", "add to a completed goal",
"over-withdraw") are enforced **on-chain by the Soroban contract at submission
time, not by the HTTP routes**. A syntactically valid illegal-transition request
still returns `200 { xdr }`.

Tests therefore assert what the routes actually guarantee (auth, validation,
error envelope, and faithful propagation of a contract-layer rejection as `500`),
and the invalid transitions are exercised by mocking the builder to throw —
proving propagation while documenting the on-chain enforcement boundary. The
recommended follow-up (a server-side pre-flight `getGoal` state check returning
`409`) is captured in `docs/savings-goals-lifecycle.md`. This change set is
test-only.

## Changes

### `tests/integration/api/goals-lifecycle.test.ts` (new)
Mocks the contract layer (`@/lib/contracts/savings-goals`,
`@/lib/contracts/savings-goal`) and `@/lib/session` so no Soroban RPC / env is
needed, then drives the route handlers directly. Coverage:

- **create** (`POST /api/goals`): 401 unauth; 200 + XDR on valid; 400 for
  missing name / non-positive amount / past date.
- **list** (`GET /api/goals`): 401 unauth; 200 paginated when authed.
- **add**: 401 unauth; 200 builds tx; 400 empty id / missing amount / non-positive
  amount; **500 on simulated "add to completed goal"**.
- **withdraw**: 401 unauth; 200 builds tx; 400 non-positive amount;
  **500 on simulated "withdraw from locked goal"**; **500 on simulated
  over-withdraw**.
- **lock**: 401 unauth; 200 builds tx; 400 empty id.
- **unlock**: 401 unauth; 200 builds tx; **unlock → withdraw allowed**
  (valid-transition sequence).
- **completed** (`GET .../completed`): 401 without `x-public-key`; 404 when goal
  missing; 200 `{ completed: true|false }`.

### `tests/integration/api/goals-validation.test.ts` (updated, test-only)
Realigned the assertions to the **current** `lib/errors/api-errors.ts` envelope
`{ success, error: { code, message } }`. The previous assertions expected an
older `{ error, details }` shape that had drifted from the implementation and
was failing — fixing it is required for a green `test:integration`.

### `package.json`
Added the new file to the `test:integration` script so it runs in CI:
```
… && vitest run tests/integration/api/goals-validation.test.ts tests/integration/api/goals-lifecycle.test.ts
```

### `docs/savings-goals-lifecycle.md` (new)
Route table, lifecycle state-machine diagram, the enforcement-boundary finding,
the error envelope, and auth quirks.

## Acceptance criteria

| Requirement                           | Status |
| ------------------------------------- | ------ |
| All lifecycle routes covered          | ✅ add/withdraw/lock/unlock/completed + create/list |
| Invalid transitions rejected          | ✅ asserted via contract-rejection propagation (500); enforcement boundary documented |
| Auth gating asserted                  | ✅ 401 on every route (both auth models) |
| test:integration + lint + tsc clean   | ⚠️ Not run — dependencies unavailable (see below) |

## Verification status

> **Not run.** `node_modules` is not installed in this environment, and several
> dependency-install attempts were declined, so these could not be executed:
> ```
> npm run test:integration
> npm run lint
> npx tsc --noEmit
> ```
> Tests were written against a close reading of the actual route handlers, auth
> helpers, validation module, and error envelope, but remain **unverified** until
> run with dependencies installed.
>
> Pre-existing install blockers (unrelated to this change):
> - `package-lock.json` pins `@babel/parser@7.29.2` with `"os": ["android"]` →
>   `npm install --legacy-peer-deps` fails `EBADPLATFORM` on win32.
> - `next@16` vs `@sentry/nextjs@8` peer conflict → needs `--legacy-peer-deps`.
>
> To verify on a clean machine:
> ```
> npm install --legacy-peer-deps --no-package-lock
> npm run test:integration
> npm run lint
> npx tsc --noEmit
> ```

## Notes

- Tests run on the `.ts`/vitest side of the `tests/integration` conventions, matching
  the existing `goals-validation.test.ts`.
- This work currently sits on branch `test/goals-lifecycle-integration`, but the
  working tree also still carries the earlier (uncommitted) insights-consolidation
  and contract-cache-coalescing changes from this session.
