### PR TITLE
feat(api-client): add timeout + idempotent-GET retry with backoff

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -37,23 +37,41 @@ Real call sites in the repo:
 
 - `apiClient.request(url, options?)`
 - `apiClient.get(url, options?)`
+- `apiClient.head(url, options?)`
 - `apiClient.post(url, options?)`
 - `apiClient.put(url, options?)`
+- `apiClient.patch(url, options?)`
 - `apiClient.delete(url, options?)`
+- `apiClient.getJson<T>(url, options?)`
 
 `ApiClientOptions` extends `RequestInit` and adds:
 
-- `retries?: number`
-- `backoff?: number`
+- `retries?: number` — max retry attempts for idempotent (`GET`/`HEAD`) requests. Default `3`. Ignored for writes.
+- `backoff?: number` — base backoff in ms; doubles each attempt and is jittered. Default `1000`.
+- `timeout?: number` — per-request timeout in ms before the request is aborted. Default `10000`. Pass `0` to disable.
 
 Return type:
 
-- `Promise<Response | null>`
+- `Promise<Response | null>` for the verb helpers and `request`.
+- `Promise<T | null>` for `getJson<T>` (parsed/validated body, or `null` on session expiry).
 
 Interpret the result like this:
 
 - `Response`: the request completed and did not enter the terminal session-expiry flow.
 - `null`: the session-expiry flow already ran, local auth state was cleared, and the UI was notified and scheduled for redirect. Callers should stop work and not show a duplicate auth error.
+
+### Timeout
+
+Every request (regardless of method) runs under a per-request timeout enforced
+with an `AbortController`. The default is `10000` ms and is configurable via the
+`timeout` option (`0` disables it). When the timeout fires, the in-flight fetch
+is aborted. For idempotent requests this counts as a retryable failure; once
+retries are exhausted (or for writes) the call rejects with a `TimeoutError`
+`DOMException`.
+
+The timeout is composed with any caller-supplied `signal`, so a component
+unmount or `useFormAction`'s latest-wins abort still cancels the request
+immediately (see [Aborting requests](#aborting-requests)).
 
 ### Retry Behavior
 
@@ -61,18 +79,56 @@ Before session-expiry logic runs, `apiClient` uses `fetchWithRetry`.
 
 Defaults:
 
-- `retries = 3`
+- `retries = 3` (idempotent methods only)
 - `backoff = 1000`
+- `timeout = 10000`
 
-Automatic retries happen for:
+Automatic retries happen **only for idempotent methods (`GET` and `HEAD`)**, on:
 
 - HTTP `5xx`
 - HTTP `429`
-- Rejected fetches such as network failures
+- Rejected fetches such as network failures and timeouts
 
-Backoff is exponential: each retry doubles the delay.
+Write methods (`POST`, `PUT`, `PATCH`, `DELETE`) are **never** auto-retried, even
+on `5xx`/`429`/network errors. This is deliberate: replaying a write could cause
+a double-submit (e.g. sending a remittance twice). Writes still get a timeout;
+they just fail fast instead of retrying.
 
-Responses such as `400`, `403`, and non-expiry `401` values are returned to the caller without this retry loop treating them as session failures.
+Backoff is exponential with jitter: the delay for each retry is
+`base * 2^attempt`, of which half is fixed and half is randomized ("equal
+jitter") so many clients don't reconverge on the server. When a response carries
+a `Retry-After` header (e.g. on `429`), that value is honored instead of the
+computed backoff (clamped to 30s).
+
+A caller-initiated abort is never retried — it rejects immediately.
+
+Responses such as `400`, `403`, and non-expiry `401` values are returned to the
+caller without this retry loop treating them as session failures.
+
+> Note: this is the **browser** client. Do not confuse it with the server-side
+> RPC retry in [`lib/soroban/client.ts`](../lib/soroban/client.ts); the two layers
+> are independent and should not be stacked on the same call path.
+
+### Typed reads with `getJson<T>()`
+
+`getJson<T>(url, options?)` is a convenience wrapper over `get` for JSON reads:
+
+1. Sends an idempotent `GET` (with the shared timeout + retry behavior).
+2. Returns `null` if the session-expiry flow ran.
+3. Throws `ApiClientError` if the response is not OK or the body is not valid JSON.
+4. Optionally runs a `validate(data) => T` function (e.g. a Zod schema's `parse`)
+   and returns the typed, validated result.
+
+```ts
+import { apiClient, ApiClientError } from '@/lib/client/apiClient';
+
+const insights = await apiClient.getJson('/api/insights', {
+  validate: (raw) => InsightsSchema.parse(raw),
+});
+
+if (insights === null) return; // session-expiry flow already handled
+// insights is typed and validated here
+```
 
 ## `401 -> refresh -> retry once`
 
@@ -315,11 +371,15 @@ You can pass an `AbortSignal` through `ApiClientOptions` because the options ext
 
 Current implementation detail:
 
-- aborted fetches are caught by the generic retry wrapper
-- if `retries > 0`, the client will retry even aborted requests
-- once retries are exhausted, the fetch rejection is thrown to the caller
+- The caller's `signal` is combined with the internal per-request timeout signal,
+  so either source can cancel the in-flight fetch.
+- A caller-initiated abort fails fast: it is surfaced to the caller immediately
+  and is **never** retried, regardless of `retries`.
+- A timeout abort, by contrast, is treated as a retryable failure for idempotent
+  `GET`/`HEAD` requests.
 
-If you need aborts to fail fast without retrying, pass `retries: 0`.
+This makes `apiClient` safe to use with abort-on-unmount patterns such as
+`useFormAction`, where the latest submit aborts the previous in-flight request.
 
 ### Concurrent `401`s
 

--- a/lib/client/apiClient.ts
+++ b/lib/client/apiClient.ts
@@ -1,73 +1,254 @@
 /**
- * API client wrapper with session expiry detection and retry mechanism
- * Automatically handles session expiry, redirects users to re-authenticate, and retries failed requests.
- * 
+ * API client wrapper with session expiry detection, per-request timeouts, and a
+ * safe retry layer.
+ *
+ * This is the **browser** client. It is intentionally separate from the
+ * server-side Soroban retry in `lib/soroban/client.ts`; do not stack the two.
+ *
+ * What it adds on top of `fetch`:
+ * - A configurable per-request timeout via `AbortController` (default 10s) for
+ *   every method.
+ * - Bounded retry with exponential backoff + jitter for **idempotent methods
+ *   only** (`GET`/`HEAD`) on network errors, timeouts, `5xx`, and `429`. Writes
+ *   (`POST`/`PUT`/`PATCH`/`DELETE`) are never auto-retried, so retries can never
+ *   cause a double-submit.
+ * - `Retry-After` awareness (e.g. on `429`) so we honor the server's backoff
+ *   instead of guessing.
+ * - The existing `401 -> refresh -> retry once` session-expiry flow and the
+ *   `Response | null` contract, unchanged.
+ * - An optional typed `getJson<T>()` helper that parses and validates the body.
+ *
+ * Aborts are first-class: a caller-supplied `signal` (e.g. from `useFormAction`
+ * or a component unmount) cancels immediately and is never retried.
+ *
  * @example Basic usage
  * ```typescript
  * import { apiClient } from '@/lib/client/apiClient';
- * 
+ *
  * const data = await apiClient.get('/api/protected/resource');
  * ```
- * 
- * @example With request options
+ *
+ * @example Typed read with validation
  * ```typescript
- * const data = await apiClient.post('/api/protected/action', {
- *   body: JSON.stringify({ key: 'value' }),
- *   headers: { 'Content-Type': 'application/json' },
- *   retries: 2,
- *   backoff: 500
+ * const goals = await apiClient.getJson('/api/goals', {
+ *   validate: (raw) => GoalsSchema.parse(raw), // any throw-on-invalid validator
  * });
+ * ```
+ *
+ * @example Abort on unmount
+ * ```typescript
+ * const controller = new AbortController();
+ * apiClient.get('/api/insights', { signal: controller.signal });
+ * // later: controller.abort();
  * ```
  */
 
 import { sessionHandler } from './sessionHandler';
 
 export interface ApiClientOptions extends RequestInit {
+  /** Max retry attempts for idempotent (GET/HEAD) requests. Ignored for writes. Default 3. */
   retries?: number;
+  /** Base backoff in ms; doubles each attempt and is jittered. Default 1000. */
   backoff?: number;
+  /** Per-request timeout in ms before the request is aborted. `0` disables it. Default 10000. */
+  timeout?: number;
   /** Internal flag used to ensure the 401 -> refresh -> retry happens only once. */
   _isRetry?: boolean;
 }
 
+export interface GetJsonOptions<T> extends Omit<ApiClientOptions, 'method' | 'body'> {
+  /**
+   * Optional validator run against the parsed JSON. Return the typed value or
+   * throw. Works with any throw-on-invalid validator, e.g. a Zod schema:
+   * `validate: (raw) => MySchema.parse(raw)`.
+   */
+  validate?: (data: unknown) => T;
+}
+
 const DEFAULT_RETRIES = 3;
 const DEFAULT_BACKOFF = 1000;
+const DEFAULT_TIMEOUT = 10_000;
+
+/** Upper bound on how long we will honor a `Retry-After` header. */
+const MAX_RETRY_AFTER_MS = 30_000;
+
+/** Methods safe to auto-retry: replaying them cannot change server state. */
+const IDEMPOTENT_METHODS = new Set(['GET', 'HEAD']);
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-async function fetchWithRetry(url: string, options: ApiClientOptions): Promise<Response> {
-  const { retries = DEFAULT_RETRIES, backoff = DEFAULT_BACKOFF, ...fetchOptions } = options;
-  
-  try {
-    const response = await fetch(url, fetchOptions);
+function isIdempotent(method?: string): boolean {
+  // A missing method means `fetch` defaults to GET, which is idempotent.
+  return IDEMPOTENT_METHODS.has((method ?? 'GET').toUpperCase());
+}
 
-    // Retry on 5xx errors or 429 rate limiting
-    if (response.status >= 500 || response.status === 429) {
-      if (retries > 0) {
-        await delay(backoff);
-        return fetchWithRetry(url, { ...options, retries: retries - 1, backoff: backoff * 2 });
+/**
+ * Exponential backoff with "equal jitter": half of the window is fixed and half
+ * is random. This bounds the worst case while spreading retries from many
+ * clients so they don't reconverge on the server (thundering herd).
+ */
+function computeBackoff(base: number, attemptIndex: number): number {
+  const window = base * 2 ** attemptIndex;
+  return window / 2 + Math.random() * (window / 2);
+}
+
+/**
+ * Parses a `Retry-After` header (delta-seconds or HTTP-date) into milliseconds.
+ * Returns `null` when the header is absent or unparseable, so callers fall back
+ * to computed backoff. Clamped to {@link MAX_RETRY_AFTER_MS}.
+ */
+function retryAfterMs(response: Response): number | null {
+  const header = response.headers?.get?.('retry-after');
+  if (!header) return null;
+
+  const seconds = Number(header);
+  let ms: number;
+  if (Number.isFinite(seconds)) {
+    ms = seconds * 1000;
+  } else {
+    const at = Date.parse(header);
+    if (Number.isNaN(at)) return null;
+    ms = at - Date.now();
+  }
+
+  if (ms < 0) ms = 0;
+  return Math.min(ms, MAX_RETRY_AFTER_MS);
+}
+
+/** Normalizes an aborted signal into an `AbortError` for the caller. */
+function abortError(signal?: AbortSignal | null): unknown {
+  const reason = signal?.reason;
+  if (reason) return reason;
+  return new DOMException('The operation was aborted.', 'AbortError');
+}
+
+/**
+ * Combines a caller signal with a per-attempt timeout signal into one signal,
+ * and returns a `cleanup` to detach listeners so retries don't leak handlers.
+ */
+function combineSignals(signals: Array<AbortSignal | null | undefined>): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  const attached: Array<{ signal: AbortSignal; handler: () => void }> = [];
+
+  for (const signal of signals) {
+    if (!signal) continue;
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      break;
+    }
+    const handler = () => controller.abort(signal.reason);
+    signal.addEventListener('abort', handler);
+    attached.push({ signal, handler });
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      for (const { signal, handler } of attached) {
+        signal.removeEventListener('abort', handler);
       }
+    },
+  };
+}
+
+/**
+ * Performs a single `fetch` with timeout + (for idempotent methods) bounded
+ * retry. Caller-initiated aborts short-circuit retries and reject immediately.
+ */
+async function fetchWithRetry(url: string, options: ApiClientOptions): Promise<Response> {
+  const {
+    retries = DEFAULT_RETRIES,
+    backoff = DEFAULT_BACKOFF,
+    timeout = DEFAULT_TIMEOUT,
+    signal: callerSignal,
+    // Stripped so they never reach `fetch`.
+    _isRetry: _ignoredIsRetry,
+    ...fetchOptions
+  } = options;
+
+  // Writes are never auto-retried, eliminating any double-submit risk.
+  const maxRetries = isIdempotent(fetchOptions.method) ? Math.max(0, retries) : 0;
+
+  let attempt = 0;
+
+  for (;;) {
+    // Fail fast if the caller already cancelled.
+    if (callerSignal?.aborted) {
+      throw abortError(callerSignal);
     }
 
-    return response;
-  } catch (error) {
-    // Retry on network errors
-    if (retries > 0) {
-      await delay(backoff);
-      return fetchWithRetry(url, { ...options, retries: retries - 1, backoff: backoff * 2 });
+    const timeoutController = new AbortController();
+    const timer =
+      timeout > 0
+        ? setTimeout(
+            () =>
+              timeoutController.abort(
+                new DOMException(`Request to ${url} timed out after ${timeout}ms`, 'TimeoutError')
+              ),
+            timeout
+          )
+        : null;
+
+    const { signal, cleanup } = combineSignals([callerSignal, timeoutController.signal]);
+
+    let response: Response | undefined;
+    let caught: unknown;
+    try {
+      response = await fetch(url, { ...fetchOptions, signal });
+    } catch (error) {
+      caught = error;
+    } finally {
+      if (timer) clearTimeout(timer);
+      cleanup();
     }
-    throw error;
+
+    if (caught !== undefined) {
+      // A caller abort must surface immediately and never be retried.
+      if (callerSignal?.aborted) {
+        throw abortError(callerSignal);
+      }
+
+      if (attempt < maxRetries) {
+        await delay(computeBackoff(backoff, attempt));
+        attempt += 1;
+        continue;
+      }
+
+      // Out of retries: surface a timeout as a clear error, else the original.
+      if (timeoutController.signal.aborted) {
+        throw timeoutController.signal.reason ?? abortError(timeoutController.signal);
+      }
+      throw caught;
+    }
+
+    const res = response as Response;
+
+    // Retry idempotent requests on transient server states.
+    if ((res.status >= 500 || res.status === 429) && attempt < maxRetries) {
+      const wait = retryAfterMs(res) ?? computeBackoff(backoff, attempt);
+      await delay(wait);
+      attempt += 1;
+      continue;
+    }
+
+    return res;
   }
 }
 
 /**
- * Makes a browser-side request to a RemitWise API route with shared retry and
- * session handling.
+ * Makes a browser-side request to a RemitWise API route with shared timeout,
+ * retry, and session handling.
  *
  * Use this instead of raw `fetch` for authenticated client requests so every
  * page gets the same `401 -> refresh -> retry once` behavior.
  *
  * Flow:
- * - Retries transport failures, `429`, and `5xx` responses with exponential backoff.
+ * - Applies a per-request timeout and retries transport failures, timeouts,
+ *   `429`, and `5xx` responses with exponential backoff + jitter — but only for
+ *   idempotent `GET`/`HEAD` requests.
  * - Detects expired sessions only when the response is a `401` whose JSON body
  *   contains `{ message: 'Session expired' }`.
  * - Attempts `POST /api/auth/refresh` once, then replays the original request once.
@@ -75,35 +256,30 @@ async function fetchWithRetry(url: string, options: ApiClientOptions): Promise<R
  *   cannot recover the request.
  *
  * @param url - API endpoint URL.
- * @param options - Standard `fetch` options plus optional `retries` and `backoff`.
+ * @param options - Standard `fetch` options plus optional `retries`, `backoff`, and `timeout`.
  * @returns The raw `Response`, or `null` when the session-expiry flow has already been triggered.
  */
 async function request(url: string, options?: ApiClientOptions): Promise<Response | null> {
-  try {
-    const response = await fetchWithRetry(url, options || {});
-    
-    // Check if session expired
-    if (await sessionHandler.isSessionExpired(response)) {
-      if (!options?._isRetry) {
-        // Attempt to refresh session
-        const refreshed = await sessionHandler.refreshSession();
-        if (refreshed) {
-          // Retry original request once
-          return request(url, { ...options, _isRetry: true });
-        }
-      }
+  const response = await fetchWithRetry(url, options || {});
 
-      // If refresh failed or already retried, trigger session expiry flow
-      const currentPath = typeof window !== 'undefined' ? window.location.pathname : undefined;
-      sessionHandler.handleSessionExpiry(currentPath);
-      return null;
+  // Check if session expired
+  if (await sessionHandler.isSessionExpired(response)) {
+    if (!options?._isRetry) {
+      // Attempt to refresh session
+      const refreshed = await sessionHandler.refreshSession();
+      if (refreshed) {
+        // Retry original request once
+        return request(url, { ...options, _isRetry: true });
+      }
     }
-    
-    return response;
-  } catch (error) {
-    // Network errors should not clear session state
-    throw error;
+
+    // If refresh failed or already retried, trigger session expiry flow
+    const currentPath = typeof window !== 'undefined' ? window.location.pathname : undefined;
+    sessionHandler.handleSessionExpiry(currentPath);
+    return null;
   }
+
+  return response;
 }
 
 /**
@@ -118,7 +294,19 @@ async function get(url: string, options?: Omit<ApiClientOptions, 'method' | 'bod
 }
 
 /**
- * Sends a `POST` request through {@link request}.
+ * Sends a `HEAD` request through {@link request}. Like `GET`, it is idempotent
+ * and therefore eligible for automatic retries.
+ *
+ * @param url - API endpoint URL.
+ * @param options - `fetch` options except `method` and `body`.
+ * @returns The raw `Response`, or `null` when the session-expiry flow has already been triggered.
+ */
+async function head(url: string, options?: Omit<ApiClientOptions, 'method' | 'body'>): Promise<Response | null> {
+  return request(url, { ...options, method: 'HEAD' });
+}
+
+/**
+ * Sends a `POST` request through {@link request}. Never auto-retried.
  *
  * @param url - API endpoint URL.
  * @param options - `fetch` options except `method`.
@@ -129,7 +317,7 @@ async function post(url: string, options?: Omit<ApiClientOptions, 'method'>): Pr
 }
 
 /**
- * Sends a `PUT` request through {@link request}.
+ * Sends a `PUT` request through {@link request}. Never auto-retried.
  *
  * @param url - API endpoint URL.
  * @param options - `fetch` options except `method`.
@@ -140,7 +328,18 @@ async function put(url: string, options?: Omit<ApiClientOptions, 'method'>): Pro
 }
 
 /**
- * Sends a `DELETE` request through {@link request}.
+ * Sends a `PATCH` request through {@link request}. Never auto-retried.
+ *
+ * @param url - API endpoint URL.
+ * @param options - `fetch` options except `method`.
+ * @returns The raw `Response`, or `null` when the session-expiry flow has already been triggered.
+ */
+async function patch(url: string, options?: Omit<ApiClientOptions, 'method'>): Promise<Response | null> {
+  return request(url, { ...options, method: 'PATCH' });
+}
+
+/**
+ * Sends a `DELETE` request through {@link request}. Never auto-retried.
  *
  * @param url - API endpoint URL.
  * @param options - `fetch` options except `method` and `body`.
@@ -151,16 +350,79 @@ async function del(url: string, options?: Omit<ApiClientOptions, 'method' | 'bod
 }
 
 /**
+ * Typed `GET` + JSON helper. Sends an idempotent `GET` (with the shared timeout
+ * and retry behavior), then parses and optionally validates the body.
+ *
+ * @typeParam T - Expected shape of the parsed body.
+ * @param url - API endpoint URL.
+ * @param options - `get` options plus an optional `validate` function.
+ * @returns The parsed (and validated) body, or `null` when the session-expiry
+ *   flow has already been triggered.
+ * @throws {ApiClientError} when the response is not OK or the body is not valid JSON.
+ * @throws Whatever `validate` throws when validation fails.
+ */
+async function getJson<T = unknown>(url: string, options?: GetJsonOptions<T>): Promise<T | null> {
+  const { validate, ...rest } = options ?? {};
+
+  const response = await get(url, rest);
+  // Session-expiry flow already handled by `request`.
+  if (response === null) return null;
+
+  if (!response.ok) {
+    throw new ApiClientError(
+      `Request to ${url} failed with status ${response.status}`,
+      response.status,
+      response
+    );
+  }
+
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch (error) {
+    throw new ApiClientError(
+      `Failed to parse JSON response from ${url}`,
+      response.status,
+      response,
+      error
+    );
+  }
+
+  return validate ? validate(data) : (data as T);
+}
+
+/**
+ * Typed error thrown by {@link getJson} so callers can distinguish a non-OK
+ * response or a bad body from a transport/abort failure.
+ */
+export class ApiClientError extends Error {
+  public readonly status?: number;
+  public readonly response?: Response;
+  public readonly cause?: unknown;
+
+  constructor(message: string, status?: number, response?: Response, cause?: unknown) {
+    super(message);
+    this.name = 'ApiClientError';
+    this.status = status;
+    this.response = response;
+    this.cause = cause;
+  }
+}
+
+/**
  * Shared browser API client for authenticated requests.
  *
  * Public methods return `Response | null`. `null` means the request ended in the
  * session-expiry flow, so callers should stop work and avoid showing duplicate
- * authentication errors.
+ * authentication errors. `getJson` returns the parsed body (or `null`) instead.
  */
 export const apiClient = {
   request,
   get,
+  head,
   post,
   put,
+  patch,
   delete: del,
+  getJson,
 };

--- a/tests/session/apiClient.test.ts
+++ b/tests/session/apiClient.test.ts
@@ -2,26 +2,19 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { apiClient } from '../../lib/client/apiClient';
 import { sessionHandler } from '../../lib/client/sessionHandler';
 
-// Mock the global fetch
-const originalFetch = global.fetch;
-
-// Mock window object
-const originalWindow = global.window;
-
 describe('apiClient', () => {
   beforeEach(() => {
     // Reset all mocks
     vi.clearAllMocks();
-    
+
     // Create a mock fetch that we can track
-    global.fetch = vi.fn();
-    
-    // Mock window
-    global.window = {
-      location: { pathname: '/current-path' },
-      dispatchEvent: vi.fn(),
-    } as any;
-    
+    vi.stubGlobal('fetch', vi.fn());
+
+    // Note: the jsdom test environment already provides a real `window` (with
+    // `location` and `dispatchEvent`), so we don't stub it. The session-expiry
+    // path that reads `window.location.pathname` runs through the mocked
+    // `handleSessionExpiry` below, so the concrete pathname value is irrelevant.
+
     // Mock the sessionHandler methods
     vi.spyOn(sessionHandler, 'isSessionExpired').mockResolvedValue(false);
     vi.spyOn(sessionHandler, 'refreshSession').mockResolvedValue(true);
@@ -29,8 +22,8 @@ describe('apiClient', () => {
   });
 
   afterEach(() => {
-    global.fetch = originalFetch;
-    global.window = originalWindow;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it('should return response normally on 200 OK', async () => {
@@ -40,7 +33,12 @@ describe('apiClient', () => {
     const response = await apiClient.get('/api/test');
     
     expect(global.fetch).toHaveBeenCalledTimes(1);
-    expect(global.fetch).toHaveBeenCalledWith('/api/test', { method: 'GET' });
+    // apiClient now injects a timeout AbortSignal on every request, so assert on
+    // the method rather than exact-matching the options object.
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/test',
+      expect.objectContaining({ method: 'GET', signal: expect.anything() })
+    );
     expect(response).toBe(mockResponse);
     expect(sessionHandler.isSessionExpired).toHaveBeenCalledWith(mockResponse);
     expect(sessionHandler.refreshSession).not.toHaveBeenCalled();

--- a/tests/unit/apiClient.retry-timeout.test.ts
+++ b/tests/unit/apiClient.retry-timeout.test.ts
@@ -1,0 +1,274 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { apiClient, ApiClientError } from '../../lib/client/apiClient';
+import { sessionHandler } from '../../lib/client/sessionHandler';
+
+// Mock sessionHandler so these tests focus purely on timeout/retry behavior.
+vi.mock('../../lib/client/sessionHandler', () => ({
+  sessionHandler: {
+    isSessionExpired: vi.fn(),
+    refreshSession: vi.fn(),
+    handleSessionExpiry: vi.fn(),
+  },
+}));
+
+const noHeaders = { get: () => null };
+
+/** A fetch mock that hangs until its signal aborts, then rejects with the abort reason. */
+function abortableFetch() {
+  return vi.fn(
+    (_url: string, opts: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        const signal = opts.signal as AbortSignal;
+        signal.addEventListener('abort', () =>
+          reject(signal.reason ?? new DOMException('The operation was aborted.', 'AbortError'))
+        );
+      })
+  );
+}
+
+describe('apiClient timeout + idempotent retry layer', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    vi.clearAllMocks();
+    (sessionHandler.isSessionExpired as any).mockResolvedValue(false);
+    (sessionHandler.refreshSession as any).mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  // ── Timeout ──────────────────────────────────────────────────────────────
+  it('aborts a GET that exceeds the timeout and surfaces a TimeoutError', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', abortableFetch());
+
+    const promise = apiClient.get('/api/slow', { timeout: 100, retries: 0 });
+    const assertion = expect(promise).rejects.toMatchObject({ name: 'TimeoutError' });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await assertion;
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies a timeout to writes too, but does not retry them', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', abortableFetch());
+
+    const promise = apiClient.post('/api/slow', { body: '{}', timeout: 100, retries: 5 });
+    const assertion = expect(promise).rejects.toMatchObject({ name: 'TimeoutError' });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await assertion;
+    expect(fetch).toHaveBeenCalledTimes(1); // never retried
+  });
+
+  // ── Retry then succeed ─────────────────────────────────────────────────────
+  it('retries a GET on 503 then succeeds on 200', async () => {
+    (fetch as any)
+      .mockResolvedValueOnce({ status: 503, headers: noHeaders })
+      .mockResolvedValueOnce({ status: 200, headers: noHeaders });
+
+    const response = await apiClient.get('/api/insights', { retries: 1, backoff: 5 });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(response?.status).toBe(200);
+  });
+
+  it('retries a GET on a network error then succeeds', async () => {
+    (fetch as any)
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce({ status: 200, headers: noHeaders });
+
+    const response = await apiClient.get('/api/insights', { retries: 1, backoff: 5 });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(response?.status).toBe(200);
+  });
+
+  // ── Retry exhausted ─────────────────────────────────────────────────────────
+  it('returns the final 5xx response once GET retries are exhausted', async () => {
+    (fetch as any).mockResolvedValue({ status: 503, headers: noHeaders });
+
+    const response = await apiClient.get('/api/insights', { retries: 2, backoff: 5 });
+
+    expect(fetch).toHaveBeenCalledTimes(3); // initial + 2 retries
+    expect(response?.status).toBe(503);
+  });
+
+  it('throws once GET network retries are exhausted', async () => {
+    (fetch as any).mockRejectedValue(new Error('still down'));
+
+    await expect(apiClient.get('/api/insights', { retries: 1, backoff: 5 })).rejects.toThrow(
+      'still down'
+    );
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  // ── Retry-After ─────────────────────────────────────────────────────────────
+  it('honors Retry-After on 429 for a GET before retrying', async () => {
+    vi.useFakeTimers();
+    const retryAfterHeaders = {
+      get: (name: string) => (name.toLowerCase() === 'retry-after' ? '1' : null),
+    };
+    (fetch as any)
+      .mockResolvedValueOnce({ status: 429, headers: retryAfterHeaders })
+      .mockResolvedValueOnce({ status: 200, headers: noHeaders });
+
+    const promise = apiClient.get('/api/rates', { retries: 1 });
+
+    // Retry-After is 1s; the retry should not fire before then.
+    await vi.advanceTimersByTimeAsync(1000);
+    const response = await promise;
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(response?.status).toBe(200);
+  });
+
+  it('retries an idempotent HEAD on 503 then succeeds', async () => {
+    (fetch as any)
+      .mockResolvedValueOnce({ status: 503, headers: noHeaders })
+      .mockResolvedValueOnce({ status: 200, headers: noHeaders });
+
+    const response = await apiClient.head('/api/x', { retries: 1, backoff: 5 });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(response?.status).toBe(200);
+  });
+
+  it('parses an HTTP-date Retry-After header (past date retries immediately)', async () => {
+    const pastDateHeaders = {
+      get: (name: string) =>
+        name.toLowerCase() === 'retry-after' ? 'Thu, 01 Jan 1970 00:00:00 GMT' : null,
+    };
+    (fetch as any)
+      .mockResolvedValueOnce({ status: 429, headers: pastDateHeaders })
+      .mockResolvedValueOnce({ status: 200, headers: noHeaders });
+
+    const response = await apiClient.get('/api/rates', { retries: 1 });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(response?.status).toBe(200);
+  });
+
+  // ── No retry on writes ──────────────────────────────────────────────────────
+  it('never retries a POST on a 500 response', async () => {
+    (fetch as any).mockResolvedValue({ status: 500, headers: noHeaders });
+
+    const response = await apiClient.post('/api/send', { body: '{}', retries: 5, backoff: 5 });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(response?.status).toBe(500);
+  });
+
+  it('never retries a POST on a network error', async () => {
+    (fetch as any).mockRejectedValue(new Error('flaky'));
+
+    await expect(apiClient.post('/api/send', { body: '{}', retries: 5 })).rejects.toThrow('flaky');
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('never retries PUT/PATCH/DELETE on a 503 response', async () => {
+    (fetch as any).mockResolvedValue({ status: 503, headers: noHeaders });
+
+    for (const call of [
+      () => apiClient.put('/api/x', { body: '{}', retries: 5, backoff: 5 }),
+      () => apiClient.patch('/api/x', { body: '{}', retries: 5, backoff: 5 }),
+      () => apiClient.delete('/api/x', { retries: 5, backoff: 5 }),
+    ]) {
+      (fetch as any).mockClear();
+      const response = await call();
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(response?.status).toBe(503);
+    }
+  });
+
+  // ── Caller-initiated abort ──────────────────────────────────────────────────
+  it('does not fire fetch when the caller signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(apiClient.get('/api/x', { signal: controller.signal })).rejects.toBeDefined();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not retry when the caller aborts mid-flight', async () => {
+    vi.stubGlobal('fetch', abortableFetch());
+    const controller = new AbortController();
+
+    const promise = apiClient.get('/api/x', { signal: controller.signal, retries: 3 });
+    controller.abort();
+
+    await expect(promise).rejects.toBeDefined();
+    expect(fetch).toHaveBeenCalledTimes(1); // aborted, not retried
+  });
+
+  // ── Session-expiry still works ──────────────────────────────────────────────
+  it('still triggers the session-expiry flow on an expired 401', async () => {
+    (fetch as any).mockResolvedValue({ status: 401, headers: noHeaders });
+    (sessionHandler.isSessionExpired as any).mockResolvedValue(true);
+    (sessionHandler.refreshSession as any).mockResolvedValue(false);
+
+    const response = await apiClient.get('/api/x', { retries: 1 });
+
+    expect(response).toBeNull();
+    expect(sessionHandler.handleSessionExpiry).toHaveBeenCalledTimes(1);
+  });
+
+  // ── getJson<T> ──────────────────────────────────────────────────────────────
+  it('getJson parses and returns the typed body', async () => {
+    (fetch as any).mockResolvedValue({
+      status: 200,
+      ok: true,
+      headers: noHeaders,
+      json: async () => ({ value: 42 }),
+    });
+
+    const data = await apiClient.getJson<{ value: number }>('/api/x');
+    expect(data).toEqual({ value: 42 });
+  });
+
+  it('getJson runs the validator against the parsed body', async () => {
+    (fetch as any).mockResolvedValue({
+      status: 200,
+      ok: true,
+      headers: noHeaders,
+      json: async () => ({ n: '7' }),
+    });
+
+    const validate = vi.fn((raw: any) => ({ n: Number(raw.n) }));
+    const data = await apiClient.getJson('/api/x', { validate });
+
+    expect(validate).toHaveBeenCalledWith({ n: '7' });
+    expect(data).toEqual({ n: 7 });
+  });
+
+  it('getJson throws ApiClientError on a non-OK response', async () => {
+    (fetch as any).mockResolvedValue({ status: 500, ok: false, headers: noHeaders });
+
+    await expect(apiClient.getJson('/api/x', { retries: 0 })).rejects.toBeInstanceOf(ApiClientError);
+  });
+
+  it('getJson throws ApiClientError when the body is not valid JSON', async () => {
+    (fetch as any).mockResolvedValue({
+      status: 200,
+      ok: true,
+      headers: noHeaders,
+      json: async () => {
+        throw new SyntaxError('Unexpected token');
+      },
+    });
+
+    await expect(apiClient.getJson('/api/x')).rejects.toBeInstanceOf(ApiClientError);
+  });
+
+  it('getJson returns null when the session-expiry flow runs', async () => {
+    (fetch as any).mockResolvedValue({ status: 401, headers: noHeaders });
+    (sessionHandler.isSessionExpired as any).mockResolvedValue(true);
+    (sessionHandler.refreshSession as any).mockResolvedValue(false);
+
+    const data = await apiClient.getJson('/api/x');
+    expect(data).toBeNull();
+  });
+});

--- a/tests/unit/apiClient.test.ts
+++ b/tests/unit/apiClient.test.ts
@@ -6,6 +6,7 @@ import { sessionHandler } from '../../lib/client/sessionHandler';
 vi.mock('../../lib/client/sessionHandler', () => ({
   sessionHandler: {
     isSessionExpired: vi.fn(),
+    refreshSession: vi.fn().mockResolvedValue(false),
     handleSessionExpiry: vi.fn(),
   }
 }));


### PR DESCRIPTION
Close #594 
---
## Summary

`lib/client/apiClient.ts` (the browser client) wrapped `fetch` with session-expiry
handling but had **no timeout** and an **unsafe retry**: a slow/stalled GET could
hang indefinitely, and — more dangerously — the existing retry loop applied to
*every* HTTP method, so a transient failure on a write (`POST`/`PUT`/`PATCH`/`DELETE`)
could silently re-issue it (double-submit risk). Aborts were also retried instead
of cancelling.

This PR adds a typed retry + timeout layer for idempotent GET/HEAD reads, makes
writes fail fast (never auto-retried), respects `Retry-After`, keeps the
session-expiry flow and `Response | null` contract intact, and adds a typed
`getJson<T>()` helper.
---
## Root cause

- No `AbortController` timeout on any request → slow GETs hang.
- `fetchWithRetry` retried `5xx`/`429`/network errors for **all** methods; since
  `request()` routes every verb through it, writes were being auto-retried →
  double-submit risk.
- Caller-initiated aborts were caught by the retry wrapper and retried rather
  than propagated, breaking abort-on-unmount.
---
## Solution

- **Per-request timeout** via `AbortController` (default 10s, configurable, `0`
  disables) on every method.
- **Bounded retry for idempotent methods only** (`GET`/`HEAD`) on network errors,
  timeouts, `5xx`, and `429`, with exponential backoff + equal jitter. Writes are
  never auto-retried.
- **`Retry-After`** (delta-seconds or HTTP-date, clamped to 30s) honored in place
  of computed backoff.
- **Abort-friendly**: caller `signal` is composed with the timeout signal; a
  caller abort rejects immediately and is never retried (keeps `useFormAction`
  latest-wins cancellation working).
- **Typed reads**: `getJson<T>(url, { validate })` parses + optionally validates,
  returns `null` on session-expiry, throws `ApiClientError` on non-OK/invalid JSON.
- **Unchanged**: `401 → refresh → retry once`, the `_isRetry` flag, and the
  `Response | null` contract.
---
## Key changes

- `lib/client/apiClient.ts` — rewritten timeout/retry core; new `head`, `patch`,
  `getJson` methods and exported `ApiClientError`.
- `tests/unit/apiClient.retry-timeout.test.ts` — new suite (timeout/AbortError,
  503→200, 429 + Retry-After, writes never retried, caller abort, session-expiry
  401, `getJson` happy/validate/error paths).
- `tests/unit/apiClient.test.ts`, `tests/session/apiClient.test.ts` — fixed
  pre-existing mock/env issues so the existing suites run green.
- `docs/client-api.md` — documented the timeout + retry policy, `Retry-After`,
  abort semantics, and `getJson<T>()`.
---
## Trade-offs / considerations

- **Writes are intentionally not retried**, even on `5xx`/network errors, to avoid
  double-submits; callers that need write retries must opt in explicitly with an
  idempotency key. This is the safe default for a remittance app.
- This is the **browser** client and is deliberately independent from the
  server-side RPC retry in `lib/soroban/client.ts`; the two are not stacked.
- A timeout signal is now injected on every request, so tests asserting exact
  `fetch` args were relaxed to match on method + signal.
---
## Testing

```bash
npx tsc --noEmit        # apiClient files type-clean
npm run lint            # clean
npx vitest run tests/unit/apiClient.test.ts \
               tests/unit/apiClient.retry-timeout.test.ts \
               tests/session/apiClient.test.ts --coverage \
               --coverage.include='lib/client/apiClient.ts'
# 28/28 pass — apiClient.ts coverage: 96.93% lines, 100% functions
---
PLEASE KINDLY REVIEW AND PLEASE LET KNOW IF THERE IS ANY FURTHER ADJUSTMENT REGARDING THE TASK! THANK YOU VERY MUCH!!