### PR TITLE
ci: make lint/test/e2e enforcing by removing blanket continue-on-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
-# CI: lint + unit tests + optional integration tests.
+# CI: lint + typecheck + unit tests + integration tests + build.
 # Runs on push/PR to main and dev. Loads .env.test when present; TEST_* can also come from GitHub Secrets.
+#
+# This is an ENFORCING gate: any failing step fails the job. Do not add a blanket
+# `continue-on-error: true` — if a single step is genuinely flaky, scope it to that
+# one step with a comment explaining why.
 name: CI
 
 on:
@@ -26,10 +30,10 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci || true
-        continue-on-error: true
+        run: npm ci
 
       - name: Load .env.test
+        shell: bash
         run: |
           if [ -f .env.test ]; then
             while IFS= read -r line; do
@@ -39,21 +43,22 @@ jobs:
               echo "${name}=${value}" >> "$GITHUB_ENV"
             done < .env.test
           fi
-        shell: bash || true
-        continue-on-error: true
 
       - name: Run lint
-        run: npm run lint || true
-        continue-on-error: true
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc --noEmit
 
       - name: Run unit tests
-        run: npm run test || true
-        continue-on-error: true
+        run: npm run test
 
       - name: Run integration tests
-        run: npm run test:integration || true
-        continue-on-error: true
+        run: npm run test:integration
         env:
           # Optional: set in GitHub Secrets to override or supply when .env.test is not committed
           TEST_SOROBAN_RPC_URL: ${{ secrets.TEST_SOROBAN_RPC_URL }}
           TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,3 +1,5 @@
+# Playwright E2E: enforcing gate. A failing install/test step fails the job.
+# The report artifact still uploads on failure via `if: always()`.
 name: Playwright E2E Tests
 
 on:
@@ -32,22 +34,19 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: npm ci || true
-        continue-on-error: true
+        run: npm ci
 
       - name: Run Unit Tests
-        run: npm run test || true
-        continue-on-error: true
+        run: npm run test
 
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium || true
-        continue-on-error: true
+        run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        run: npm run test:e2e || true
-        continue-on-error: true
+        run: npm run test:e2e
 
       - name: Upload test results
+        # Keep the report even when the Playwright step above fails, so failures are debuggable.
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -328,12 +328,12 @@
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
       "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.5"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
@@ -341,12 +341,14 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@esbuild/android-arm64": {


### PR DESCRIPTION
- Remove continue-on-error: true from all lint, test, build, and Playwright steps
- Add typecheck (npx tsc --noEmit) and build steps to ci.yml
- Keep artifact upload with if: always() so e2e reports upload on failure
- Document CI gate expectations in docs/testing.md and CONTRIBUTING.md

closes #574 