### PR TITLE
refactor(idempotency): make cleanup timer shutdown-aware

### DIFF
--- a/lib/idempotency/store.ts
+++ b/lib/idempotency/store.ts
@@ -5,6 +5,8 @@
  * For production, replace with Redis or database storage.
  */
 
+import { registerShutdownHook } from '../background/runtime';
+import { registerCache } from '../cache/registry';
 import { IdempotencyRecord, IdempotencyCheckResult } from './types';
 
 // In-memory store (replace with Redis/DB in production)
@@ -12,6 +14,13 @@ const store = new Map<string, IdempotencyRecord>();
 
 // Default TTL: 24 hours
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
+const CLEANUP_TIMER_KEY = '__remitwiseIdempotencyCleanupTimer';
+
+type CleanupTimer = ReturnType<typeof setInterval>;
+type CleanupTimerGlobal = typeof globalThis & {
+    [CLEANUP_TIMER_KEY]?: CleanupTimer;
+};
 
 /**
  * Clean up expired records periodically
@@ -25,8 +34,29 @@ function cleanupExpired() {
     }
 }
 
-// Run cleanup every hour
-setInterval(cleanupExpired, 60 * 60 * 1000);
+function startCleanupTimer(): CleanupTimer {
+    const cleanupGlobal = globalThis as CleanupTimerGlobal;
+    if (cleanupGlobal[CLEANUP_TIMER_KEY]) {
+        return cleanupGlobal[CLEANUP_TIMER_KEY];
+    }
+
+    const cleanupTimer = setInterval(cleanupExpired, CLEANUP_INTERVAL_MS);
+    if (typeof cleanupTimer.unref === 'function') {
+        cleanupTimer.unref();
+    }
+
+    cleanupGlobal[CLEANUP_TIMER_KEY] = cleanupTimer;
+    return cleanupTimer;
+}
+
+const cleanupTimer = startCleanupTimer();
+
+registerShutdownHook('idempotency_store_cleanup', () => {
+    clearInterval(cleanupTimer);
+    delete (globalThis as CleanupTimerGlobal)[CLEANUP_TIMER_KEY];
+});
+
+registerCache('idempotency_store', clearIdempotencyStore);
 
 /**
  * Store an idempotency record

--- a/tests/unit/idempotency/store-runtime.test.ts
+++ b/tests/unit/idempotency/store-runtime.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const CLEANUP_TIMER_KEY = '__remitwiseIdempotencyCleanupTimer';
+
+describe('idempotency store runtime integration', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.doUnmock('../../../lib/background/runtime');
+    vi.doUnmock('../../../lib/cache/registry');
+    delete (globalThis as typeof globalThis & Record<string, unknown>)[CLEANUP_TIMER_KEY];
+  });
+
+  it('unrefs the cleanup interval and registers shutdown/cache clearers', async () => {
+    const registeredHooks = new Map<string, () => void | Promise<void>>();
+    const registeredCaches = new Map<string, () => void | Promise<void>>();
+    const timer = { unref: vi.fn() } as unknown as ReturnType<typeof setInterval>;
+
+    const setIntervalSpy = vi
+      .spyOn(globalThis, 'setInterval')
+      .mockReturnValue(timer);
+    const clearIntervalSpy = vi
+      .spyOn(globalThis, 'clearInterval')
+      .mockImplementation(() => undefined);
+
+    vi.doMock('../../../lib/background/runtime', () => ({
+      registerShutdownHook: vi.fn((name: string, hook: () => void | Promise<void>) => {
+        registeredHooks.set(name, hook);
+      }),
+    }));
+    vi.doMock('../../../lib/cache/registry', () => ({
+      registerCache: vi.fn((name: string, clearer: () => void | Promise<void>) => {
+        registeredCaches.set(name, clearer);
+      }),
+    }));
+
+    const store = await import('../../../lib/idempotency/store');
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 60 * 60 * 1000);
+    expect(timer.unref).toHaveBeenCalledTimes(1);
+    expect(registeredHooks.has('idempotency_store_cleanup')).toBe(true);
+    expect(registeredCaches.has('idempotency_store')).toBe(true);
+
+    store.storeIdempotencyRecord('shutdown-key', 'hash', { status: 200, body: {} });
+    expect(store.getStoreSize()).toBe(1);
+
+    await registeredCaches.get('idempotency_store')?.();
+    expect(store.getStoreSize()).toBe(0);
+
+    await registeredHooks.get('idempotency_store_cleanup')?.();
+    expect(clearIntervalSpy).toHaveBeenCalledWith(timer);
+    expect((globalThis as typeof globalThis & Record<string, unknown>)[CLEANUP_TIMER_KEY]).toBeUndefined();
+  });
+
+  it('reuses an existing cleanup timer during module re-evaluation', async () => {
+    const existingTimer = { unref: vi.fn() } as unknown as ReturnType<typeof setInterval>;
+    (globalThis as typeof globalThis & Record<string, unknown>)[CLEANUP_TIMER_KEY] = existingTimer;
+
+    const setIntervalSpy = vi
+      .spyOn(globalThis, 'setInterval')
+      .mockReturnValue(existingTimer);
+
+    vi.doMock('../../../lib/background/runtime', () => ({
+      registerShutdownHook: vi.fn(),
+    }));
+    vi.doMock('../../../lib/cache/registry', () => ({
+      registerCache: vi.fn(),
+    }));
+
+    await import('../../../lib/idempotency/store');
+
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+    expect(existingTimer.unref).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Captures the idempotency cleanup interval, calls `unref()` when available, and reuses an existing timer on module re-evaluation/dev hot reload.
- Registers a graceful-shutdown hook that clears the cleanup interval.
- Registers the idempotency store with the cache registry via the existing `clearIdempotencyStore` function.
- Adds focused Vitest coverage for timer `unref`, shutdown hook clearing, cache registry clearing, and double-start reuse.

Fixes Remitwise-Org/Remitwise-Frontend#659

## Verification
- `npm exec vitest run tests/unit/idempotency/store-runtime.test.ts tests/unit/idempotency/idempotency.test.ts` -> 23 passed / 0 failed
- `git diff --check` -> passed

## Broader checks
- `npx tsc --noEmit` and `npm run lint` are currently blocked on upstream `app/bills/page.tsx`, which contains a merge conflict marker at line 14 before this PR's changes. This PR only touches `lib/idempotency/store.ts` and `tests/unit/idempotency/store-runtime.test.ts`.
