### PR TITLE
fix(metrics): replace spoofable x-admin header with shared isAdminAuthorized guard (#634)

### DIFF
--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -1,15 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { metrics } from '../../../middleware';
-
-// Simple admin check (replace with real auth in production)
-function isAdmin(request: NextRequest) {
-  // Example: check for a header or session
-  return request.headers.get('x-admin') === 'true';
-}
+import { isAdminAuthorized } from '../../../lib/admin/auth';
 
 export async function GET(request: NextRequest) {
-  if (!isAdmin(request)) {
-    return new NextResponse('Unauthorized', { status: 401 });
+  if (!isAdminAuthorized(request)) {
+    return NextResponse.json(
+      { error: 'Unauthorized' },
+      { status: 401 }
+    );
   }
   return NextResponse.json(metrics);
 }


### PR DESCRIPTION
## Summary
Replace the hand-rolled `isAdmin()` check in `app/api/metrics/route.ts` that only verified `x-admin: true` header with the shared `isAdminAuthorized()` guard from `lib/admin/auth.ts` used by all other admin routes.

## Changes
- `app/api/metrics/route.ts`: Replace local `isAdmin()` with `isAdminAuthorized(request)`, return consistent 401 JSON response

## Security Impact
The metrics endpoint previously exposed request counts, rate-limit data, and operational intelligence to anyone who could set an HTTP header. Now uses the same timing-safe `ADMIN_SECRET` guard as all other admin routes.

Closes #634