### PR TITLE
fix(explorer): derive Stellar explorer URL from active network instead of hardcoding public (#638)

### DIFF
--- a/components/TransactionProofCard.tsx
+++ b/components/TransactionProofCard.tsx
@@ -13,6 +13,7 @@ import {
   Wallet,
   ArrowRightLeft,
 } from "lucide-react";
+import { getExplorerTxUrl } from "../lib/config/stellar";
 
 interface TransactionProofProps {
   hash: string;
@@ -212,7 +213,7 @@ export default function TransactionProofCard({
         </div>
 
         <a
-          href={`https://stellar.expert/explorer/public/tx/${hash}`}
+          href={getExplorerTxUrl(hash)}
           target="_blank"
           rel="noopener noreferrer"
           className="w-full flex items-center justify-center gap-2 bg-[#2664eb] hover:bg-blue-700 text-white font-bold py-4 px-4 rounded-xl transition-all shadow-md hover:shadow-lg transform active:scale-[0.98]"

--- a/lib/config/stellar.ts
+++ b/lib/config/stellar.ts
@@ -14,3 +14,24 @@ export const CONTRACTS = {
     mainnet: process.env.REMITTANCE_SPLIT_CONTRACT_ID || 'CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
   }
 };
+
+/**
+ * Returns the Stellar explorer segment ('testnet' | 'public') for the active network.
+ * Uses NEXT_PUBLIC_STELLAR_NETWORK for client-side code, falls back to STELLAR_NETWORK
+ * for server-side, defaulting to 'testnet'.
+ */
+export function getExplorerNetworkSegment(): 'testnet' | 'public' {
+  const network =
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK ||
+    process.env.STELLAR_NETWORK ||
+    'testnet';
+  return network === 'mainnet' || network === 'public' ? 'public' : 'testnet';
+}
+
+/**
+ * Returns a full Stellar Expert explorer URL for a transaction hash.
+ */
+export function getExplorerTxUrl(hash: string): string {
+  const segment = getExplorerNetworkSegment();
+  return `https://stellar.expert/explorer/${segment}/tx/${hash}`;
+}


### PR DESCRIPTION
## Summary
Fix the Stellar explorer link in `TransactionProofCard` to respect testnet vs public network instead of hardcoding `public`.

## Changes
- `lib/config/stellar.ts`: Add `getExplorerNetworkSegment()` and `getExplorerTxUrl(hash)` helpers that read `NEXT_PUBLIC_STELLAR_NETWORK` (client) or `STELLAR_NETWORK` (server)
- `components/TransactionProofCard.tsx`: Use `getExplorerTxUrl(hash)` instead of hardcoded `https://stellar.expert/explorer/public/tx/${hash}`

## Why
The app runs on testnet by default but the explorer link was hardcoded to `public`, causing 404s when users click "View on explorer" for testnet transactions.

Closes #638