### PR TITLE
refactor(prisma): consolidate lib/db.ts into lib/prisma.ts singleton (#635)

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,38 +1,4 @@
-import { PrismaClient } from "@prisma/client";
-
-declare global {
-  // eslint-disable-next-line no-var
-  var prisma: PrismaClient | undefined;
-}
-
-function getDatabaseUrl(): string | undefined {
-  const urlString = process.env.DATABASE_URL;
-  if (!urlString) return undefined;
-  try {
-    const url = new URL(urlString);
-    if (!url.searchParams.has("connection_limit")) {
-      url.searchParams.set("connection_limit", "10");
-    }
-    if (!url.searchParams.has("connect_timeout")) {
-      url.searchParams.set("connect_timeout", "5");
-    }
-    if (!url.searchParams.has("pool_timeout")) {
-      url.searchParams.set("pool_timeout", "5");
-    }
-    return url.toString();
-  } catch (e) {
-    return urlString;
-  }
-}
-
-const dbUrl = getDatabaseUrl();
-
-const prisma = global.prisma || new PrismaClient({
-  ...(dbUrl ? { datasources: { db: { url: dbUrl } } } : {}),
-});
-
-if (process.env.NODE_ENV !== "production") {
-  global.prisma = prisma;
-}
-
-export default prisma;
+// lib/db.ts — re-exports the canonical Prisma client from lib/prisma.ts
+// This module is kept for backward compatibility. New code should import
+// directly from '@/lib/prisma'.
+export { prisma as default } from './prisma';


### PR DESCRIPTION
## Summary
Consolidate the two near-identical Prisma client modules into one singleton.

## Changes
- `lib/db.ts`: Replace duplicate PrismaClient code with `export { prisma as default } from './prisma'`
- No changes needed to any of the 4 existing importers (webhook processor, admin users route, health route, tests)

## Why
Two `PrismaClient` singletons keyed off two different globals can open two connection pools (10 connections each) in the same process and produce divergent logging behavior. One module = one pool, one config.

Closes #635