### PR TITLE
feat(split): add Zod request validation to split routes (#660)

### DIFF
--- a/app/api/split/calculate/route.ts
+++ b/app/api/split/calculate/route.ts
@@ -1,21 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth, ApiError } from '@/lib/auth';
 import { calculateSplit } from '@/lib/contracts/remittance-split';
+import { splitCalculateQuerySchema } from '@/lib/validation/split-schemas';
+import { createValidationError } from '@/lib/errors/api-errors';
 
 async function handler(request: NextRequest, session: string) {
   try {
     const { searchParams } = new URL(request.url);
-    const amountStr = searchParams.get('amount');
-    
-    if (!amountStr) {
-      throw new ApiError(400, 'Amount parameter required');
+    const raw = { amount: searchParams.get('amount') };
+
+    const parsed = splitCalculateQuerySchema.safeParse(raw);
+    if (!parsed.success) {
+      const fieldErrors = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+      return createValidationError('Query parameter validation failed', fieldErrors);
     }
-    
-    const amount = parseFloat(amountStr);
-    if (isNaN(amount) || amount <= 0) {
-      throw new ApiError(400, 'Invalid amount');
-    }
-    
+
+    const { amount } = parsed.data;
+
     const env = (process.env.STELLAR_NETWORK as 'testnet' | 'mainnet') || 'testnet';
     const amounts = await calculateSplit(amount, env);
     

--- a/app/api/split/initialize/route.ts
+++ b/app/api/split/initialize/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSession } from '@/lib/auth/session';
 import { buildInitializeSplitTx } from '@/lib/contracts/remittance-split';
-import { SplitPercentages, ValidationError } from '@/lib/validation/percentages';
+import { ValidationError } from '@/lib/validation/percentages';
+import { splitPercentagesSchema } from '@/lib/validation/split-schemas';
+import { createValidationError } from '@/lib/errors/api-errors';
 
 export async function POST(request: NextRequest) {
   try {
@@ -15,28 +17,28 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // 2. Parse request body
-    let body: SplitPercentages;
-    try {
-      body = await request.json();
-    } catch {
-      return NextResponse.json(
-        { success: false, error: 'Invalid JSON in request body' },
-        { status: 400 }
-      );
+    // 2. Parse and validate request body with Zod
+    const rawBody = await request.json().catch(() => null);
+    if (rawBody === null) {
+      return createValidationError('Invalid JSON in request body');
     }
 
-    // 3. Extract percentages
-    const { spending, savings, bills, insurance } = body;
+    const parsed = splitPercentagesSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      const fieldErrors = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+      return createValidationError('Request validation failed', fieldErrors);
+    }
 
-    // 4. Build transaction using session address as owner
+    const { spending, savings, bills, insurance } = parsed.data;
+
+    // 3. Build transaction using session address as owner
     const result = await buildInitializeSplitTx(
       session.address,
       { spending, savings, bills, insurance },
-      { simulate: true } // Include simulation for cost estimation
+      { simulate: true }
     );
 
-    // 5. Return success response
+    // 4. Return success response
     return NextResponse.json({
       success: true,
       xdr: result.xdr,
@@ -47,10 +49,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     // Handle validation errors
     if (error instanceof ValidationError) {
-      return NextResponse.json(
-        { success: false, error: error.message },
-        { status: 400 }
-      );
+      return createValidationError(error.message);
     }
 
     // Handle other errors

--- a/app/api/split/update/route.ts
+++ b/app/api/split/update/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSession } from '@/lib/auth/session';
 import { buildUpdateSplitTx } from '@/lib/contracts/remittance-split';
-import { SplitPercentages, ValidationError } from '@/lib/validation/percentages';
+import { ValidationError } from '@/lib/validation/percentages';
+import { splitPercentagesSchema } from '@/lib/validation/split-schemas';
+import { createValidationError } from '@/lib/errors/api-errors';
 
 export async function POST(request: NextRequest) {
   try {
@@ -15,28 +17,28 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // 2. Parse request body
-    let body: SplitPercentages;
-    try {
-      body = await request.json();
-    } catch {
-      return NextResponse.json(
-        { success: false, error: 'Invalid JSON in request body' },
-        { status: 400 }
-      );
+    // 2. Parse and validate request body with Zod
+    const rawBody = await request.json().catch(() => null);
+    if (rawBody === null) {
+      return createValidationError('Invalid JSON in request body');
     }
 
-    // 3. Extract percentages
-    const { spending, savings, bills, insurance } = body;
+    const parsed = splitPercentagesSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      const fieldErrors = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+      return createValidationError('Request validation failed', fieldErrors);
+    }
 
-    // 4. Build transaction using session address as caller
+    const { spending, savings, bills, insurance } = parsed.data;
+
+    // 3. Build transaction using session address as caller
     const result = await buildUpdateSplitTx(
       session.address,
       { spending, savings, bills, insurance },
-      { simulate: true } // Include simulation for cost estimation
+      { simulate: true }
     );
 
-    // 5. Return success response
+    // 4. Return success response
     return NextResponse.json({
       success: true,
       xdr: result.xdr,
@@ -47,10 +49,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     // Handle validation errors
     if (error instanceof ValidationError) {
-      return NextResponse.json(
-        { success: false, error: error.message },
-        { status: 400 }
-      );
+      return createValidationError(error.message);
     }
 
     // Handle other errors

--- a/lib/validation/split-schemas.ts
+++ b/lib/validation/split-schemas.ts
@@ -1,0 +1,23 @@
+// Zod schemas for split route request validation
+import { z } from 'zod';
+
+export const splitPercentagesSchema = z.object({
+  spending: z.number().nonnegative('spending must be non-negative'),
+  savings: z.number().nonnegative('savings must be non-negative'),
+  bills: z.number().nonnegative('bills must be non-negative'),
+  insurance: z.number().nonnegative('insurance must be non-negative'),
+}).refine(
+  (data) => Math.abs(data.spending + data.savings + data.bills + data.insurance - 100) <= 0.01,
+  { message: 'Percentages must sum to 100' }
+);
+
+export const splitCalculateQuerySchema = z.object({
+  amount: z.coerce.number().positive('amount must be a positive number'),
+});
+
+export const splitAddressSchema = z.string().regex(
+  /^G[A-Z2-7]{55}$/,
+  'Invalid Stellar address format'
+);
+
+export type SplitPercentagesInput = z.infer<typeof splitPercentagesSchema>;


### PR DESCRIPTION
## Summary
Add Zod request validation to the Smart Money Split API routes to prevent unvalidated input from reaching the contract-build path.

## Changes
- `lib/validation/split-schemas.ts` (new): Zod schemas for split percentages (non-negative, sum to 100) and calculate query params (positive amount)
- `app/api/split/initialize/route.ts`: Validate POST body with Zod
- `app/api/split/update/route.ts`: Validate POST body with Zod
- `app/api/split/calculate/route.ts`: Validate `amount` query param with Zod

All validation errors return structured 400 responses with field-level error details via `createValidationError`.

Closes #660