### PR TITLE
fix(health): replace hardcoded anchor placeholder with real HTTP probe (#650)

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -32,7 +32,7 @@ export async function GET() {
   try {
     await Promise.race([
       prisma.$queryRaw`SELECT 1`,
-      new Promise((_, reject) => 
+      new Promise((_, reject) =>
         setTimeout(() => reject(new Error('Database query timeout')), 5000)
       )
     ]);
@@ -71,10 +71,29 @@ export async function GET() {
   }
 
   // ── 3. Anchor ────────────────────────────────────────────────────
-  // Placeholder — swap for a real HTTP probe once an anchor URL is configured
-  const anchor: { reachable: boolean; error?: string } = { reachable: true };
+  // Probe the anchor platform URL if configured (non-critical check)
+  let anchor: { reachable: boolean; error?: string };
+  const anchorUrl = process.env.ANCHOR_PLATFORM_URL;
+  if (anchorUrl) {
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000);
+      const res = await fetch(`${anchorUrl}/info`, { signal: controller.signal });
+      clearTimeout(timeoutId);
+      if (res.ok) {
+        anchor = { reachable: true };
+      } else {
+        anchor = { reachable: false, error: `Anchor returned status ${res.status}` };
+      }
+    } catch (err: any) {
+      anchor = { reachable: false, error: err?.message ?? "unreachable" };
+    }
+  } else {
+    anchor = { reachable: false, error: "ANCHOR_PLATFORM_URL not configured" };
+  }
 
   // ── 4. Overall status ────────────────────────────────────────────
+  // Anchor is non-critical: only database and RPC determine overall health
   const healthy = database.reachable && rpc.reachable;
 
   return NextResponse.json(


### PR DESCRIPTION
## Summary
Replaces the hardcoded `anchor: { reachable: true }` placeholder in `/api/health` with a real HTTP probe to the anchor platform, matching the pattern already used in `/api/v1/health`.

## Changes
- Reads `ANCHOR_PLATFORM_URL` from env vars
- Probes `{anchorUrl}/info` with a 5-second timeout
- Anchor check is **non-critical** — does not affect overall health status
- Graceful error handling when anchor URL is not configured

## Testing
- [ ] Verify `/api/health` returns real anchor status when `ANCHOR_PLATFORM_URL` is set
- [ ] Verify `/api/health` returns anchor error when URL is not configured
- [ ] Verify overall health status is unaffected by anchor check

Closes #650