### PR TITLE
fix(idempotency): make cleanup timer shutdown-aware instead of leaking module-level setInterval (#659)

### DIFF
--- a/lib/idempotency/store.ts
+++ b/lib/idempotency/store.ts
@@ -1,10 +1,11 @@
 /**
  * Idempotency Store
- * 
+ *
  * In-memory cache for idempotency keys with TTL support.
  * For production, replace with Redis or database storage.
  */
 
+import { registerShutdownHook } from '../background/runtime';
 import { IdempotencyRecord, IdempotencyCheckResult } from './types';
 
 // In-memory store (replace with Redis/DB in production)
@@ -25,8 +26,18 @@ function cleanupExpired() {
     }
 }
 
-// Run cleanup every hour
-setInterval(cleanupExpired, 60 * 60 * 1000);
+// Run cleanup every hour; capture the timer so shutdown can clear it
+const cleanupTimer = setInterval(cleanupExpired, 60 * 60 * 1000);
+
+/** Stop the background cleanup timer (idempotent). */
+export function stopIdempotencyCleanup(): void {
+    clearInterval(cleanupTimer);
+}
+
+// Register with graceful shutdown so the timer doesn't keep the process alive
+registerShutdownHook('idempotency-store', () => {
+    stopIdempotencyCleanup();
+});
 
 /**
  * Store an idempotency record


### PR DESCRIPTION
Hi! I would like to work on this issue.

## Problem
`lib/idempotency/store.ts` starts a cleanup timer at module import time with `setInterval(cleanupExpired, 60 * 60 * 1000)` but the timer ID is never captured or cleared. This leaks the interval — it keeps the Node.js process alive during graceful shutdown and is never registered with the shutdown runtime.

## Approach
- Capture the `setInterval` return value in a `cleanupTimer` constant
- Export a `stopIdempotencyCleanup()` function that calls `clearInterval(cleanupTimer)`
- Register a shutdown hook via `registerShutdownHook('idempotency-store', ...)` from `lib/background/runtime.ts`
- The hook calls `stopIdempotencyCleanup()` on SIGTERM/SIGINT

## Files modified
- `lib/idempotency/store.ts` — capture timer, export cleanup, register shutdown hook

## Effort estimate
Small — single file, ~14 lines added, follows existing shutdown hook pattern in the codebase.

Closes #659