### PR TITLE
fix(a11y): add aria-disabled/aria-expanded semantics to SettingsItem (#662)

### DIFF
--- a/components/SettingsItem.tsx
+++ b/components/SettingsItem.tsx
@@ -48,6 +48,7 @@ export default function SettingsItem({
           divider ? "border-b border-zinc-800" : ""
         } ${type !== "toggle" && onClick ? "cursor-pointer" : ""}`}
         onClick={type !== "toggle" ? onClick : undefined}
+        aria-disabled={comingSoon ? "true" : undefined}
       >
         {/* Left side: Icon + Text */}
         <div className="flex items-center gap-4 flex-1 min-w-0">
@@ -85,6 +86,11 @@ export default function SettingsItem({
           type !== "toggle" && type !== "text" ? "cursor-pointer" : ""
         } group`}
         onClick={type !== "toggle" && type !== "text" ? onClick : undefined}
+        role={type === "dropdown" ? "button" : undefined}
+        aria-disabled={comingSoon ? "true" : undefined}
+        aria-expanded={type === "dropdown" ? hasDropdownBar : undefined}
+        aria-controls={type === "dropdown" && hasDropdownBar ? `dropdown-${title.replace(/\s+/g, "-").toLowerCase()}` : undefined}
+        tabIndex={comingSoon ? -1 : 0}
       >
         <div className="flex items-center gap-3 flex-1 min-w-0">
           {icon && (
@@ -129,7 +135,12 @@ export default function SettingsItem({
       
       {/* Dropdown bar for dropdown type items */}
       {hasDropdownBar && (
-        <div className="px-4 pb-4">
+        <div
+          id={`dropdown-${title.replace(/\s+/g, "-").toLowerCase()}`}
+          className="px-4 pb-4"
+          role="region"
+          aria-label={`${title} dropdown`}
+        >
           <div className="flex items-center gap-2 bg-[#161616] rounded-lg px-3 py-2.5 border border-gray-700/20">
             <ChevronDown className="w-4 h-4 text-gray-500" />
           </div>


### PR DESCRIPTION
Hi! I would like to work on this issue.

## Problem
`components/SettingsItem.tsx` supports `toggle`, `navigation`, `text`, and `dropdown` variants but does not expose ARIA attributes for assistive technology. Disabled/Coming Soon items lack `aria-disabled`, and the dropdown variant lacks `aria-expanded`/`aria-controls`.

## Approach
- Add `aria-disabled="true"` to disabled/Coming Soon items in both default and notification-row variants
- Add `role="button"`, `aria-expanded`, and `aria-controls` to dropdown type items
- Add `tabIndex={-1}` to comingSoon items to remove from tab order
- Add `id`, `role="region"`, and `aria-label` to dropdown bar for `aria-controls` reference

## Files modified
- `components/SettingsItem.tsx`

Closes #662