### PR TITLE
feat(dashboard): add explicit loading skeleton state to all dashboard widgets (#652)

### DIFF
--- a/components/Dashboard/MoneyDistributionWidget.tsx
+++ b/components/Dashboard/MoneyDistributionWidget.tsx
@@ -88,14 +88,56 @@ interface MoneyDistributionWidgetProps {
   distributionData?: typeof data;
   /** Pass true to show the error state */
   hasError?: boolean;
+  /** Pass true to show the loading skeleton state */
+  isLoading?: boolean;
+}
+
+function MoneyDistributionSkeleton() {
+  return (
+    <div className="rounded-3xl border border-white/10 bg-gradient-to-b from-[#0f0f0f] via-[#0b0b0b] to-[#090909] p-8 text-white shadow-[0_30px_60px_rgba(0,0,0,0.45)] lg:w-[50%] w-full animate-pulse">
+      <div className="flex flex-wrap items-start justify-between gap-6">
+        <div className="space-y-3">
+          <div className="h-9 w-9 rounded-full bg-white/10" />
+          <div className="h-7 w-48 rounded bg-white/10" />
+          <div className="h-4 w-36 rounded bg-white/5" />
+        </div>
+        <div className="space-y-2 text-right">
+          <div className="h-4 w-12 rounded bg-white/5" />
+          <div className="h-9 w-28 rounded bg-white/10" />
+        </div>
+      </div>
+      <div className="mt-8 flex flex-col gap-10 items-start">
+        <div className="h-[280px] w-full rounded-2xl bg-white/5" />
+        <div className="w-[90%] sm:w-full">
+          <div className="grid w-full grid-cols-2 gap-x-10 gap-y-4">
+            {[0, 1, 2, 3].map((i) => (
+              <div key={i} className="flex items-start gap-3">
+                <div className="mt-2 h-3 w-3 rounded-full bg-white/10" />
+                <div className="space-y-2 flex-1">
+                  <div className="h-3 w-16 rounded bg-white/5" />
+                  <div className="h-4 w-20 rounded bg-white/10" />
+                  <div className="h-3 w-12 rounded bg-white/5" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default function MoneyDistributionWidget({
   distributionData = data,
   hasError = false,
+  isLoading = false,
 }: MoneyDistributionWidgetProps) {
   const [retryKey, setRetryKey] = useState(0);
   const handleRetry = useCallback(() => setRetryKey((k) => k + 1), []);
+
+  if (isLoading) {
+    return <MoneyDistributionSkeleton />;
+  }
 
   const isEmpty = !hasError && distributionData.length === 0;
   const total = distributionData.reduce(

--- a/components/Dashboard/RecentTransactionsWidget.tsx
+++ b/components/Dashboard/RecentTransactionsWidget.tsx
@@ -98,16 +98,69 @@ interface RecentTransactionsWidgetProps {
     transactions?: Transaction[];
     /** Pass true to show the error state */
     hasError?: boolean;
+    /** Pass true to show the loading skeleton state */
+    isLoading?: boolean;
+}
+
+function RecentTransactionsSkeleton() {
+    return (
+        <div className="bg-[#0A0A0A] rounded-2xl border border-white/10 p-6 w-full animate-pulse">
+            <div className="flex justify-between items-start mb-8">
+                <div className="space-y-2">
+                    <div className="h-7 w-48 rounded bg-white/10" />
+                    <div className="h-4 w-32 rounded bg-white/5" />
+                </div>
+                <div className="h-4 w-20 rounded bg-white/10" />
+            </div>
+            <div className="hidden md:block">
+                <div className="grid grid-cols-5 gap-4 border-b border-white/5 pb-4 mb-4">
+                    {Array.from({ length: 5 }).map((_, i) => (
+                        <div key={i} className="h-4 rounded bg-white/5" />
+                    ))}
+                </div>
+                {Array.from({ length: 5 }).map((_, i) => (
+                    <div key={i} className="grid grid-cols-5 gap-4 py-4 border-b border-white/5">
+                        <div className="h-4 w-24 rounded bg-white/5" />
+                        <div className="h-4 w-36 rounded bg-white/10" />
+                        <div className="h-6 w-20 rounded-full bg-white/5 mx-auto" />
+                        <div className="h-4 w-16 rounded bg-white/10 ml-auto" />
+                        <div className="h-6 w-20 rounded-full bg-white/5 ml-auto" />
+                    </div>
+                ))}
+            </div>
+            <div className="md:hidden space-y-4">
+                {Array.from({ length: 3 }).map((_, i) => (
+                    <div key={i} className="bg-white/[0.03] rounded-xl border border-white/5 p-5">
+                        <div className="flex justify-between items-start mb-2">
+                            <div className="h-5 w-32 rounded bg-white/10" />
+                            <div className="h-6 w-20 rounded-full bg-white/5" />
+                        </div>
+                        <div className="flex items-center gap-2 mb-4">
+                            <div className="h-3 w-20 rounded bg-white/5" />
+                            <div className="h-1 w-1 rounded-full bg-white/10" />
+                            <div className="h-3 w-16 rounded bg-white/5" />
+                        </div>
+                        <div className="h-7 w-24 rounded bg-white/10" />
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
 }
 
 const RecentTransactionsWidget = ({
     transactions = mockTransactions,
     hasError = false,
+    isLoading = false,
 }: RecentTransactionsWidgetProps) => {
     const { density } = useDensity();
     const isCompact = density === 'compact';
     const [retryKey, setRetryKey] = useState(0);
     const handleRetry = useCallback(() => setRetryKey((k) => k + 1), []);
+
+    if (isLoading) {
+        return <RecentTransactionsSkeleton />;
+    }
 
     const isEmpty = !hasError && transactions.length === 0;
 

--- a/components/Dashboard/SavingsByGoalWidget.tsx
+++ b/components/Dashboard/SavingsByGoalWidget.tsx
@@ -16,6 +16,36 @@ interface SavingsByGoalWidgetProps {
   goals?: SavingsGoal[]
   /** Pass true to show the error state */
   hasError?: boolean
+  /** Pass true to show the loading skeleton state */
+  isLoading?: boolean
+}
+
+function SavingsByGoalSkeleton() {
+  return (
+    <div className="bg-[#0f0f0f] rounded-2xl p-6 border border-gray-800 w-full animate-pulse">
+      <div className="flex items-center gap-3 mb-2">
+        <div className="h-6 w-6 rounded bg-white/10" />
+        <div className="h-7 w-36 rounded bg-white/10" />
+      </div>
+      <div className="h-4 w-28 rounded bg-white/5 mb-6" />
+      <div className="space-y-6">
+        {[0, 1, 2].map((i) => (
+          <div key={i}>
+            <div className="flex justify-between items-center mb-2">
+              <div className="h-4 w-28 rounded bg-white/10" />
+              <div className="flex items-center gap-3">
+                <div className="h-4 w-14 rounded bg-white/10" />
+                <div className="h-3 w-8 rounded bg-white/5" />
+              </div>
+            </div>
+            <div className="w-full bg-gray-800 rounded-full h-2.5 overflow-hidden">
+              <div className="bg-white/10 h-2.5 rounded-full w-3/4" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 export default function SavingsByGoalWidget({
@@ -25,9 +55,14 @@ export default function SavingsByGoalWidget({
     { name: 'Medical Fund', amount: 310, percentage: 19 },
   ],
   hasError = false,
+  isLoading = false,
 }: SavingsByGoalWidgetProps) {
   const [retryKey, setRetryKey] = useState(0)
   const handleRetry = useCallback(() => setRetryKey((k) => k + 1), [])
+
+  if (isLoading) {
+    return <SavingsByGoalSkeleton />;
+  }
 
   const isEmpty = !hasError && goals.length === 0
 

--- a/components/Dashboard/SixMonthTrendsWidget.tsx
+++ b/components/Dashboard/SixMonthTrendsWidget.tsx
@@ -97,7 +97,38 @@ function SummaryCard({ icon, label, value, subtitle, variant = 'default', valueC
     )
 }
 
-export default function SixMonthTrendsWidget() {
+export default function SixMonthTrendsWidget({ isLoading = false }: { isLoading?: boolean }) {
+    if (isLoading) {
+        return (
+            <div className="flex flex-col items-start pt-[25px] px-[25px] pb-[16px] gap-6 rounded-2xl border border-[rgba(255,255,255,0.08)] w-full max-w-[928px] animate-pulse" style={{ background: 'linear-gradient(180deg, #0F0F0F 0%, #0A0A0A 100%)' }}>
+                <div className="flex flex-row items-center justify-between gap-4 w-full">
+                    <div className="flex flex-col gap-1">
+                        <div className="flex items-center gap-2">
+                            <div className="h-5 w-5 rounded bg-white/10" />
+                            <div className="h-7 w-36 rounded bg-white/10" />
+                        </div>
+                        <div className="h-4 w-44 rounded bg-white/5" />
+                    </div>
+                    <div className="h-7 w-24 rounded-lg bg-white/10" />
+                </div>
+                <div className="w-full h-[280px] sm:h-[320px] rounded-2xl bg-white/5" />
+                <div className="w-full border-t border-[rgba(255,255,255,0.08)] pt-[25px]">
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                        {[0, 1, 2].map((i) => (
+                            <div key={i} className="flex flex-col items-start gap-2 pt-[17px] px-[17px] pb-[1px] rounded-[14px] bg-white/5 border border-white/5">
+                                <div className="flex items-center gap-2">
+                                    <div className="h-4 w-4 rounded bg-white/10" />
+                                    <div className="h-3 w-20 rounded bg-white/10" />
+                                </div>
+                                <div className="h-7 w-24 rounded bg-white/10" />
+                                <div className="h-3 w-16 rounded bg-white/5" />
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        );
+    }
     return (
         <div
             className="flex flex-col items-start pt-[25px] px-[25px] pb-[16px] gap-6 rounded-2xl border border-[rgba(255,255,255,0.08)] w-full max-w-[928px]"


### PR DESCRIPTION
Hi! I would like to work on this issue.

## Problem
The four dashboard widgets (MoneyDistribution, SixMonthTrends, RecentTransactions, SavingsByGoal) render no loading state — content pops in abruptly when data arrives.

## Approach
Add an `isLoading` prop to each widget. When `isLoading=true`, render an animated skeleton placeholder that mirrors the widget's actual layout:

- **MoneyDistributionWidget**: header + pie chart + 4 legend items
- **SixMonthTrendsWidget**: header + chart + 3 summary cards
- **RecentTransactionsWidget**: header + desktop table + mobile cards
- **SavingsByGoalWidget**: header + 3 progress bars

All skeletons use `animate-pulse` matching the existing design system.

## Files modified
- `components/Dashboard/MoneyDistributionWidget.tsx`
- `components/Dashboard/SixMonthTrendsWidget.tsx`
- `components/Dashboard/RecentTransactionsWidget.tsx`
- `components/Dashboard/SavingsByGoalWidget.tsx`

Closes #652