### PR TITLE
feat: implement localized contract error message system with full i18…

### DIFF
--- a/app/bills/page.tsx
+++ b/app/bills/page.tsx
@@ -11,7 +11,6 @@ import { ActionState } from "@/lib/auth/middleware";
 import { useFormAction } from "@/lib/hooks/useFormAction";
 import AsyncOperationsPanel from "@/components/AsyncOperationsPanel";
 import AsyncSubmissionStatus from "@/components/AsyncSubmissionStatus";
-<<<<<<< HEAD
 import { apiClient } from "@/lib/client/apiClient";
 import { Bill } from "@/lib/contracts/bill-payments";
 import { WidgetErrorState } from "@/components/ui/WidgetStates";

--- a/lib/errors/contract-errors.ts
+++ b/lib/errors/contract-errors.ts
@@ -5,6 +5,10 @@ export enum ContractErrorCategory {
   EXECUTION_FAILED = 'EXECUTION_FAILED',
 }
 
+// Compatibility aliases
+export type ErrorCategory = ContractErrorCategory;
+export const ErrorCategory = ContractErrorCategory;
+
 export class ContractError extends Error {
   constructor(
     public category: ContractErrorCategory,
@@ -18,9 +22,158 @@ export class ContractError extends Error {
   }
 }
 
-// Support optional arguments and context blocks seamlessly
-export const parseContractError = (err: any, context?: any) => {
-  return new ContractError(ContractErrorCategory.EXECUTION_FAILED, 'CONTRACT_EXEC_ERROR', String(err?.message || err));
+export enum ContractErrorCode {
+  INVALID_INPUT = 1000,
+  INVALID_AMOUNT = 1001,
+  INVALID_RECIPIENT = 1002,
+  UNAUTHORIZED = 2000,
+  FORBIDDEN = 2001,
+  NOT_FOUND = 3000,
+  EXECUTION_FAILED = 4000,
+  CONTRACT_EXEC_ERROR = 4001,
+  SYSTEM_ERROR = 4002,
+  LIMIT_EXCEEDED = 5000,
+}
+
+export const CONTRACT_ERROR_KEY_MAP: Record<ContractErrorCode, string> = {
+  [ContractErrorCode.INVALID_INPUT]: 'contractErrors.invalidInput',
+  [ContractErrorCode.INVALID_AMOUNT]: 'contractErrors.invalidAmount',
+  [ContractErrorCode.INVALID_RECIPIENT]: 'contractErrors.invalidRecipient',
+  [ContractErrorCode.UNAUTHORIZED]: 'contractErrors.unauthorized',
+  [ContractErrorCode.FORBIDDEN]: 'contractErrors.forbidden',
+  [ContractErrorCode.NOT_FOUND]: 'contractErrors.notFound',
+  [ContractErrorCode.EXECUTION_FAILED]: 'contractErrors.executionFailed',
+  [ContractErrorCode.CONTRACT_EXEC_ERROR]: 'contractErrors.contractExecError',
+  [ContractErrorCode.SYSTEM_ERROR]: 'contractErrors.systemError',
+  [ContractErrorCode.LIMIT_EXCEEDED]: 'contractErrors.limitExceeded',
+};
+
+export const getContractErrorMessageKey = (code: number | string): string => {
+  if (typeof code === 'number') {
+    if (code in CONTRACT_ERROR_KEY_MAP) {
+      return CONTRACT_ERROR_KEY_MAP[code as ContractErrorCode];
+    }
+  } else if (typeof code === 'string') {
+    const parsed = parseInt(code, 10);
+    if (!isNaN(parsed) && parsed in CONTRACT_ERROR_KEY_MAP) {
+      return CONTRACT_ERROR_KEY_MAP[parsed as ContractErrorCode];
+    }
+    const upper = code.toUpperCase();
+    const matchedEnum = (ContractErrorCode as any)[upper];
+    if (matchedEnum !== undefined && matchedEnum in CONTRACT_ERROR_KEY_MAP) {
+      return CONTRACT_ERROR_KEY_MAP[matchedEnum as ContractErrorCode];
+    }
+  }
+  return 'contractErrors.generic';
+};
+
+export const toUserMessage = (error: ContractError, t: (key: string) => string): string => {
+  if (error.message.startsWith('contractErrors.') || error.message.startsWith('errors.')) {
+    return t(error.message);
+  }
+  const key = getContractErrorMessageKey(error.code);
+  return t(key);
+};
+
+export const mapNumericCodeToError = (code: number): ContractError => {
+  const key = getContractErrorMessageKey(code);
+  
+  let category = ContractErrorCategory.EXECUTION_FAILED;
+  let httpStatus = 400;
+  let isRetryable = false;
+
+  if (code >= 1000 && code < 2000) {
+    category = ContractErrorCategory.VALIDATION;
+    httpStatus = 400;
+  } else if (code >= 2000 && code < 3000) {
+    category = ContractErrorCategory.AUTHENTICATION;
+    httpStatus = 401;
+  } else if (code >= 3000 && code < 4000) {
+    category = ContractErrorCategory.NOT_FOUND;
+    httpStatus = 404;
+  } else if (code >= 4000 && code < 5000) {
+    category = ContractErrorCategory.EXECUTION_FAILED;
+    httpStatus = 500;
+    if (code === ContractErrorCode.SYSTEM_ERROR) {
+      isRetryable = true;
+    }
+  } else if (code >= 5000 && code < 8000) {
+    category = ContractErrorCategory.VALIDATION;
+    httpStatus = 422;
+  }
+
+  return new ContractError(category, String(code), key, httpStatus, isRetryable);
+};
+
+export const mapStringCodeToError = (code: string): ContractError => {
+  const parsed = parseInt(code, 10);
+  if (!isNaN(parsed)) {
+    return mapNumericCodeToError(parsed);
+  }
+
+  const key = getContractErrorMessageKey(code);
+  
+  let category = ContractErrorCategory.EXECUTION_FAILED;
+  let httpStatus = 400;
+  let isRetryable = false;
+
+  const upper = code.toUpperCase();
+  const matchedEnum = (ContractErrorCode as any)[upper];
+
+  if (matchedEnum !== undefined) {
+    return mapNumericCodeToError(matchedEnum);
+  }
+
+  return new ContractError(category, code, key, httpStatus, isRetryable);
+};
+
+export const parseContractError = (err: any, context?: any): ContractError => {
+  if (err instanceof ContractError) {
+    return err;
+  }
+
+  const rawMessage = String(err?.message || err || '');
+  
+  // Look for numeric code matching 1000-7999, e.g. "Contract error: 4002" or just "4002"
+  const numericMatch = rawMessage.match(/(?:Contract error(?: code)?:?\s*)?\b(\d{4})\b/i);
+  if (numericMatch) {
+    const codeVal = parseInt(numericMatch[1], 10);
+    if (codeVal >= 1000 && codeVal <= 7999) {
+      return mapNumericCodeToError(codeVal);
+    }
+  }
+
+  // Check if err has code property
+  if (err?.code !== undefined) {
+    const codeAsNum = Number(err.code);
+    if (!isNaN(codeAsNum) && codeAsNum >= 1000 && codeAsNum <= 7999) {
+      return mapNumericCodeToError(codeAsNum);
+    }
+    if (typeof err.code === 'string') {
+      return mapStringCodeToError(err.code);
+    }
+  }
+
+  // Look for string code, e.g. "Contract error: UNAUTHORIZED"
+  const stringMatch = rawMessage.match(/(?:Contract error(?: code)?:?\s*)?\b([A-Za-z0-9_]+)\b/i);
+  if (stringMatch) {
+    const codeStr = stringMatch[1];
+    const parsedNum = parseInt(codeStr, 10);
+    if (isNaN(parsedNum)) {
+      const errMapped = mapStringCodeToError(codeStr);
+      if (errMapped.code !== codeStr || getContractErrorMessageKey(codeStr) !== 'contractErrors.generic') {
+        return errMapped;
+      }
+    }
+  }
+
+  return new ContractError(
+    ContractErrorCategory.EXECUTION_FAILED,
+    'CONTRACT_EXEC_ERROR',
+    'contractErrors.generic',
+    400,
+    false
+  );
 };
 
 export const createSystemError = (msg: string, context?: any, isRetryable: boolean = false) => {

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -4,6 +4,19 @@
     "network": "Network connection error. Check your connection.",
     "unauthorized": "Session expired. Please log in again."
   },
+  "contractErrors": {
+    "generic": "Contract execution failed. Please try again.",
+    "invalidInput": "Invalid input provided.",
+    "invalidAmount": "Invalid contract amount.",
+    "invalidRecipient": "Invalid contract recipient.",
+    "unauthorized": "Unauthorized access to contract.",
+    "forbidden": "Action forbidden by contract.",
+    "notFound": "Contract resource not found.",
+    "executionFailed": "Contract execution failed.",
+    "contractExecError": "Contract execution failed.",
+    "systemError": "Internal system error.",
+    "limitExceeded": "Contract operation limit exceeded."
+  },
   "transactionHistory": {
     "title": "Transaction History",
     "empty": "No transactions found",

--- a/lib/i18n/locales/es.json
+++ b/lib/i18n/locales/es.json
@@ -4,6 +4,19 @@
     "network": "Error de conexión de red. Compruebe su conexión.",
     "unauthorized": "Sesión expirada. Por favor, inicie sesión de nuevo."
   },
+  "contractErrors": {
+    "generic": "Falló la ejecución del contrato. Por favor, inténtelo de nuevo.",
+    "invalidInput": "Entrada inválida proporcionada.",
+    "invalidAmount": "Monto del contrato inválido.",
+    "invalidRecipient": "Destinatario del contrato inválido.",
+    "unauthorized": "Acceso no autorizado al contrato.",
+    "forbidden": "Acción prohibida por el contrato.",
+    "notFound": "Recurso del contrato no encontrado.",
+    "executionFailed": "Falló la ejecución del contrato.",
+    "contractExecError": "Falló la ejecución del contrato.",
+    "systemError": "Error interno del sistema.",
+    "limitExceeded": "Límite de operación del contrato excedido."
+  },
   "transactionHistory": {
     "title": "Historial de Transacciones",
     "empty": "No se encontraron transacciones",

--- a/tests/unit/i18n/contract-errors.test.ts
+++ b/tests/unit/i18n/contract-errors.test.ts
@@ -1,0 +1,224 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  ContractErrorCode,
+  CONTRACT_ERROR_KEY_MAP,
+  getContractErrorMessageKey,
+  toUserMessage,
+  parseContractError,
+  mapNumericCodeToError,
+  mapStringCodeToError,
+  ContractError,
+  ContractErrorCategory,
+  createSystemError,
+} from '../../../lib/errors/contract-errors';
+
+// Helper to check if a dot-separated path exists in a JSON object
+function hasKey(obj: any, pathStr: string): boolean {
+  const parts = pathStr.split('.');
+  let current = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined || typeof current !== 'object') {
+      return false;
+    }
+    if (!(part in current)) {
+      return false;
+    }
+    current = current[part];
+  }
+  return true;
+}
+
+describe('Contract Error Localized Message System Tests', () => {
+  const enPath = path.resolve(process.cwd(), 'lib/i18n/locales/en.json');
+  const esPath = path.resolve(process.cwd(), 'lib/i18n/locales/es.json');
+
+  const enCatalog = JSON.parse(fs.readFileSync(enPath, 'utf8'));
+  const esCatalog = JSON.parse(fs.readFileSync(esPath, 'utf8'));
+
+  // A. Every ContractErrorCode has a mapping.
+  it('A. Every ContractErrorCode enum value has a translation mapping', () => {
+    const codes = Object.values(ContractErrorCode).filter((v) => typeof v === 'number') as number[];
+    expect(codes.length).toBeGreaterThan(0);
+    for (const code of codes) {
+      expect(CONTRACT_ERROR_KEY_MAP).toHaveProperty(String(code));
+      const key = CONTRACT_ERROR_KEY_MAP[code as ContractErrorCode];
+      expect(key).toBeDefined();
+      expect(typeof key).toBe('string');
+    }
+  });
+
+  // B. Every mapped key exists in BOTH en.json and es.json
+  it('B. Every mapped key exists in both en.json and es.json', () => {
+    // Also include the fallback generic key
+    const keysToCheck: string[] = [
+      'contractErrors.generic',
+      ...Object.values(CONTRACT_ERROR_KEY_MAP),
+    ];
+
+    for (const key of keysToCheck) {
+      const existsInEn = hasKey(enCatalog, key);
+      const existsInEs = hasKey(esCatalog, key);
+
+      if (!existsInEn) {
+        throw new Error(`Missing translation key "${key}" in en.json`);
+      }
+      if (!existsInEs) {
+        throw new Error(`Missing translation key "${key}" in es.json`);
+      }
+
+      expect(existsInEn).toBe(true);
+      expect(existsInEs).toBe(true);
+    }
+  });
+
+  // C. Unknown numeric codes return the generic localized key.
+  it('C. Unknown numeric codes return the generic localized key', () => {
+    const key = getContractErrorMessageKey(9999);
+    expect(key).toBe('contractErrors.generic');
+
+    const err = mapNumericCodeToError(9999);
+    expect(err.message).toBe('contractErrors.generic');
+  });
+
+  // D. Unknown string codes return the generic localized key.
+  it('D. Unknown string codes return the generic localized key', () => {
+    const key = getContractErrorMessageKey('UNKNOWN_CODE_STRING');
+    expect(key).toBe('contractErrors.generic');
+
+    const err = mapStringCodeToError('UNKNOWN_CODE_STRING');
+    expect(err.message).toBe('contractErrors.generic');
+  });
+
+  // E. No raw code fallback strings are returned anywhere.
+  it('E. No raw code fallback strings are returned anywhere', () => {
+    const mockT = (key: string) => {
+      // simulate localized translation resolution
+      if (key === 'contractErrors.unauthorized') return 'Unauthorized';
+      if (key === 'contractErrors.generic') return 'Generic Error';
+      return key;
+    };
+
+    const err1 = mapNumericCodeToError(2000); // unauthorized
+    const msg1 = toUserMessage(err1, mockT);
+    expect(msg1).not.toContain('2000');
+    expect(msg1).not.toContain('Contract error');
+    expect(msg1).toBe('Unauthorized');
+
+    const err2 = mapNumericCodeToError(9999); // unknown
+    const msg2 = toUserMessage(err2, mockT);
+    expect(msg2).not.toContain('9999');
+    expect(msg2).not.toContain('Contract error');
+    expect(msg2).toBe('Generic Error');
+  });
+
+  // F. Missing translation keys cause tests to fail loudly.
+  it('F. Missing translation keys fail loudly', () => {
+    const fakeKey = 'contractErrors.nonExistentKey';
+    expect(() => {
+      if (!hasKey(enCatalog, fakeKey)) {
+        throw new Error(`Missing translation key "${fakeKey}" in en.json`);
+      }
+    }).toThrow(`Missing translation key "${fakeKey}" in en.json`);
+  });
+
+  describe('Additional unit testing for full coverage', () => {
+    it('handles numeric string code in mapStringCodeToError', () => {
+      const err = mapStringCodeToError('2000');
+      expect(err.code).toBe('2000');
+      expect(err.message).toBe('contractErrors.unauthorized');
+      expect(err.category).toBe(ContractErrorCategory.AUTHENTICATION);
+      expect(err.httpStatus).toBe(401);
+    });
+
+    it('handles case-insensitive enum names in mapStringCodeToError', () => {
+      const err = mapStringCodeToError('unauthorized');
+      expect(err.code).toBe('2000');
+      expect(err.message).toBe('contractErrors.unauthorized');
+    });
+
+    it('correctly maps ranges to categories and statuses', () => {
+      // 1000 range (Validation)
+      const errValidation = mapNumericCodeToError(1000);
+      expect(errValidation.category).toBe(ContractErrorCategory.VALIDATION);
+      expect(errValidation.httpStatus).toBe(400);
+
+      // 2000 range (Authentication)
+      const errAuth = mapNumericCodeToError(2000);
+      expect(errAuth.category).toBe(ContractErrorCategory.AUTHENTICATION);
+      expect(errAuth.httpStatus).toBe(401);
+
+      // 3000 range (Not Found)
+      const errNotFound = mapNumericCodeToError(3000);
+      expect(errNotFound.category).toBe(ContractErrorCategory.NOT_FOUND);
+      expect(errNotFound.httpStatus).toBe(404);
+
+      // 4000 range (Execution / System)
+      const errSystem = mapNumericCodeToError(4002);
+      expect(errSystem.category).toBe(ContractErrorCategory.EXECUTION_FAILED);
+      expect(errSystem.httpStatus).toBe(500);
+      expect(errSystem.isRetryable).toBe(true);
+
+      const errExec = mapNumericCodeToError(4000);
+      expect(errExec.category).toBe(ContractErrorCategory.EXECUTION_FAILED);
+      expect(errExec.httpStatus).toBe(500);
+      expect(errExec.isRetryable).toBe(false);
+
+      // 5000 range (Limits / Validation)
+      const errLimit = mapNumericCodeToError(5000);
+      expect(errLimit.category).toBe(ContractErrorCategory.VALIDATION);
+      expect(errLimit.httpStatus).toBe(422);
+    });
+
+    it('parses contract error objects correctly', () => {
+      // Should return original ContractError
+      const orig = new ContractError(ContractErrorCategory.VALIDATION, '1001', 'custom');
+      expect(parseContractError(orig)).toBe(orig);
+
+      // Should extract numeric code from messages
+      const parsed1 = parseContractError(new Error('Contract error: 4002'));
+      expect(parsed1.code).toBe('4002');
+      expect(parsed1.message).toBe('contractErrors.systemError');
+
+      const parsed2 = parseContractError(new Error('Contract error code 2001'));
+      expect(parsed2.code).toBe('2001');
+      expect(parsed2.message).toBe('contractErrors.forbidden');
+
+      // Should extract code property
+      const parsedProp = parseContractError({ code: 1002 });
+      expect(parsedProp.code).toBe('1002');
+      expect(parsedProp.message).toBe('contractErrors.invalidRecipient');
+
+      // Should handle string codes from message
+      const parsedStr = parseContractError(new Error('Contract error: unauthorized'));
+      expect(parsedStr.code).toBe('2000');
+      expect(parsedStr.message).toBe('contractErrors.unauthorized');
+
+      // Should extract code property as string
+      const parsedPropStr = parseContractError({ code: 'unauthorized' });
+      expect(parsedPropStr.code).toBe('2000');
+      expect(parsedPropStr.message).toBe('contractErrors.unauthorized');
+
+      // Should fallback gracefully
+      const parsedFallback = parseContractError(new Error('something weird happened'));
+      expect(parsedFallback.code).toBe('CONTRACT_EXEC_ERROR');
+      expect(parsedFallback.message).toBe('contractErrors.generic');
+    });
+
+    it('toUserMessage falls back cleanly if message doesn\'t start with expected namespace', () => {
+      const mockT = (key: string) => `translated-${key}`;
+      const err = new ContractError(ContractErrorCategory.VALIDATION, '1001', 'some_legacy_message');
+      const msg = toUserMessage(err, mockT);
+      expect(msg).toBe('translated-contractErrors.invalidAmount');
+    });
+
+    it('covers createSystemError helper', () => {
+      const err = createSystemError('system failed');
+      expect(err.code).toBe('SYSTEM_ERROR');
+      expect(err.message).toBe('system failed');
+      expect(err.category).toBe(ContractErrorCategory.EXECUTION_FAILED);
+    });
+  });
+});


### PR DESCRIPTION
Closes #641 Add a human-readable, i18n-ready message map for the contract error taxonomy in lib/errors/contract-errors.ts