### PR TITLE
docs(db): document Prisma data model + ERD and the durability boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Frontend application for the RemitWise remittance and financial planning platfor
 
 This is a Next.js-based frontend skeleton that provides the UI structure for all RemitWise features. The application is built with:
 
+- [Prisma data model and durability boundary](./docs/data-model.md)
+
 - **Next.js 14** - React framework with App Router
 - **TypeScript** - Type safety
 - **Tailwind CSS** - Utility-first styling
@@ -69,7 +71,7 @@ npm install
 
 # Setup Database
 # 1. Ensure you have `.env` file with `DATABASE_URL="file:./dev.db"`
-# Note: For serverless environments (like Vercel), connection pooling limits (default min 1, max 10) 
+# Note: For serverless environments (like Vercel), connection pooling limits (default min 1, max 10)
 # and timeouts (5s) are automatically configured on the Prisma DB client.
 # 2. Run initial Prisma migration
 npx prisma migrate dev
@@ -470,8 +472,8 @@ RemitWise uses wallet-based authentication with the following flow:
 
 The application interacts with the following Soroban smart contracts on Stellar:
 
-| Contract         | Purpose                       | Preferred Environment Variable                    |
-| ---------------- | ----------------------------- | ------------------------------------------------- |
+| Contract         | Purpose                       | Preferred Environment Variable                  |
+| ---------------- | ----------------------------- | ----------------------------------------------- |
 | Remittance Split | Automatic money allocation    | `REMITTANCE_SPLIT_CONTRACT_ID_TESTNET/_MAINNET` |
 | Savings Goals    | Goal-based savings management | `SAVINGS_GOALS_CONTRACT_ID_TESTNET/_MAINNET`    |
 | Bill Payments    | Bill tracking and payments    | `BILL_PAYMENTS_CONTRACT_ID_TESTNET/_MAINNET`    |
@@ -775,7 +777,7 @@ Example environment variables:
 
 RemitWise exposes an OpenAPI discovery endpoint:
 
- /api/.well-known/openapi
+/api/.well-known/openapi
 
 This allows integrators and wallets to automatically discover
 the RemitWise API specification.
@@ -785,6 +787,7 @@ the RemitWise API specification.
 Sentry error monitoring is integrated for client, server, and edge runtimes.
 
 **Required environment variables** (see `.env.example`):
+
 - `NEXT_PUBLIC_SENTRY_DSN` — public DSN for browser and client
 - `SENTRY_DSN` — server/edge DSN (same value)
 - `SENTRY_ORG`, `SENTRY_PROJECT` — project identifiers for source map uploads
@@ -793,17 +796,21 @@ Sentry error monitoring is integrated for client, server, and edge runtimes.
 - `NEXT_PUBLIC_APP_ENV` — `development` | `staging` | `production`
 
 **Sample rates**:
+
 - `NEXT_PUBLIC_APP_ENV=production` sets lower rates: `tracesSampleRate: 0.1`, `replaysSessionSampleRate: 0.05`
 - Non-production uses higher rates for visibility
 
 **Tunnel route**:
+
 - All Sentry requests are proxied through `/monitoring` (configured in `next.config.js`) to avoid ad blockers.
 
 **PII scrubbing**:
+
 - Client (`scrubStellarPII`): Stellar addresses (`G[A-Z2-7]{55}`) and amounts (`\d+ XLM|USDC|USD`) are replaced before send.
 - Server (`scrubServerPII`): same + `iron-session` tokens are redacted.
 - Scrubbers live inside each config file for edge compatibility.
 
 **Source maps**:
+
 - Uploaded during build when `SENTRY_AUTH_TOKEN` and CI are present.
 - `hideSourceMaps: true` prevents browser exposure.

--- a/app/bills/page.tsx
+++ b/app/bills/page.tsx
@@ -11,7 +11,6 @@ import { ActionState } from "@/lib/auth/middleware";
 import { useFormAction } from "@/lib/hooks/useFormAction";
 import AsyncOperationsPanel from "@/components/AsyncOperationsPanel";
 import AsyncSubmissionStatus from "@/components/AsyncSubmissionStatus";
-<<<<<<< HEAD
 import { apiClient } from "@/lib/client/apiClient";
 import { Bill } from "@/lib/contracts/bill-payments";
 import { WidgetErrorState } from "@/components/ui/WidgetStates";

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,154 @@
+# Data Model and Persistence Boundary
+
+This document describes the current Prisma persistence layer for RemitWise, including the exact Prisma models in `prisma/schema.prisma`, the main persisted entities, and the durability boundary between on-chain, in-memory, and persisted data.
+
+## Current Prisma Models
+
+### `User`
+
+Represents an authenticated user who has signed in with a Stellar address.
+
+- `id: String` — primary key, generated with `cuid()`.
+- `stellar_address: String` — unique Stellar public key used as the user identity.
+- `createdAt: DateTime` — timestamp when the record was created.
+- `updatedAt: DateTime` — auto-updated timestamp when the record changes.
+- `preferences: UserPreference?` — optional one-to-one relation to `UserPreference`.
+
+### `UserPreference`
+
+Stores user-specific UI and locale preferences.
+
+- `id: String` — primary key, generated with `cuid()`.
+- `userId: String` — unique foreign key to `User.id`.
+- `user: User` — relation back to `User`, with `onDelete: Cascade`.
+- `currency: String` — selected display currency (default `USD`).
+- `language: String` — selected language/locale code (default `en`).
+- `notifications_enabled: Boolean` — whether the user has enabled notifications (default `true`).
+
+### `TutorialProgress`
+
+Tracks per-user tutorial state for the in-app education experience.
+
+- `id: String` — primary key, generated with `cuid()`.
+- `userId: String` — user identifier.
+- `tutorialId: String` — tutorial identifier.
+- `data: String` — JSON string that contains chapter progress details.
+- `createdAt: DateTime` — timestamp for record creation.
+- `updatedAt: DateTime` — timestamp updated on record modification.
+
+Indexes:
+
+- unique composite index: `@@unique([userId, tutorialId])`
+- `@@index([userId])`
+- `@@index([tutorialId])`
+
+### `WebhookEvent`
+
+Persisted webhook events used for reliable asynchronous processing and retry handling.
+
+- `id: String` — primary key, generated with `cuid()`.
+- `source: String` — event origin, e.g. `anchor`, `stripe`.
+- `eventType: String` — event type name, e.g. `deposit_completed`.
+- `rawPayload: String` — raw JSON body as text.
+- `status: String` — processing status; default is `pending`.
+- `retryCount: Int` — current retry attempt count, default `0`.
+- `maxRetries: Int` — maximum allowed retries, default `5`.
+- `lastError: String?` — last failure message, nullable.
+- `nextRetryAt: DateTime?` — if failed, when to retry next.
+- `createdAt: DateTime` — creation timestamp.
+- `updatedAt: DateTime` — auto-updated timestamp.
+- `processedAt: DateTime?` — timestamp when processing completed.
+
+Indexes:
+
+- `@@index([status])`
+- `@@index([source])`
+- `@@index([nextRetryAt])`
+
+## ERD
+
+```mermaid
+erDiagram
+    User ||--o{ UserPreference : has
+    UserPreference }o--|| User : belongs_to
+    WebhookEvent {
+      String id
+      String source
+      String eventType
+      String rawPayload
+      String status
+      Int retryCount
+      Int maxRetries
+      String lastError
+      DateTime nextRetryAt
+      DateTime createdAt
+      DateTime updatedAt
+      DateTime processedAt
+    }
+    User {
+      String id
+      String stellar_address
+      DateTime createdAt
+      DateTime updatedAt
+    }
+    UserPreference {
+      String id
+      String userId
+      String currency
+      String language
+      Boolean notifications_enabled
+    }
+```
+
+> Note: `TutorialProgress` is also in Prisma today, but it is not part of the issue's requested primary ERD. It is still documented above as part of the current persistence surface.
+
+## Durability Map
+
+| Domain Entity         | Persistence Category       | Where it lives today                          | Notes                                                                                |
+| --------------------- | -------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `User`                | Persisted                  | Prisma/SQLite                                 | Durable identity storage for authenticated users.                                    |
+| `UserPreference`      | Persisted                  | Prisma/SQLite                                 | Durable UI preferences and locale settings.                                          |
+| `WebhookEvent`        | Persisted                  | Prisma/SQLite                                 | Durable webhook retry queue and dead-letter queue state.                             |
+| Tutorial progress     | Persisted                  | Prisma/SQLite                                 | Durably stores tutorial progress state.                                              |
+| Bills                 | Contract-backed / on-chain | Wallet transaction payloads, not DB persisted | Bill requests are built into on-chain payloads and submitted through wallet signing. |
+| Savings goals         | Contract-backed / on-chain | Smart contract state on Stellar               | Goals are built and submitted on-chain, not stored in local DB.                      |
+| Insurance             | Contract-backed / on-chain | Smart contract or anchor flows                | Insurance actions are prepared on-chain and not persisted in Prisma.                 |
+| Anchor flows          | In-memory                  | `lib/anchor/flow-store.ts`                    | Anchor deposit/withdrawal state is kept in a server-side in-memory map.              |
+| Recurring remittances | In-memory                  | `lib/remittance/recurring-store.ts`           | Recurring schedule state is currently stored in-memory only.                         |
+| Idempotency keys      | In-memory                  | `lib/idempotency/store.ts`                    | Request de-duplication cache held in-memory; replaceable by Redis/DB in production.  |
+
+## DB Client Notes
+
+### Connection-string augmentation
+
+The Prisma client helpers augment `process.env.DATABASE_URL` when running with a supported URL:
+
+- `connection_limit=10` if not already present
+- `connect_timeout=5` if not already present
+- `pool_timeout=5` if not already present
+
+This is implemented in both `lib/prisma.ts` and `lib/db.ts`.
+
+### Dev-global singleton pattern
+
+To avoid creating multiple Prisma clients during hot reload in development, both helpers use a global singleton:
+
+- `lib/prisma.ts` stores `globalForPrisma.prisma`
+- `lib/db.ts` stores `global.prisma`
+
+In production, the Prisma client is created once and exported directly.
+
+## Where the Prisma client is used
+
+- `lib/db.ts` is imported by `lib/webhooks/processor.ts`, `app/api/v1/health/route.ts`, and admin/user routes.
+- `lib/prisma.ts` is imported by `app/api/auth/login/route.ts`, `app/api/user/profile/route.ts`, and `app/api/user/preferences/route.ts`.
+
+## Planned/Potential models
+
+The schema currently has no persistent model for these planned domain entities; they are documented here as possible future additions:
+
+- `RecurringRemittanceSchedule` — a planned database model to persist recurring remittance schedules.
+- `AnchorFlowRecord` — a planned persistent model to replace the in-memory anchor flow store.
+- `AuditLogEntry` — a planned durable audit or admin event log for system actions.
+
+These are not present in the current Prisma schema and are therefore labelled as planned only.

--- a/lib/README.md
+++ b/lib/README.md
@@ -20,9 +20,12 @@ lib/
 
 ## Modules
 
+- [Prisma data model and durability boundary](../docs/data-model.md)
+
 ### Authentication (`auth/`)
 
 **session.ts** - Session management utilities
+
 - `getSessionFromRequest()` - Extract session from Next.js request
 - `validateSession()` - Validate session structure
 - `getPublicKeyFromSession()` - Extract public key from session
@@ -30,6 +33,7 @@ lib/
 ### Contracts (`contracts/`)
 
 **savings-goals.ts** - Transaction builders for savings goals smart contract
+
 - `buildCreateGoalTx()` - Build transaction to create a new goal
 - `buildAddToGoalTx()` - Build transaction to add funds to a goal
 - `buildWithdrawFromGoalTx()` - Build transaction to withdraw from a goal
@@ -39,6 +43,7 @@ lib/
 ### Errors (`errors/`)
 
 **api-errors.ts** - API error response utilities
+
 - `createValidationError()` - Create 400 validation error response
 - `createAuthenticationError()` - Create 401 authentication error response
 - `createServerError()` - Create 500 server error response
@@ -48,6 +53,7 @@ lib/
 ### Types (`types/`)
 
 **savings-goals.ts** - TypeScript interfaces and types
+
 - `CreateGoalParams` - Parameters for creating a goal
 - `GoalOperationParams` - Parameters for goal operations
 - `BuildTxResult` - Transaction builder result
@@ -58,6 +64,7 @@ lib/
 ### Validation (`validation/`)
 
 **savings-goals.ts** - Input validation functions
+
 - `validateAmount()` - Validate positive number amounts
 - `validateFutureDate()` - Validate dates are in the future
 - `validateGoalId()` - Validate goal ID format
@@ -69,13 +76,13 @@ lib/
 ### Building a Transaction
 
 ```typescript
-import { buildCreateGoalTx } from '@/lib/contracts/savings-goals';
+import { buildCreateGoalTx } from "@/lib/contracts/savings-goals";
 
 const result = await buildCreateGoalTx(
-  'GXXXXXXX...', // owner public key
-  'Emergency Fund',
+  "GXXXXXXX...", // owner public key
+  "Emergency Fund",
   5000,
-  '2025-12-31T00:00:00Z'
+  "2025-12-31T00:00:00Z",
 );
 
 console.log(result.xdr); // Transaction XDR string
@@ -84,14 +91,17 @@ console.log(result.xdr); // Transaction XDR string
 ### Validating Input
 
 ```typescript
-import { validateAmount, validateFutureDate } from '@/lib/validation/savings-goals';
+import {
+  validateAmount,
+  validateFutureDate,
+} from "@/lib/validation/savings-goals";
 
 const amountValidation = validateAmount(100);
 if (!amountValidation.isValid) {
   console.error(amountValidation.error);
 }
 
-const dateValidation = validateFutureDate('2025-12-31');
+const dateValidation = validateFutureDate("2025-12-31");
 if (!dateValidation.isValid) {
   console.error(dateValidation.error);
 }
@@ -100,11 +110,14 @@ if (!dateValidation.isValid) {
 ### Handling Errors
 
 ```typescript
-import { createValidationError, handleUnexpectedError } from '@/lib/errors/api-errors';
+import {
+  createValidationError,
+  handleUnexpectedError,
+} from "@/lib/errors/api-errors";
 
 // Return validation error
 if (!isValid) {
-  return createValidationError('Invalid input', 'Amount must be positive');
+  return createValidationError("Invalid input", "Amount must be positive");
 }
 
 // Handle unexpected errors
@@ -118,14 +131,17 @@ try {
 ### Session Management
 
 ```typescript
-import { getSessionFromRequest, getPublicKeyFromSession } from '@/lib/auth/session';
+import {
+  getSessionFromRequest,
+  getPublicKeyFromSession,
+} from "@/lib/auth/session";
 
 export async function POST(request: NextRequest) {
   const session = getSessionFromRequest(request);
   if (!session) {
     return createAuthenticationError();
   }
-  
+
   const publicKey = getPublicKeyFromSession(session);
   // ... use publicKey
 }
@@ -147,7 +163,7 @@ This makes it easy to test validation logic:
 ```typescript
 const result = validateAmount(-5);
 expect(result.isValid).toBe(false);
-expect(result.error).toBe('Amount must be positive');
+expect(result.error).toBe("Amount must be positive");
 ```
 
 ## Adding New Modules

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5,7 +5,7 @@ declare global {
   var prisma: PrismaClient | undefined;
 }
 
-function getDatabaseUrl(): string | undefined {
+export function getDatabaseUrl(): string | undefined {
   const urlString = process.env.DATABASE_URL;
   if (!urlString) return undefined;
   try {

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,7 +1,7 @@
 // lib/prisma.ts
 import { PrismaClient } from '@prisma/client';
 
-function getDatabaseUrl(): string | undefined {
+export function getDatabaseUrl(): string | undefined {
   const urlString = process.env.DATABASE_URL;
   if (!urlString) return undefined;
   try {

--- a/tests/unit/db-helper.test.ts
+++ b/tests/unit/db-helper.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getDatabaseUrl } from '@/lib/db';
+
+const originalEnv = process.env;
+
+describe('lib/db database URL helper', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('returns undefined when DATABASE_URL is missing', () => {
+    delete process.env.DATABASE_URL;
+    expect(getDatabaseUrl()).toBeUndefined();
+  });
+
+  it('augments the connection string with defaults when missing', () => {
+    process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/db';
+    const url = getDatabaseUrl();
+    expect(url).toContain('connection_limit=10');
+    expect(url).toContain('connect_timeout=5');
+    expect(url).toContain('pool_timeout=5');
+  });
+
+  it('does not override existing query params', () => {
+    process.env.DATABASE_URL =
+      'postgresql://user:pass@localhost:5432/db?connection_limit=20&connect_timeout=8';
+    const url = getDatabaseUrl();
+    expect(url).toContain('connection_limit=20');
+    expect(url).toContain('connect_timeout=8');
+    expect(url).toContain('pool_timeout=5');
+  });
+
+  it('returns original string on invalid URL parse', () => {
+    process.env.DATABASE_URL = 'not-a-valid-db-url';
+    expect(getDatabaseUrl()).toBe('not-a-valid-db-url');
+  });
+});


### PR DESCRIPTION
closes #654 

Title: docs(db): document Prisma data model + ERD and the durability boundary

Summary
- Adds comprehensive documentation of the Prisma schema, an ERD, and an explicit durability map showing which domain entities are on-chain, in-memory, or persisted. Also documents connection-string augmentation and the dev-global Prisma singleton pattern. Includes a small unit test for the DB helper and a minor merge-conflict fix that blocked linting.

Why
- Contributors frequently ask “where is X stored?”. Currently only a small set of models are persisted (User, UserPreference, TutorialProgress, WebhookEvent) and this is not documented. This PR makes the persistence boundary explicit and documents where planned persistence should land.

What I changed
- New docs:
  - [docs/data-model.md](docs/data-model.md) — model field/index/relation docs, Mermaid ERD, durability map, notes on connection-string augmentation and singleton pattern.
- Tests:
  - [tests/unit/db-helper.test.ts](tests/unit/db-helper.test.ts) — unit tests for `getDatabaseUrl()` behavior.
- Small code/docs edits:
  - [lib/prisma.ts](lib/prisma.ts) — export `getDatabaseUrl()` and keep connection-string augmentation implementation (unchanged semantics).
  - [lib/db.ts](lib/db.ts) — export `getDatabaseUrl()` and use dev-global singleton (unchanged semantics).
  - [README.md](README.md) — link to new data-model doc.
  - [lib/README.md](lib/README.md) — link to new data-model doc.
  - [app/bills/page.tsx](app/bills/page.tsx) — remove stray merge conflict marker that blocked lint.

Branch
- Branch name: `docs/data-model-erd`

Files changed (high level)
- Created: [docs/data-model.md](docs/data-model.md)
- Created: [tests/unit/db-helper.test.ts](tests/unit/db-helper.test.ts)
- Updated: [lib/prisma.ts](lib/prisma.ts), [lib/db.ts](lib/db.ts), [README.md](README.md), [lib/README.md](lib/README.md), [app/bills/page.tsx](app/bills/page.tsx)

Validation & Tests performed
- Generated Prisma client and validated schema:
  - `pnpm exec prisma generate` then `pnpm exec prisma validate` — schema valid (used `DATABASE_URL=file:./dev.db` for validation).
- Linting:
  - `pnpm exec eslint .` — no lint errors after resolving merge marker.
- Unit test:
  - `pnpm exec vitest run tests/unit/db-helper.test.ts` — passed (tests validate connection-string augmentation behavior).
- Confirmed branch created and pushed: `docs/data-model-erd` (pushed to your fork).

How to review
- Read the main doc first: [docs/data-model.md](docs/data-model.md).
- Scan the small unit test to confirm behavior: [tests/unit/db-helper.test.ts](tests/unit/db-helper.test.ts).
- Confirm `lib/prisma.ts` / `lib/db.ts` exports and comments align with runtime expectations.
- Optional: Run local validations (commands below) to reproduce CI checks.

Commands to reproduce locally
```bash
# from repo root
# 1) validate Prisma schema (set DATABASE_URL for sqlite)
export DATABASE_URL="file:./dev.db"        # macOS / Linux
# or on Windows PowerShell:
# $env:DATABASE_URL='file:./dev.db'

pnpm exec prisma generate
pnpm exec prisma validate

# 2) lint
pnpm exec eslint .

# 3) run the focused unit test
pnpm exec vitest run db-helper.test.ts