### PR TITLE
a11y(settings): make SettingsItem keyboard-accessible

### DIFF
--- a/components/SettingsItem.tsx
+++ b/components/SettingsItem.tsx
@@ -17,9 +17,7 @@ interface SettingsItemProps {
   comingSoon?: boolean;
   hasDropdownBar?: boolean;
   hasIconBackground?: boolean;
-  /** Styling variants; default preserves existing look. */
   variant?: "default" | "notification-row" | "security-row";
-  /** When using notification-row, set true to draw a divider under the row. */
   divider?: boolean;
 }
 
@@ -41,23 +39,47 @@ export default function SettingsItem({
 }: SettingsItemProps) {
   const isNotificationRow = variant === "notification-row";
 
+  // =========================
+  // NOTIFICATION ROW
+  // =========================
   if (isNotificationRow) {
+    const isClickable = type !== "toggle" && !!onClick;
+
+    const Wrapper: any = isClickable ? "button" : "div";
+
     return (
-      <div
+      <Wrapper
+        type={isClickable ? "button" : undefined}
+        onClick={isClickable ? onClick : undefined}
+        onKeyDown={(e: any) => {
+          if (!isClickable) return;
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onClick?.();
+          }
+        }}
+        tabIndex={isClickable ? 0 : undefined}
         className={`flex items-center justify-between border border-[#FFFFFF14] h-[77px] p-3 sm:p-4 transition-colors bg-zinc-800/50 ${
           divider ? "border-b border-zinc-800" : ""
-        } ${type !== "toggle" && onClick ? "cursor-pointer" : ""}`}
-        onClick={type !== "toggle" ? onClick : undefined}
+        } ${
+          isClickable
+            ? "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 rounded-md"
+            : ""
+        }`}
       >
-        {/* Left side: Icon + Text */}
+        {/* Left side */}
         <div className="flex items-center gap-4 flex-1 min-w-0">
-          {icon && <div className="text-[#FFFFFF99] flex-shrink-0">{icon}</div>}
+          {icon && (
+            <div className="text-[#FFFFFF99] flex-shrink-0">{icon}</div>
+          )}
           <div className="flex-1 min-w-0">
             <h3 className="text-[#FFFFFF] font-semibold text-[14px] truncate">
               {title}
             </h3>
             {description && (
-              <p className="text-[#FFFFFF80] text-[12px] font-normal truncate">{description}</p>
+              <p className="text-[#FFFFFF80] text-[12px] font-normal truncate">
+                {description}
+              </p>
             )}
           </div>
         </div>
@@ -74,28 +96,50 @@ export default function SettingsItem({
             <ChevronRight className="w-5 h-5 text-zinc-500" />
           )}
         </div>
-      </div>
+      </Wrapper>
     );
   }
 
+  // =========================
+  // DEFAULT ROW
+  // =========================
+
+  const isClickable = type !== "toggle" && type !== "text" && !!onClick;
+  const Wrapper: any = isClickable ? "button" : "div";
+
   return (
     <div className="bg-[#0f0f0f]">
-      <div
-        className={`flex items-center justify-between p-4 hover:bg-gray-800/20 transition-colors ${
-          type !== "toggle" && type !== "text" ? "cursor-pointer" : ""
-        } group`}
-        onClick={type !== "toggle" && type !== "text" ? onClick : undefined}
+      <Wrapper
+        type={isClickable ? "button" : undefined}
+        onClick={isClickable ? onClick : undefined}
+        onKeyDown={(e: any) => {
+          if (!isClickable) return;
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onClick?.();
+          }
+        }}
+        tabIndex={isClickable ? 0 : undefined}
+        className={`flex items-center justify-between p-4 hover:bg-gray-800/20 transition-colors group ${
+          isClickable
+            ? "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 rounded-md"
+            : ""
+        }`}
       >
+        {/* Left */}
         <div className="flex items-center gap-3 flex-1 min-w-0">
           {icon && (
-            <div className={`flex-shrink-0 ${
-              hasIconBackground 
-                ? "w-9 h-9 rounded-lg bg-[#161616] border border-gray-700/20 flex items-center justify-center text-gray-400"
-                : "text-gray-400"
-            }`}>
+            <div
+              className={`flex-shrink-0 ${
+                hasIconBackground
+                  ? "w-9 h-9 rounded-lg bg-[#161616] border border-gray-700/20 flex items-center justify-center text-gray-400"
+                  : "text-gray-400"
+              }`}
+            >
               {icon}
             </div>
           )}
+
           <div className="flex flex-col flex-1 min-w-0">
             <span className="text-sm font-medium text-white">{title}</span>
             {description && (
@@ -104,30 +148,33 @@ export default function SettingsItem({
           </div>
         </div>
 
+        {/* Right */}
         <div className="flex items-center gap-2 sm:gap-3 flex-shrink-0">
           {comingSoon && (
             <span className="px-1.5 sm:px-2 py-0.5 sm:py-1 text-[10px] sm:text-xs font-bold text-red-500 bg-red-500/10 rounded border border-red-500/20 uppercase tracking-wide">
               Coming Soon
             </span>
           )}
+
           {type === "toggle" && onToggle && (
             <Toggle enabled={enabled} onChange={onToggle} />
           )}
+
           {type === "text" && value && (
             <span className="text-sm text-gray-500">{value}</span>
           )}
+
           {type === "navigation" && rightIcon && (
-            <div className="text-gray-500">
-              {rightIcon}
-            </div>
+            <div className="text-gray-500">{rightIcon}</div>
           )}
+
           {type === "navigation" && !rightIcon && (
             <ChevronRight className="w-5 h-5 text-gray-500" />
           )}
         </div>
-      </div>
-      
-      {/* Dropdown bar for dropdown type items */}
+      </Wrapper>
+
+      {/* Dropdown bar */}
       {hasDropdownBar && (
         <div className="px-4 pb-4">
           <div className="flex items-center gap-2 bg-[#161616] rounded-lg px-3 py-2.5 border border-gray-700/20">


### PR DESCRIPTION
## Summary
This PR improves keyboard accessibility for SettingsItem by replacing non-semantic clickable div behavior with proper accessible interaction patterns.

## Changes
- Replaced clickable div behavior with semantic button usage where applicable
- Added keyboard support (Enter and Space activation)
- Added focus-visible styles for accessibility
- Ensured non-interactive rows remain static and non-focusable
- Preserved existing UI layout and styling

## Accessibility Improvements
- Fixes WCAG violation: keyboard-only users can now interact with settings rows
- Screen readers now correctly interpret interactive elements
- Improves focus visibility and navigation consistency

## Testing
- Verified mouse click behavior remains unchanged
- Verified Enter key triggers action
- Verified Space key triggers action
- Verified Tab focus visibility works correctly