### PR TITLE
dark theme constrast implementation

### DIFF
--- a/components/Dashboard/SplitBar.tsx
+++ b/components/Dashboard/SplitBar.tsx
@@ -12,12 +12,19 @@ export default function SplitBar({
   return (
     <div>
       <div className="flex justify-between mb-2">
-        <span className="text-gray-700 font-medium">{label}</span>
-        <span className="text-(--foreground) font-semibold">
+        <span className="text-gray-100 font-medium">{label}</span>
+        <span className="text-white font-semibold">
           ${amount} ({percentage}%)
         </span>
       </div>
-      <div className="w-full bg-gray-200 rounded-full h-3">
+      <div 
+        className="w-full bg-[#1F1F1F] rounded-full h-3"
+        role="progressbar"
+        aria-valuenow={percentage}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`${label} split`}
+      >
         <div
           className={`${color} h-3 rounded-full`}
           style={{ width: `${percentage}%` }}

--- a/scripts/wcag_contrast.py
+++ b/scripts/wcag_contrast.py
@@ -12,6 +12,8 @@ colors = {
     "brand_red": "#D72323",
     "white": "#ffffff",
     "gray400": "#9CA3AF",  # Tailwind gray-400
+    "gray100": "#F3F4F6",
+    "track": "#1F1F1F"
 }
 
 pairs = [
@@ -21,6 +23,8 @@ pairs = [
     ("brand_red", "background"),
     ("brand_red", "surface"),
     ("white", "brand_red"),
+    ("gray100", "track"),
+    ("white", "track"),
 ]
 
 


### PR DESCRIPTION
closes #584

1. Dark Theme Tokens: I swapped out the hardcoded light-theme classes (
  text-gray-700  and  bg-gray-200 ) in  components/Dashboard/SplitBar.tsx 
  text-gray-700  and  bg-gray-200 ) in  components/Dashboard/SplitBar.tsx 
  for proper dark-theme tokens ( text-gray-100  and  bg-[#1F1F1F] ), matching
  other sibling widgets like  CurrentMoneySplitWidget . I also standardized
  the inner text to  text-white .
  2. Accessibility: I added the required ARIA accessibility attributes to the
  track  div  (including  role="progressbar" ,  aria-valuenow ,  aria-
  valuemin ,  aria-valuemax , and  aria-label ).
  3. Contrast Validation: I added the new tokens into the
  scripts/wcag_contrast.py  checker and ran the script. The newly established
  color contrast for the widget reads:
      •  gray100  (#F3F4F6) on  track  (#1F1F1F) -> 14.98 (AAA)
      •  white  (#ffffff) on  track  (#1F1F1F) -> 16.48 (AAA)
      This fully exceeds the required WCAG AA standard.
