### PR TITLE
fix(a11y): disable pulse animations when prefers-reduced-motion: reduce

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Pulse and shimmer animations must only run when the user has not requested
+ * reduced motion (WCAG 2.1 AA – Success Criterion 2.3.3 / 2.2.2).
+ * Tailwind's built-in `animate-pulse` and `animate-spin` classes, plus our
+ * custom `animate-neon-pulse` and `animate-shimmer`, are wrapped here so they
+ * have no effect when prefers-reduced-motion: reduce is active.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .animate-pulse,
+  .animate-spin,
+  .animate-shimmer,
+  .animate-neon-pulse {
+    animation: none !important;
+  }
+}
+
 :root {
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -123,16 +123,5 @@ module.exports = {
   },
   plugins: [
     require('@tailwindcss/container-queries'),
-    function ({ addUtilities }) {
-      addUtilities({
-        '@media (prefers-reduced-motion: reduce)': {
-          '*, *::before, *::after': {
-            'animation-duration': '0.01ms !important',
-            'animation-iteration-count': '1 !important',
-            'transition-duration': '0.01ms !important',
-          },
-        },
-      });
-    },
   ],
 };


### PR DESCRIPTION
Gate animate-pulse, animate-shimmer, and animate-neon-pulse behind a prefers-reduced-motion: reduce media query in globals.css so they only run when the user has no motion preference (WCAG 2.1 AA SC 2.3.3).

Also removes the broken addUtilities plugin from tailwind.config.js that was emitting the media query as an invalid CSS selector, producing no output and leaving the animations unguarded.
closes #757 