### PR TITLE
fix(api): validate memo byte length, not character count (#issue)

### DIFF
--- a/app/api/remittance/build/route.ts
+++ b/app/api/remittance/build/route.ts
@@ -53,7 +53,7 @@ interface BuildRemittanceResponse {
 
 // ── Validation ────────────────────────────────────────────────────────────────
 
-function validateBuildRequest(body: unknown): BuildRemittanceRequest {
+export function validateBuildRequest(body: unknown): BuildRemittanceRequest {
   if (!body || typeof body !== 'object') {
     throw new Error('Request body must be a JSON object');
   }
@@ -81,10 +81,13 @@ function validateBuildRequest(body: unknown): BuildRemittanceRequest {
     throw new Error('currency must be either XLM or USDC');
   }
 
-  // Validate memo (optional)
+  // Validate memo (optional) — Stellar Memo.text is limited to 28 bytes
   const memo = typeof o.memo === 'string' ? o.memo.trim() : undefined;
-  if (memo && memo.length > 28) {
-    throw new Error('memo must be 28 characters or less');
+  if (memo) {
+    const byteLength = new TextEncoder().encode(memo).length;
+    if (byteLength > 28) {
+      throw new Error('memo must be 28 bytes or less');
+    }
   }
 
   return {

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -1,4 +1,4 @@
-# Idempotency Contract & Documentation
+ # Idempotency Contract & Documentation
 
 This document describes the design, contract, constraints, and known limitations of the idempotency layer in the Remitwise application.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:ui": "node node_modules/vitest/vitest.mjs --config vitest.config.mjs --configLoader runner --ui",
     "test:unit": "npm run test:unit:node && npm run test:unit:vitest",
     "test:unit:node": "node --test tests/unit/webhooks-verify.test.cjs tests/unit/middleware.test.cjs tests/unit/contract-cache.test.cjs",
-    "test:unit:vitest": "node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/unit/validation/savings-goals.test.ts tests/unit/middleware-gateway.test.ts",
+    "test:unit:vitest": "node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/unit/validation/savings-goals.test.ts tests/unit/middleware-gateway.test.ts tests/unit/remittance/build-validation.test.ts",
     "test:property": "node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/property",
     "test:integration": "node --test tests/integration/auth.test.cjs tests/integration/health.test.cjs tests/integration/validation.test.cjs && node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/integration/api",
     "test:e2e": "playwright test"

--- a/tests/unit/remittance/build-validation.test.ts
+++ b/tests/unit/remittance/build-validation.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression test: memo length validation uses byte count, not character count.
+ *
+ * Stellar Memo.text is limited to 28 bytes. The route handler must reject
+ * memos whose UTF‑8 encoding exceeds 28 bytes — even when the character
+ * count is ≤28 (e.g. multi‑byte characters like 'é' or emoji).
+ *
+ * Bug: inline check used `memo.length > 28` (character count) instead of
+ * `new TextEncoder().encode(memo).length > 28` (byte count).
+ *
+ * This test FAILS when run against the buggy code and PASSES after the fix.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('next/server', () => ({
+  NextRequest: class NextRequest {
+    readonly url: string;
+    readonly method: string;
+    private _body: unknown;
+    constructor(input: string, init?: RequestInit & { body?: string }) {
+      this.url = input;
+      this.method = init?.method ?? 'GET';
+      if (init?.body) {
+        try { this._body = JSON.parse(init.body as string); } catch { this._body = {}; }
+      }
+    }
+    async json(): Promise<unknown> { return this._body; }
+  },
+  NextResponse: {
+    json: (data: unknown) => new Response(JSON.stringify(data)),
+  },
+}));
+
+vi.mock('@/lib/session', () => ({
+  requireAuth: vi.fn(() =>
+    Promise.resolve({ address: 'GD6EAN3FULNVU5QMVLAXANHMIPPAIWLIPFZYBCMJ4LPH5VME4H477EYQ' }),
+  ),
+}));
+
+vi.mock('@/lib/api/types', () => ({
+  jsonSuccess: (data: unknown) =>
+    new Response(JSON.stringify({ success: true, ...(data as object) }), { status: 200 }),
+  jsonError: (_code: string, message: string) =>
+    new Response(JSON.stringify({ success: false, error: message }), { status: 400 }),
+}));
+
+vi.mock('@/lib/soroban/client', () => ({
+  getServer: vi.fn(() => ({
+    getAccount: vi.fn(() =>
+      Promise.resolve({ accountId: () => '', sequenceNumber: () => '0' }),
+    ),
+    simulateTransaction: vi.fn(() => Promise.resolve({})),
+  })),
+  getNetworkPassphrase: vi.fn(() => 'Test SDF Network ; September 2015'),
+}));
+
+import { validateBuildRequest } from '@/app/api/remittance/build/route';
+
+const VALID_ADDRESS = 'GD6EAN3FULNVU5QMVLAXANHMIPPAIWLIPFZYBCMJ4LPH5VME4H477EYQ';
+const VALID_BASE = {
+  amount: 100,
+  currency: 'USDC' as const,
+  recipientAddress: VALID_ADDRESS,
+};
+
+describe('validateBuildRequest – memo byte-length validation', () => {
+  it('accepts undefined memo', () => {
+    const result = validateBuildRequest({ ...VALID_BASE });
+    expect(result.memo).toBeUndefined();
+  });
+
+  it('accepts empty memo string', () => {
+    expect(() => validateBuildRequest({ ...VALID_BASE, memo: '' })).not.toThrow();
+  });
+
+  it('accepts ASCII memo within 28 bytes', () => {
+    const result = validateBuildRequest({ ...VALID_BASE, memo: 'Hello' });
+    expect(result.memo).toBe('Hello');
+  });
+
+  it('accepts exactly 28‑byte ASCII memo', () => {
+    const memo = 'A'.repeat(28);
+    const result = validateBuildRequest({ ...VALID_BASE, memo });
+    expect(result.memo).toBe(memo);
+  });
+
+  it('rejects ASCII memo exceeding 28 bytes', () => {
+    expect(() => validateBuildRequest({ ...VALID_BASE, memo: 'A'.repeat(29) }))
+      .toThrow('memo must be 28 bytes or less');
+  });
+
+  it('rejects multi‑byte memo exceeding 28 bytes', () => {
+    // 'é' (U+00E9) = 2 bytes in UTF‑8; 15 chars = 30 bytes
+    // BUG: With memo.length > 28 check: 15 > 28 is false → no reject → test FAILS
+    // FIX: With byte length check: 30 > 28 is true → rejects → test PASSES
+    expect(() => validateBuildRequest({ ...VALID_BASE, memo: 'é'.repeat(15) }))
+      .toThrow('memo must be 28 bytes or less');
+  });
+
+  it('accepts multi‑byte memo exactly 28 bytes', () => {
+    // 14 × 'é' = 28 bytes
+    const memo = 'é'.repeat(14);
+    const result = validateBuildRequest({ ...VALID_BASE, memo });
+    expect(result.memo).toBe(memo);
+  });
+
+  it('rejects emoji memo exceeding 28 bytes', () => {
+    // '😀' (U+1F600) = 4 bytes; 8 chars = 32 bytes
+    expect(() => validateBuildRequest({ ...VALID_BASE, memo: '😀'.repeat(8) }))
+      .toThrow('memo must be 28 bytes or less');
+  });
+
+  it('accepts emoji memo exactly 28 bytes', () => {
+    // 7 × '😀' = 28 bytes
+    const memo = '😀'.repeat(7);
+    const result = validateBuildRequest({ ...VALID_BASE, memo });
+    expect(result.memo).toBe(memo);
+  });
+});


### PR DESCRIPTION
Close #725 

PR Description
## Summary

Reject memos > 28 bytes with an inline validation error in `POST /api/remittance/build`, preventing the Stellar network rejection that would otherwise occur at submission time.

Closes #issue

## Background

The route handler in `app/api/remittance/build/route.ts` validated memo length with `memo.length > 28`, which counts JavaScript characters, not UTF-8 bytes. Stellar's `Memo.text` enforces a **28-byte** limit. Multi-byte characters such as `é` (2 bytes) or `😀` (4 bytes) could pass the character-count check but exceed the byte limit, causing a network-level rejection after the user had already signed and submitted the transaction.

## Changes

1. **`app/api/remittance/build/route.ts`** — Replace `memo.length > 28` with `new TextEncoder().encode(memo).length > 28`. Also updated the comment and error message from "28 characters" to "28 bytes".

2. **`tests/unit/remittance/build-validation.test.ts`** — 9-test regression suite covering:
   - Valid memos (undefined, empty, ASCII within bounds, multi-byte exactly 28 bytes)
   - Rejected memos (ASCII > 28 bytes, multi-byte > 28 bytes, emoji > 28 bytes)
   - The multi-byte and emoji cases **fail against the old character-count code** and **pass after the fix**

3. **`package.json`** — Added the new test to the `test:unit:vitest` script.

## User-visible impact

Before this fix, a user entering a memo such as `ééééééééééééééé` (15 chars, 30 bytes) would pass client-side validation, submit the transaction, and receive a network rejection — with no clear indication that the memo was the cause. After the fix, the error is surfaced inline before the transaction is built, with the message *"memo must be 28 bytes or less"*.

**Mitigations users may have applied:** Shortening memos experimentally until submission succeeded, or using ASCII-only memos.

## Verification

- `npm run test:unit:vitest` — 50/50 tests pass (30 savings-goals, 11 middleware-gateway, 9 build-validation)
- `npm run test:unit:node` — 23/23 pass
- The multi-byte regression test (`'é'.repeat(15)` → 30 bytes) fails on the old code and passes on the fix

