### PR TITLE
Add a session-timeout warning modal

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -83,11 +83,12 @@ export async function POST(request: NextRequest) {
     }
 
     // Create encrypted session (production logic from main)
-    const sealed = await createSession(address);
+    const { sealed, session } = await createSession(address);
 
     const response = NextResponse.json({
       success: true,
       address,
+      expiresAt: session.expiresAt,
     });
 
     response.headers.set(

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -10,5 +10,5 @@ export async function GET() {
       { status: 401 }
     );
   }
-  return Response.json({ address: session.address });
+  return Response.json({ address: session.address, expiresAt: session.expiresAt });
 }

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -12,5 +12,5 @@ export async function POST() {
     );
   }
   
-  return Response.json({ success: true, address: session.address });
+  return Response.json({ success: true, address: session.address, expiresAt: session.expiresAt });
 }

--- a/lib/client/sessionHandler.ts
+++ b/lib/client/sessionHandler.ts
@@ -135,6 +135,7 @@ function clearAuthState(): void {
     localStorage.removeItem('wallet_address');
     localStorage.removeItem('wallet_connected');
     localStorage.removeItem('auth_state');
+    localStorage.removeItem('remitwise_session_expiry');
   }
 }
 

--- a/lib/client/useSessionExpiry.ts
+++ b/lib/client/useSessionExpiry.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { apiClient } from './apiClient';
+import { sessionHandler } from './sessionHandler';
 
 export type SessionPhase = 'none' | 'warning' | 'expired';
 
@@ -26,11 +27,33 @@ export interface SessionExpiryState {
   clearExpiry: () => void;
 }
 
+const SESSION_EXPIRY_KEY = 'remitwise_session_expiry';
+const WARNING_SECONDS = 60;
+
+function storeSessionExpiry(expiresAt: number) {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(SESSION_EXPIRY_KEY, expiresAt.toString());
+  }
+}
+
+function getStoredSessionExpiry(): number | null {
+  if (typeof window === 'undefined') return null;
+  const stored = localStorage.getItem(SESSION_EXPIRY_KEY);
+  return stored ? parseInt(stored, 10) : null;
+}
+
+function clearStoredSessionExpiry() {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem(SESSION_EXPIRY_KEY);
+  }
+}
+
 /**
  * Listens for global session-expiry window events and turns them into local UI state.
+ * Also tracks session expiry from stored data and dispatches warnings at T-60s.
  *
  * Phases:
- * - `'warning'`: the app has received a `session-expiring` event and should show a countdown.
+ * - `'warning'`: the app has received a `session-expiring` event or T-60s is reached, and should show a countdown.
  * - `'expired'`: the app has received `session-expired`, or the warning countdown reached zero.
  *
  * Event contract:
@@ -50,6 +73,8 @@ export function useSessionExpiry(): SessionExpiryState {
   const [countdown, setCountdown] = useState(0);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const expiryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const warningTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const clearCountdown = useCallback(() => {
     if (countdownRef.current) {
@@ -58,12 +83,49 @@ export function useSessionExpiry(): SessionExpiryState {
     }
   }, []);
 
-  const reset = useCallback(() => {
+  const clearTimers = useCallback(() => {
     clearCountdown();
+    if (expiryTimerRef.current) {
+      clearTimeout(expiryTimerRef.current);
+      expiryTimerRef.current = null;
+    }
+    if (warningTimerRef.current) {
+      clearTimeout(warningTimerRef.current);
+      warningTimerRef.current = null;
+    }
+  }, [clearCountdown]);
+
+  const reset = useCallback(() => {
+    clearTimers();
     setPhase('none');
     setMessage('');
     setCountdown(0);
-  }, [clearCountdown]);
+  }, [clearTimers]);
+
+  const setSessionExpiry = useCallback((expiresAt: number) => {
+    storeSessionExpiry(expiresAt);
+    clearTimers();
+
+    const now = Date.now();
+    const timeUntilExpiry = expiresAt - now;
+    const timeUntilWarning = Math.max(0, timeUntilExpiry - WARNING_SECONDS * 1000);
+
+    if (timeUntilExpiry <= 0) {
+      // Session already expired
+      sessionHandler.handleSessionExpiry();
+      return;
+    }
+
+    // Set warning timer
+    warningTimerRef.current = setTimeout(() => {
+      sessionHandler.dispatchSessionExpiring(WARNING_SECONDS);
+    }, timeUntilWarning);
+
+    // Set expiry timer
+    expiryTimerRef.current = setTimeout(() => {
+      sessionHandler.handleSessionExpiry();
+    }, timeUntilExpiry);
+  }, [clearTimers]);
 
   const staySignedIn = useCallback(async () => {
     if (process.env.NEXT_PUBLIC_SESSION_REFRESH_ENABLED !== 'true') {
@@ -74,7 +136,13 @@ export function useSessionExpiry(): SessionExpiryState {
     setIsRefreshing(true);
     try {
       // Use the server-aware apiClient so 401s are handled consistently.
-      await apiClient.post('/api/auth/refresh');
+      const response = await apiClient.post('/api/auth/refresh');
+      if (response) {
+        const data = await response.json();
+        if (data.expiresAt) {
+          setSessionExpiry(data.expiresAt);
+        }
+      }
       // Dispatch success to clear UI warnings (handled by the listener below).
       window.dispatchEvent(new CustomEvent('session-refresh'));
       return true;
@@ -84,11 +152,35 @@ export function useSessionExpiry(): SessionExpiryState {
     } finally {
       setIsRefreshing(false);
     }
-  }, []);
+  }, [setSessionExpiry]);
 
   const reconnect = useCallback(() => {
     window.location.href = '/';
   }, []);
+
+  // Initial load: check stored expiry and fetch current session
+  useEffect(() => {
+    const fetchSession = async () => {
+      try {
+        const response = await apiClient.get('/api/auth/me');
+        if (response) {
+          const data = await response.json();
+          if (data.expiresAt) {
+            setSessionExpiry(data.expiresAt);
+          }
+        }
+      } catch (error) {
+        console.error('Failed to fetch session', error);
+      }
+    };
+
+    const storedExpiry = getStoredSessionExpiry();
+    if (storedExpiry) {
+      setSessionExpiry(storedExpiry);
+    }
+
+    fetchSession();
+  }, [setSessionExpiry]);
 
   useEffect(() => {
     const handleExpiring = (event: Event) => {
@@ -96,7 +188,7 @@ export function useSessionExpiry(): SessionExpiryState {
       clearCountdown();
       setPhase('warning');
       setMessage(detail.message || 'Your session is about to expire. For your security, you will be signed out automatically.');
-      const initialCountdown = detail.countdown ?? 120;
+      const initialCountdown = detail.countdown ?? WARNING_SECONDS;
       setCountdown(initialCountdown);
 
       countdownRef.current = setInterval(() => {
@@ -113,7 +205,8 @@ export function useSessionExpiry(): SessionExpiryState {
     };
 
     const handleExpired = (event: Event) => {
-      clearCountdown();
+      clearTimers();
+      clearStoredSessionExpiry();
       const detail = (event as CustomEvent).detail || {};
       setPhase('expired');
       setMessage(detail.message || 'Your session has expired. Please reconnect your wallet to continue.');
@@ -124,17 +217,27 @@ export function useSessionExpiry(): SessionExpiryState {
       reset();
     };
 
+    // Listen for login events to store new session expiry
+    const handleLogin = (event: Event) => {
+      const detail = (event as CustomEvent).detail || {};
+      if (detail.expiresAt) {
+        setSessionExpiry(detail.expiresAt);
+      }
+    };
+
     window.addEventListener('session-expiring', handleExpiring);
     window.addEventListener('session-expired', handleExpired);
     window.addEventListener('session-refresh', handleRefresh);
+    window.addEventListener('session-login', handleLogin);
 
     return () => {
       window.removeEventListener('session-expiring', handleExpiring);
       window.removeEventListener('session-expired', handleExpired);
       window.removeEventListener('session-refresh', handleRefresh);
-      clearCountdown();
+      window.removeEventListener('session-login', handleLogin);
+      clearTimers();
     };
-  }, [clearCountdown, reset]);
+  }, [clearCountdown, clearTimers, reset, setSessionExpiry]);
 
   return { phase, message, countdown, isRefreshing, staySignedIn, reconnect, clearExpiry: reset };
 }

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -357,7 +357,7 @@ export async function requireAuth(): Promise<{ address: string }> {
   }
 }
 
-export async function createSession(address: string): Promise<string> {
+export async function createSession(address: string): Promise<{ sealed: string; session: SessionData }> {
   const now = Date.now();
   const sessionMaxAge = getSessionMaxAge();
   const expiresAt = now + sessionMaxAge * 1000;
@@ -366,7 +366,7 @@ export async function createSession(address: string): Promise<string> {
     password: getPassword(),
     ttl: sessionMaxAge,
   });
-  return sealed;
+  return { sealed, session };
 }
 
 export function getSessionCookieHeader(sealed: string): string {


### PR DESCRIPTION
Close: #770

## Summary
1. Updated Session Management ( lib/session.ts ):
   
   - Modified createSession to return both the sealed session cookie and the session data (including expiresAt ).
2. Enhanced Auth API Routes:
   
   - app/api/auth/login/route.ts : Now returns expiresAt in the login response.
   - app/api/auth/me/route.ts : Returns expiresAt when fetching the current session.
   - app/api/auth/refresh/route.ts : Returns expiresAt when refreshing the session.
3. Improved Session Expiry Hook ( lib/client/useSessionExpiry.ts ):
   
   - Tracks session expiry using localStorage.
   - Fetches current session data on initial load to get the expiry time.
   - Sets timers to trigger the warning modal at T-60 seconds and auto-logout at T=0.
   - Updates expiry time when the session is refreshed.
4. Updated Session Handler ( lib/client/sessionHandler.ts ):
   
   - Clears the stored session expiry from localStorage when logging out.
The warning modal will appear 60 seconds before the session expires, giving the user the option to "Stay logged in" (which refreshes the session). If the user doesn't take action, they will be automatically logged out and redirected to the home page when the session expires.