### PR TITLE
feat(ui): add success and failure toasts for sign, send, approve, and…

### DIFF
--- a/app/family/components/ApprovalsQueue.tsx
+++ b/app/family/components/ApprovalsQueue.tsx
@@ -4,6 +4,7 @@ import { CheckCircle2, Clock3, Loader2, PenLine, Users, XCircle } from "lucide-r
 import { useEffect, useRef } from "react";
 import { useWallet } from "stellar-wallet-kit";
 import { useClientTranslator } from "@/lib/i18n/client";
+import { useToast } from "@/lib/context/ToastContext";
 import AsyncSubmissionStatus from "@/components/AsyncSubmissionStatus";
 import WidgetEmptyState from "@/components/ui/WidgetEmptyState";
 import WidgetErrorState from "@/components/ui/WidgetErrorState";
@@ -121,6 +122,7 @@ export interface ApprovalsQueueProps {
 
 export default function ApprovalsQueue({ hook }: ApprovalsQueueProps) {
   const { t } = useClientTranslator();
+  const { toast } = useToast();
   const { account, isConnected: connected, signTransaction } = useWallet();
   const address = account?.address ?? "";
   const internal = useApprovalsQueue();
@@ -139,11 +141,26 @@ export default function ApprovalsQueue({ hook }: ApprovalsQueueProps) {
 
   const handleSign = async (id: string) => {
     if (!connected || !address) return;
-    await signItem(id, address, (xdr) =>
-      // Route through the wallet-kit's signTransaction — no new primitive
+    const result = await signItem(id, address, (xdr) =>
+      // Route through the wallet-kit signTransaction — no new primitive
       signTransaction(xdr, { networkPassphrase: undefined as unknown as string })
         .then((r) => (typeof r === "string" ? r : (r as { signedTxXdr: string }).signedTxXdr))
     );
+
+    if (!result) return;
+
+    if (result.success && result.approved) {
+      toast({ variant: "success", title: t("approvals_queue.approved_toast") });
+    } else if (result.success) {
+      toast({ variant: "success", title: t("approvals_queue.signed_toast") });
+    } else {
+      toast({
+        variant: "error",
+        title: t("approvals_queue.sign_failed_toast"),
+        description: result.error,
+        duration: 0,
+      });
+    }
   };
 
   const pendingCount = visibleQueue.filter((i) => i.status === "pending").length;

--- a/components/insurance/PolicyDetail.tsx
+++ b/components/insurance/PolicyDetail.tsx
@@ -16,6 +16,7 @@ import {
 import { type Policy } from "@/lib/contracts/insurance";
 import { getPolicyPaymentPresentation } from "@/lib/ui/status-semantics";
 import { usePolicyActions } from "@/lib/hooks/usePolicyActions";
+import { useToast } from "@/lib/context/ToastContext";
 import AsyncSubmissionStatus from "@/components/AsyncSubmissionStatus";
 
 /**
@@ -70,6 +71,8 @@ export default function PolicyDetail({
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const [showPayConfirm, setShowPayConfirm] = useState(false);
   const [showDeactivateConfirm, setShowDeactivateConfirm] = useState(false);
+
+  const { toast } = useToast();
 
   const {
     payState,
@@ -132,18 +135,45 @@ export default function PolicyDetail({
     }
   }, [open, resetPay, resetDeactivate]);
 
+  // ── Toast feedback (separate from callbacks to avoid re-firing) ────────────
+  useEffect(() => {
+    if (payState.status === "success") {
+      toast({ variant: "success", title: t("insurance.pay_success_toast") });
+    } else if (payState.status === "error") {
+      toast({
+        variant: "error",
+        title: t("insurance.pay_error_toast"),
+        description: payState.message,
+        duration: 0,
+      });
+    }
+  }, [payState.status, payState.message, payState.xdr, toast, t]);
+
+  useEffect(() => {
+    if (deactivateState.status === "success") {
+      toast({ variant: "success", title: t("insurance.deactivate_success_toast") });
+    } else if (deactivateState.status === "error") {
+      toast({
+        variant: "error",
+        title: t("insurance.deactivate_error_toast"),
+        description: deactivateState.message,
+        duration: 0,
+      });
+    }
+  }, [deactivateState.status, deactivateState.message, deactivateState.xdr, toast, t]);
+
   // ── Handle action success callbacks ────────────────────────────────────────
   useEffect(() => {
     if (payState.status === "success" && onPaySuccess) {
       onPaySuccess(payState.xdr);
     }
-  }, [payState, onPaySuccess]);
+  }, [payState.status, payState.xdr, onPaySuccess]);
 
   useEffect(() => {
     if (deactivateState.status === "success" && onDeactivateSuccess) {
       onDeactivateSuccess(deactivateState.xdr);
     }
-  }, [deactivateState, onDeactivateSuccess]);
+  }, [deactivateState.status, deactivateState.xdr, onDeactivateSuccess]);
 
   if (!open || !policy) return null;
 

--- a/docs/toast-pattern.md
+++ b/docs/toast-pattern.md
@@ -106,3 +106,10 @@ Programmatically remove a toast before its timer expires.
 | Bills | Bill overdue reminder | `warning` + action → `/bills` |
 | Settings | Preferences saved | `success` (short duration) |
 | Session | Session expired | `error` (duration: 0) — replaces `SessionExpiryNotification` |
+| Approvals queue | Signature collected (approval threshold not yet met) | `success` |
+| Approvals queue | Approval threshold reached (item approved) | `success` |
+| Approvals queue | Signing failed | `error` (duration: 0) |
+| Policy (pay) | Premium payment XDR ready | `success` |
+| Policy (pay) | Payment request failed | `error` (duration: 0) |
+| Policy (deactivate) | Policy deactivated | `success` |
+| Policy (deactivate) | Deactivation request failed | `error` (duration: 0) |

--- a/lib/hooks/useApprovalsQueue.ts
+++ b/lib/hooks/useApprovalsQueue.ts
@@ -108,6 +108,12 @@ export interface EnqueueUpdateLimitParams {
   requiredSignatures?: number;
 }
 
+export interface SignItemResult {
+  success: boolean;
+  approved: boolean;
+  error?: string;
+}
+
 export interface UseApprovalsQueueReturn {
   queue: ApprovalItem[];
   enqueueAddMember: (params: EnqueueAddMemberParams) => Promise<void>;
@@ -115,12 +121,13 @@ export interface UseApprovalsQueueReturn {
   /**
    * Sign a pending item.
    * `signXdr` should invoke the wallet-kit sign method and return the signed XDR.
+   * Returns the outcome so callers can show toast feedback.
    */
   signItem: (
     id: string,
     signerAddress: string,
     signXdr: (xdr: string) => Promise<string>
-  ) => Promise<void>;
+  ) => Promise<SignItemResult | undefined>;
   /** Mark any items older than APPROVAL_TTL_MS as expired */
   expireStale: () => void;
 }
@@ -225,7 +232,7 @@ export function useApprovalsQueue(): UseApprovalsQueueReturn {
       id: string,
       signerAddress: string,
       signXdr: (xdr: string) => Promise<string>
-    ) => {
+    ): Promise<SignItemResult | undefined> => {
       const item = queue.find((i) => i.id === id);
       if (!item || item.status !== "pending") return;
       if (item.collectedSignatures.includes(signerAddress)) return;
@@ -234,6 +241,12 @@ export function useApprovalsQueue(): UseApprovalsQueueReturn {
       try {
         await signXdr(item.xdr);
         dispatch({ type: "ADD_SIGNATURE", id, signer: signerAddress });
+        // Use the original item data (from the closure) plus the new signer
+        // to determine approval status.  Reading queue after dispatch would
+        // still see the stale closure, so we compute from what we know.
+        const approved =
+          item.collectedSignatures.length + 1 >= item.requiredSignatures;
+        return { success: true, approved };
       } catch (err) {
         // Revert to pending so the user can retry
         dispatch({
@@ -242,6 +255,11 @@ export function useApprovalsQueue(): UseApprovalsQueueReturn {
           status: "pending",
           error: err instanceof Error ? err.message : "Signing failed",
         });
+        return {
+          success: false,
+          approved: false,
+          error: err instanceof Error ? err.message : "Signing failed",
+        };
       }
     },
     [queue]

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -1,4 +1,15 @@
 {
+  "approvals_queue": {
+    "signed_toast": "Signature collected",
+    "approved_toast": "Approval complete",
+    "sign_failed_toast": "Signing failed"
+  },
+  "insurance": {
+    "pay_success_toast": "Payment XDR ready for signing",
+    "pay_error_toast": "Payment failed",
+    "deactivate_success_toast": "Policy deactivated",
+    "deactivate_error_toast": "Deactivation failed"
+  },
   "errors": {
     "generic": "Something went wrong. Please try again.",
     "network": "Network connection error. Check your connection.",

--- a/lib/i18n/locales/es.json
+++ b/lib/i18n/locales/es.json
@@ -1,4 +1,15 @@
 {
+  "approvals_queue": {
+    "signed_toast": "Firma registrada",
+    "approved_toast": "Aprobación completada",
+    "sign_failed_toast": "Error al firmar"
+  },
+  "insurance": {
+    "pay_success_toast": "Pago listo para firmar",
+    "pay_error_toast": "Error al procesar el pago",
+    "deactivate_success_toast": "Póliza desactivada",
+    "deactivate_error_toast": "Error al desactivar"
+  },
   "errors": {
     "generic": "Algo salió mal. Por favor, inténtelo de nuevo.",
     "network": "Error de conexión de red. Compruebe su conexión.",


### PR DESCRIPTION
closes #720 
… delete actions

# Add success/failure toasts for sign, send, approve, and delete actions

## Summary

Success and failure toasts now appear for **sign**, **send**, **approve**, and **delete** actions across the app, closing the last gaps in the toast-feedback surface established by the `ToastContext` pattern.

Previously the send-money flow showed toasts but the approvals queue (sign/approve) and the insurance policy detail (pay/deactivate) did not, forcing users to check inline status indicators to know whether an action completed or failed.

Closes #

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [x] `docs` — documentation only
- [ ] `ci` — CI / workflow changes
- [ ] `chore` — dependency bump or tooling update

## Scope

- [ ] Contract (`contracts/`)
- [x] Frontend / Web (`app/`, `lib/i18n/`)
- [x] Docs (`docs/`)
- [ ] CI / Ops (`.github/`)

---

## What changed and why

### `lib/hooks/useApprovalsQueue.ts` — `signItem` returns a result

| Area | Before | After |
|---|---|---|
| `signItem` return type | `Promise<void>` | `Promise<SignItemResult \| undefined>` |
| Caller visibility | Could not distinguish success, failure, or approval-threshold reached | Returns `{ success, approved, error? }` |
| API compatibility | — | Backwards compatible — existing code ignores the return value |

The `signItem` method now returns a `SignItemResult` object so the component layer can fire the correct toast without reading stale reducer state. The approval check uses `item.collectedSignatures.length + 1 >= item.requiredSignatures` (derived from the closure-captured item, which avoids stale-queue bugs).

### `app/family/components/ApprovalsQueue.tsx` — sign / approve toasts

- Imported `useToast`
- `handleSign` now inspects the `signItem` return value:
  - `approved: true` → success toast **"Approval complete"**
  - `approved: false` → success toast **"Signature collected"**
  - Error → persistent error toast **"Signing failed"** with description

### `components/insurance/PolicyDetail.tsx` — pay / deactivate toasts

- Imported `useToast`
- Separated toast feedback from callback handling into two `useEffect` blocks per action to prevent duplicate toasts when the parent re-passes `onPaySuccess` / `onDeactivateSuccess`
- **Pay success** → success toast **"Payment XDR ready for signing"**
- **Pay error** → persistent error toast **"Payment failed"**
- **Deactivate success** → success toast **"Policy deactivated"**
- **Deactivate error** → persistent error toast **"Deactivation failed"**

### Send — already covered

The send-money page (`app/send/page.tsx`) and emergency-transfer page (`app/emergency-transfer/page.tsx`) already had success/error toasts. No change needed.

### `lib/i18n/locales/en.json` + `es.json`

Added 6 keys in each locale:

| Key | EN | ES |
|---|---|---|
| `approvals_queue.signed_toast` | Signature collected | Firma registrada |
| `approvals_queue.approved_toast` | Approval complete | Aprobación completada |
| `approvals_queue.sign_failed_toast` | Signing failed | Error al firmar |
| `insurance.pay_success_toast` | Payment XDR ready for signing | Pago listo para firmar |
| `insurance.pay_error_toast` | Payment failed | Error al procesar el pago |
| `insurance.deactivate_success_toast` | Policy deactivated | Póliza desactivada |
| `insurance.deactivate_error_toast` | Deactivation failed | Error al desactivar |

### `docs/toast-pattern.md` — documentation

Added 6 rows to the "Key flow integration points" table covering the new toast events.

---

## Acceptance criteria

| Requirement | Status |
|---|---|
| Sign → success/failure toasts | ✅ |
| Approve → success toast when threshold reached | ✅ |
| Send → already had toasts | ✅ (no change) |
| Delete (deactivate) → success/failure toasts | ✅ |
| Backwards compatible public API | ✅ `signItem` returns richer type; existing callers ignore it |
| i18n keys in en + es | ✅ 7 keys per locale |
| Docs updated | ✅ `docs/toast-pattern.md` |

## Edge cases covered

- **Stale closure in `signItem`**: Approval threshold is computed from the closure-captured `item.collectedSignatures.length + 1`, not from a post-dispatch `queue.find()` that could still see stale state
- **Duplicate toasts on prop re-render**: `PolicyDetail.tsx` separates toast effects (depend only on state primitives) from callback effects (depend on `onPaySuccess`/`onDeactivateSuccess`)
- **Silent no-op when signer already signed**: `signItem` returns `undefined`, `handleSign` exits without a toast
- **Silent no-op when item not pending**: Same — `undefined` return, no toast

## Breaking changes

None. The `UseApprovalsQueueReturn` interface gains the `SignItemResult` type but the return value of `signItem` is backwards compatible — existing consumers that ignore the return value compile without changes.

## Checklist

- [x] Self-review completed
- [x] Code follows existing patterns (ToastContext, useCallback/useReducer)
- [x] No new dependencies added
- [x] All copy externalised to `lib/i18n/locales/`
- [x] Docs updated (`docs/toast-pattern.md`)
- [x] No breaking changes to public API
- [x] Pre-existing test suites unaffected (hook tests use inline reducer copies; PolicyDetail tests don't exist yet)
