### PR TITLE
fix: add page heading deep links

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ See [API Routes Documentation](./docs/API_ROUTES.md) for details on authenticati
 
 For authenticated browser-side requests, use the shared client API layer documented in [docs/client-api.md](docs/client-api.md). That guide covers when to use `apiClient` instead of raw `fetch`, the `401 -> refresh -> retry once` flow, session-expiry UI surfacing, and logout behavior.
 
+Route-level page titles now use a shared deep-link heading pattern. Use the shared heading primitive with a stable route-specific id whenever you add or update a primary page title. See [docs/page-heading-deeplinks.md](docs/page-heading-deeplinks.md).
+
 **Quick Reference:**
 
 - Public routes: `/api/health`, `/api/auth/*`

--- a/app/api/docs/SwaggerUIWrapper.tsx
+++ b/app/api/docs/SwaggerUIWrapper.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import SwaggerUI from 'swagger-ui-react';
 import Image from 'next/image';
 import Link from 'next/link';
+import PageHeadingLink from '@/components/PageHeadingLink';
 
 type SwaggerUIWrapperProps = {
   specUrl: string;
@@ -48,7 +49,14 @@ export default function SwaggerUIWrapper({ specUrl }: SwaggerUIWrapperProps) {
                 <span className="text-brand-dark text-lg font-bold tracking-tight">RemitWise</span>
               </Link>
               <div className="hidden sm:block w-px h-6 bg-gray-300"></div>
-              <h1 className="text-gray-700 font-semibold text-base sm:text-lg">API Documentation</h1>
+              <PageHeadingLink
+                headingId="api-docs-page-heading"
+                label="API Documentation"
+                headingClassName="text-gray-700 font-semibold text-base sm:text-lg"
+                buttonClassName="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-gray-300 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              >
+                API Documentation
+              </PageHeadingLink>
             </div>
 
             {/* Navigation */}

--- a/app/bills/page.tsx
+++ b/app/bills/page.tsx
@@ -199,6 +199,7 @@ export default function Bills() {
 				title='Bill Payments'
 				subtitle='Manage and track your recurring bills'
 				ctaLabel='Add Bill'
+				headingId='bills-page-heading'
 				onCtaClick={handleAddBill}
 				showBottomDivider
 			/>

--- a/app/dashboard/goals/page.tsx
+++ b/app/dashboard/goals/page.tsx
@@ -104,6 +104,7 @@ export default function SavingsGoalsPage() {
         title={t('savingsGoals.title')}
         subtitle={t('savingsGoals.subtitle')}
         ctaLabel={t('savingsGoals.newGoal')}
+        headingId="savings-goals-page-heading"
         onCtaClick={handleNewGoal}
         showBottomDivider
       />
@@ -153,4 +154,3 @@ export default function SavingsGoalsPage() {
     </div>
   )
 }
-

--- a/app/dashboard/insight/page.tsx
+++ b/app/dashboard/insight/page.tsx
@@ -9,6 +9,7 @@ import { RemittanceTrendChart, type TrendDataPoint } from '@/components/Insights
 import { WidgetErrorState, WidgetEmptyState } from '@/components/ui/WidgetStates';
 import { SkeletonCard } from '@/components/ui/Skeleton';
 import { formatCurrency } from '@/lib/utils/format-currency';
+import PageHeadingLink from '@/components/PageHeadingLink';
 
 type Period = 'current_month' | 'last_3_months' | 'last_year';
 
@@ -129,7 +130,14 @@ export default function InsightPage() {
         >
             <div className="max-w-[928px] mx-auto space-y-6">
                 <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-                    <h1 className="text-2xl font-bold text-white tracking-tight">Financial Insights</h1>
+                    <PageHeadingLink
+                        headingId="dashboard-insights-page-heading"
+                        label="Financial Insights"
+                        headingClassName="text-2xl font-bold text-white tracking-tight"
+                        buttonClassName="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 text-white/60 transition-colors hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0A0A]"
+                    >
+                        Financial Insights
+                    </PageHeadingLink>
                     <select
                         aria-label="Select period"
                         value={period}

--- a/app/dashboard/transaction-history/components/transaction-history-header.tsx
+++ b/app/dashboard/transaction-history/components/transaction-history-header.tsx
@@ -3,6 +3,7 @@
 import { ArrowLeft } from "lucide-react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import PageHeadingLink from "@/components/PageHeadingLink";
 
 interface ITransactionHistoryHeaderProps {
   title: string;
@@ -28,9 +29,14 @@ const TransactionHistoryHeader: React.FC<ITransactionHistoryHeaderProps> = ({
             <ArrowLeft size={17} className="text-white" />
           </button>
           <div className="min-w-0">
-            <h5 className="text-xl font-bold leading-7 tracking-[0.07px] text-white sm:text-2xl sm:leading-8">
+            <PageHeadingLink
+              headingId="transaction-history-page-heading"
+              label={title}
+              headingClassName="text-xl font-bold leading-7 tracking-[0.07px] text-white sm:text-2xl sm:leading-8"
+              buttonClassName="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 text-white/60 transition-colors hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#010101]"
+            >
               {title}
-            </h5>
+            </PageHeadingLink>
             <p className="mt-1 max-w-2xl text-xs font-normal leading-5 tracking-[-0.15px] text-white/60 sm:text-sm">
               {subtitle}
             </p>

--- a/app/emergency-transfer/page.tsx
+++ b/app/emergency-transfer/page.tsx
@@ -18,6 +18,7 @@ import {
   Shield,
 } from "lucide-react";
 import TransactionSuccessReceipt from "@/components/TransactionSuccessReceipt";
+import PageHeadingLink from "@/components/PageHeadingLink";
 
 type Step = "recipient" | "amount" | "review" | "confirm";
 
@@ -106,9 +107,14 @@ export default function EmergencyTransferPage() {
               <div className="p-2 bg-brand-red rounded-full shadow-[0_0_20px_rgba(215,35,35,0.4)]">
                 <Zap className="w-5 h-5 text-white" />
               </div>
-              <h1 className="text-2xl font-bold text-(--foreground)">
+              <PageHeadingLink
+                headingId="emergency-transfer-page-heading"
+                label="Emergency Transfer"
+                headingClassName="text-2xl font-bold text-(--foreground)"
+                buttonClassName="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 text-white/60 transition-colors hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              >
                 Emergency Transfer
-              </h1>
+              </PageHeadingLink>
             </div>
           </div>
         </div>

--- a/app/family/page.tsx
+++ b/app/family/page.tsx
@@ -25,6 +25,7 @@ export default function FamilyWallets() {
 				title={t("family_wallets.page_title")}
 				subtitle={t("family_wallets.page_subtitle")}
 				ctaLabel={t("family_wallets.add_member_cta")}
+				headingId='family-wallets-page-heading'
 				onCtaClick={handleAddMember}
 				showBottomDivider
 			/>

--- a/app/financial-insight/page.tsx
+++ b/app/financial-insight/page.tsx
@@ -7,6 +7,7 @@ import {
     Shield,
 } from "lucide-react";
 import StatCard from "@/components/Dashboard/StatCard";
+import PageHeadingLink from "@/components/PageHeadingLink";
 
 export default function FinancialInsight() {
     return (
@@ -21,9 +22,14 @@ export default function FinancialInsight() {
                         >
                             <ArrowLeft className="w-6 h-6" />
                         </Link>
-                        <h1 className="text-2xl font-bold text-white">
+                        <PageHeadingLink
+                            headingId="financial-insight-page-heading"
+                            label="Financial Insights"
+                            headingClassName="text-2xl font-bold text-white"
+                            buttonClassName="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 text-white/60 transition-colors hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0A0A]"
+                        >
                             Financial Insights
-                        </h1>
+                        </PageHeadingLink>
                     </div>
                 </div>
             </header>

--- a/app/insurance/page.tsx
+++ b/app/insurance/page.tsx
@@ -8,6 +8,7 @@ import { apiClient } from "@/lib/client/apiClient";
 import { SkeletonList } from "@/components/ui/Skeleton";
 import PolicyDetail from "@/components/insurance/PolicyDetail";
 import NewPolicyForm from "@/components/forms/NewPolicyForm";
+import PageHeadingLink from "@/components/PageHeadingLink";
 
 // ─── i18n stubs (replace with your real i18n hook) ───────────────────────────
 
@@ -146,9 +147,14 @@ export default function InsurancePage() {
         {/* Header */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
           <div>
-            <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">
+            <PageHeadingLink
+              headingId="insurance-page-heading"
+              label={t("insurance.page_title")}
+              headingClassName="text-2xl sm:text-3xl font-bold tracking-tight"
+              buttonClassName="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 text-white/60 transition-colors hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0b0f]"
+            >
               {t("insurance.page_title")}
-            </h1>
+            </PageHeadingLink>
             <p className="text-gray-400 mt-1 text-sm sm:text-base">
               {t("insurance.page_subtitle")}
             </p>

--- a/app/send/components/SendHeader.tsx
+++ b/app/send/components/SendHeader.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 import { ArrowLeft, Users } from 'lucide-react'
+import PageHeadingLink from '@/components/PageHeadingLink'
 
 export default function SendHeader() {
     const router = useRouter()
@@ -19,7 +20,14 @@ export default function SendHeader() {
                     </button>
 
                     <div>
-                        <h1 className="text-xl sm:text-2xl font-bold">Send Remittance</h1>
+                        <PageHeadingLink
+                            headingId="send-page-heading"
+                            label="Send Remittance"
+                            headingClassName="text-xl sm:text-2xl font-bold"
+                            buttonClassName="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 text-white/60 transition-colors hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#010101]"
+                        >
+                            Send Remittance
+                        </PageHeadingLink>
                         <p className="text-sm text-[#FFFFFF66] hidden sm:block">Transfer money via Stellar network</p>
                     </div>
                 </div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -9,6 +9,7 @@ import { SecuritySection } from "@/components/settings/SecuritySection";
 import { WalletSection } from "@/components/settings/WalletSection";
 import { FamilySection } from "@/components/settings/FamilySection";
 import { PreferencesSection } from "@/components/settings/PreferencesSection";
+import PageHeadingLink from "@/components/PageHeadingLink";
 
 const SECTIONS = [
   { id: "profile",        labelKey: "settings.sections.profile",         icon: User    },
@@ -65,9 +66,14 @@ export default function SettingsPage() {
       {/* ── Sticky top bar (mobile breadcrumb / desktop title) ── */}
       <header className="sticky top-0 z-30 bg-white/80 dark:bg-gray-900/80 backdrop-blur border-b border-gray-100 dark:border-gray-800">
         <div className="mx-auto max-w-5xl flex h-14 items-center gap-3 px-4 sm:px-6">
-          <h1 className="text-base font-semibold text-gray-900 dark:text-white">
+          <PageHeadingLink
+            headingId="settings-page-heading"
+            label={t("settings.page_title")}
+            headingClassName="text-base font-semibold text-gray-900 dark:text-white"
+            buttonClassName="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-gray-300 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white dark:focus-visible:ring-offset-gray-900"
+          >
             {t("settings.page_title")}
-          </h1>
+          </PageHeadingLink>
           {/* Mobile: horizontal scrollable nav pills */}
           <nav
             className="ml-auto flex gap-1 overflow-x-auto sm:hidden scrollbar-none"

--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -30,6 +30,7 @@ import {
   serializeToJson,
   getExportFilename,
 } from "@/lib/utils/export-serializer";
+import PageHeadingLink from "@/components/PageHeadingLink";
 
 const allTransactions: Transaction[] = [
   {
@@ -466,9 +467,15 @@ export default function TransactionsPage() {
               <p className="text-xs font-semibold uppercase tracking-[0.28em] text-red-300">
                 {t("transactionHistory.titleStandalone")}
               </p>
-              <h1 className="mt-3 text-2xl font-semibold text-white sm:text-3xl">
+              <PageHeadingLink
+                headingId="transactions-page-heading"
+                label="USDC activity"
+                wrapperClassName="mt-3 flex min-w-0 items-center gap-2"
+                headingClassName="text-2xl font-semibold text-white sm:text-3xl"
+                buttonClassName="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 text-white/60 transition-colors hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#010101]"
+              >
                 USDC activity
-              </h1>
+              </PageHeadingLink>
               <p className="mt-2 max-w-2xl text-sm leading-6 text-gray-400">
                 {t("transactionHistory.subtitleStandalone")}
               </p>

--- a/app/tutorial/[tutorialId]/page.tsx
+++ b/app/tutorial/[tutorialId]/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import PageHeadingLink from "@/components/PageHeadingLink";
 
 type Props = {
   params: Promise<{ tutorialId: string }>;
@@ -31,7 +32,15 @@ export default async function TutorialOverviewPage({ params }: Props) {
             <Link href="/tutorial" className="text-sm font-medium text-brand-red hover:text-brand-redHover">
               Back to tutorials
             </Link>
-            <h1 className="mt-3 text-3xl font-bold text-foreground">{tutorialId}</h1>
+            <PageHeadingLink
+              headingId="tutorial-overview-page-heading"
+              label={`${tutorialId} tutorial`}
+              wrapperClassName="mt-3 flex min-w-0 items-center gap-2"
+              headingClassName="text-3xl font-bold text-foreground"
+              buttonClassName="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-current/15 text-current/70 transition-colors hover:bg-current/10 hover:text-current focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#101010]"
+            >
+              {tutorialId}
+            </PageHeadingLink>
             <p className="mt-2 text-sm text-muted max-w-2xl">
               Continue your learning path and resume the next available chapter when you’re ready.
             </p>

--- a/app/tutorial/page.tsx
+++ b/app/tutorial/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ArrowLeft, BookOpen } from "lucide-react";
 import TutorialList from "../../components/tutorials/TutorialList";
+import PageHeadingLink from "@/components/PageHeadingLink";
 
 export default function TutorialPage() {
   const tutorials = [
@@ -55,7 +56,14 @@ export default function TutorialPage() {
             >
               <ArrowLeft className="w-6 h-6" />
             </Link>
-            <h1 className="text-2xl font-bold text-foreground">Tutorials</h1>
+            <PageHeadingLink
+              headingId="tutorials-page-heading"
+              label="Tutorials"
+              headingClassName="text-2xl font-bold text-foreground"
+              buttonClassName="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-current/15 text-current/70 transition-colors hover:bg-current/10 hover:text-current focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#101010]"
+            >
+              Tutorials
+            </PageHeadingLink>
           </div>
         </div>
       </header>

--- a/components/FinancialInsightsHeader.tsx
+++ b/components/FinancialInsightsHeader.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { ArrowLeft, Calendar, ChevronDown, Download } from 'lucide-react'
 import { useState } from 'react'
+import PageHeadingLink from '@/components/PageHeadingLink'
 
 type DateRange = 'This Month' | 'Last Month' | 'Last 3 Months' | 'Last 6 Months' | 'This Year' | 'Custom Range'
 
@@ -62,9 +63,16 @@ export default function FinancialInsightsHeader({
             
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-1.5">
-                <h1 className="text-sm sm:text-base font-bold text-white leading-tight truncate">
+                <PageHeadingLink
+                  headingId="financial-insights-page-heading-mobile"
+                  copyHeadingId="financial-insights-page-heading"
+                  label="Financial Insights"
+                  headingClassName="truncate text-sm sm:text-base font-bold text-white leading-tight"
+                  buttonClassName="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-white/10 text-white/60 transition-colors hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0A0A]"
+                  iconClassName="h-3.5 w-3.5"
+                >
                   Financial Insights
-                </h1>
+                </PageHeadingLink>
                 <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-[#D72323] text-white text-[9px] font-bold uppercase tracking-wide">
                   PRO
                 </span>
@@ -154,7 +162,14 @@ export default function FinancialInsightsHeader({
             </button>
             <div>
               <div className="flex items-center gap-2.5">
-                <h1 className="text-xl xl:text-2xl font-bold text-white">Financial Insights</h1>
+                <PageHeadingLink
+                  headingId="financial-insights-page-heading"
+                  label="Financial Insights"
+                  headingClassName="text-xl xl:text-2xl font-bold text-white"
+                  buttonClassName="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 text-white/60 transition-colors hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0A0A]"
+                >
+                  Financial Insights
+                </PageHeadingLink>
                 <span className="inline-flex items-center px-2.5 py-1 rounded-lg bg-[#D72323] text-white text-xs font-bold uppercase tracking-wider shadow-lg shadow-[#D72323]/30">
                   PRO
                 </span>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { LightningBoltIcon } from "@radix-ui/react-icons";
 import Image from "next/image";
+import PageHeadingLink from "@/components/PageHeadingLink";
 
 export default function Hero() {
   return (
@@ -41,13 +42,21 @@ export default function Hero() {
         </div>
 
         {/* Main Headline - Clear value proposition */}
-        <h1 className="mx-auto font-bold text-center text-white text-[44px] sm:text-[56px] md:text-[72px] leading-[52px] sm:leading-[64px] md:leading-[84px] w-full max-w-[1000px] tracking-tight">
-          Global Payments
-          <br />
-          <span className="bg-gradient-to-r from-[#DC2626] to-[#FF6B35] bg-clip-text text-transparent">
-            Without Borders
-          </span>
-        </h1>
+        <PageHeadingLink
+          headingId="home-page-heading"
+          label="Global Payments Without Borders"
+          wrapperClassName="mx-auto flex w-full max-w-[1040px] items-start justify-center gap-3 text-center"
+          headingClassName="mx-auto w-full max-w-[1000px] font-bold text-center text-white text-[44px] sm:text-[56px] md:text-[72px] leading-[52px] sm:leading-[64px] md:leading-[84px] tracking-tight"
+          buttonClassName="mt-2 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/5 text-white/70 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+        >
+          <>
+            Global Payments
+            <br />
+            <span className="bg-gradient-to-r from-[#DC2626] to-[#FF6B35] bg-clip-text text-transparent">
+              Without Borders
+            </span>
+          </>
+        </PageHeadingLink>
 
         {/* Subheadline - Concise, benefit-focused */}
         <div className="mx-auto mt-6 w-full max-w-[700px] px-4">

--- a/components/PageHeader.tsx
+++ b/components/PageHeader.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 import { ArrowLeft, Plus } from 'lucide-react'
+import PageHeadingLink from '@/components/PageHeadingLink'
 
 type PageHeaderProps = {
   title: string
@@ -9,6 +10,7 @@ type PageHeaderProps = {
   ctaLabel: string
   onCtaClick?: () => void
   showBottomDivider?: boolean
+  headingId?: string
   /** 'red' (default) or 'redOrange' for reddish-orange CTA e.g. Savings Goals */
   ctaVariant?: 'red' | 'redOrange'
 }
@@ -19,6 +21,7 @@ export default function PageHeader({
   ctaLabel,
   onCtaClick,
   showBottomDivider = false,
+  headingId = 'page-heading',
   ctaVariant = 'red',
 }: PageHeaderProps) {
   const router = useRouter()
@@ -42,7 +45,14 @@ export default function PageHeader({
               <ArrowLeft className="w-5 h-5 text-white" />
             </button>
             <div>
-              <h1 className="text-xl sm:text-2xl font-bold text-white">{title}</h1>
+              <PageHeadingLink
+                headingId={headingId}
+                label={title}
+                headingClassName="text-xl sm:text-2xl font-bold text-white"
+                buttonClassName="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 text-white/60 transition-colors hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#010101]"
+              >
+                {title}
+              </PageHeadingLink>
               <p className="text-sm text-gray-400 mt-0.5">{subtitle}</p>
             </div>
           </div>

--- a/components/PageHeadingLink.tsx
+++ b/components/PageHeadingLink.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Check, Hash } from "lucide-react";
+import { useEffect, useRef, useState, type ElementType, type ReactNode } from "react";
+import {
+  buildCanonicalHeadingUrl,
+  copyTextToClipboard,
+  PAGE_HEADING_LINK_FEEDBACK_MS,
+} from "@/lib/client/pageHeadingLink";
+
+type PageHeadingLinkProps = {
+  headingId: string;
+  copyHeadingId?: string;
+  label: string;
+  children: ReactNode;
+  as?: ElementType;
+  wrapperClassName?: string;
+  headingClassName?: string;
+  buttonClassName?: string;
+  iconClassName?: string;
+};
+
+const DEFAULT_WRAPPER_CLASS =
+  "flex min-w-0 items-center gap-2";
+const DEFAULT_BUTTON_CLASS =
+  "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-current/15 text-current/70 transition-colors hover:bg-current/10 hover:text-current focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent";
+const DEFAULT_ICON_CLASS = "h-4 w-4";
+
+export default function PageHeadingLink({
+  headingId,
+  copyHeadingId = headingId,
+  label,
+  children,
+  as: HeadingTag = "h1",
+  wrapperClassName = DEFAULT_WRAPPER_CLASS,
+  headingClassName,
+  buttonClassName = DEFAULT_BUTTON_CLASS,
+  iconClassName = DEFAULT_ICON_CLASS,
+}: PageHeadingLinkProps) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      const canonicalUrl = buildCanonicalHeadingUrl(window.location, copyHeadingId);
+      await copyTextToClipboard(canonicalUrl);
+      setCopied(true);
+
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+
+      timeoutRef.current = window.setTimeout(() => {
+        setCopied(false);
+      }, PAGE_HEADING_LINK_FEEDBACK_MS);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  const buttonLabel = copied ? `Copied link to ${label}` : `Copy link to ${label}`;
+
+  return (
+    <div className={wrapperClassName}>
+      <HeadingTag id={headingId} className={headingClassName}>
+        {children}
+      </HeadingTag>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className={buttonClassName}
+        aria-label={buttonLabel}
+        title={buttonLabel}
+      >
+        {copied ? (
+          <Check className={iconClassName} aria-hidden="true" />
+        ) : (
+          <Hash className={iconClassName} aria-hidden="true" />
+        )}
+        <span className="sr-only">{buttonLabel}</span>
+      </button>
+    </div>
+  );
+}

--- a/components/SmartMoneySplitHeader.tsx
+++ b/components/SmartMoneySplitHeader.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 import { ArrowLeft, AlertCircle } from 'lucide-react'
+import PageHeadingLink from '@/components/PageHeadingLink'
 
 interface SmartMoneySplitHeaderProps {
   totalPercentage?: number
@@ -25,7 +26,14 @@ export default function SmartMoneySplitHeader({ totalPercentage = 100 }: SmartMo
           </button>
           
           <div>
-            <h1 className="text-2xl 375:text-3xl font-bold text-white tracking-tight">Smart Money Split</h1>
+            <PageHeadingLink
+              headingId="split-page-heading"
+              label="Smart Money Split"
+              headingClassName="text-2xl 375:text-3xl font-bold text-white tracking-tight"
+              buttonClassName="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 text-white/60 transition-colors hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#010101]"
+            >
+              Smart Money Split
+            </PageHeadingLink>
             <p className="text-white/40 text-xs 375:text-sm mt-1">Configure automatic allocation</p>
           </div>
         </div>

--- a/docs/page-heading-deeplinks.md
+++ b/docs/page-heading-deeplinks.md
@@ -1,0 +1,28 @@
+# Page Heading Deep Links
+
+Primary page titles in RemitWise include an inline hash-link button that copies the canonical page URL with a stable heading hash.
+
+## Rules
+
+- Scope is primary route-level page titles only.
+- Do not add this control to section headings, widget headings, or modal headings.
+- Use an explicit stable heading id per route, such as `bills-page-heading`.
+- Keep ids stable across copy edits, translations, and design changes.
+
+## URL format
+
+Copied links use:
+
+`origin + pathname + #headingId`
+
+The copied URL does not include the current query string or any existing hash.
+
+## Feedback behavior
+
+- Clicking the inline hash button copies the canonical URL.
+- The control shows inline success feedback briefly.
+- The click does not mutate the current URL or trigger toast feedback.
+
+## Implementation note
+
+Use the shared `PageHeadingLink` primitive for new primary page titles. Shared header components should pass an explicit `headingId` so page-level routes keep a stable canonical link target.

--- a/lib/client/pageHeadingLink.ts
+++ b/lib/client/pageHeadingLink.ts
@@ -1,0 +1,48 @@
+export const PAGE_HEADING_LINK_FEEDBACK_MS = 2000;
+
+export type CanonicalHeadingLocation = Pick<Location, "origin" | "pathname">;
+
+export function buildCanonicalHeadingUrl(
+  location: CanonicalHeadingLocation,
+  headingId: string,
+): string {
+  return `${location.origin}${location.pathname}#${headingId}`;
+}
+
+function fallbackCopyText(text: string): void {
+  if (typeof document === "undefined") {
+    throw new Error("Clipboard fallback is unavailable.");
+  }
+
+  const textArea = document.createElement("textarea");
+  textArea.value = text;
+  textArea.setAttribute("readonly", "");
+  textArea.style.position = "fixed";
+  textArea.style.opacity = "0";
+  textArea.style.pointerEvents = "none";
+
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+  textArea.setSelectionRange(0, text.length);
+
+  const copied = document.execCommand("copy");
+  document.body.removeChild(textArea);
+
+  if (!copied) {
+    throw new Error("Clipboard copy failed.");
+  }
+}
+
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (
+    typeof navigator !== "undefined" &&
+    navigator.clipboard &&
+    typeof navigator.clipboard.writeText === "function"
+  ) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  fallbackCopyText(text);
+}

--- a/tests/unit/client/pageHeadingLink.test.tsx
+++ b/tests/unit/client/pageHeadingLink.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import PageHeadingLink from "@/components/PageHeadingLink";
+import {
+  buildCanonicalHeadingUrl,
+  PAGE_HEADING_LINK_FEEDBACK_MS,
+} from "@/lib/client/pageHeadingLink";
+
+describe("PageHeadingLink", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    window.history.replaceState({}, "", "/insights?tab=latest#current");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("builds a canonical URL from origin, pathname, and heading id", () => {
+    expect(
+      buildCanonicalHeadingUrl(
+        { origin: "https://example.com", pathname: "/dashboard/insight" },
+        "dashboard-insights-page-heading",
+      ),
+    ).toBe("https://example.com/dashboard/insight#dashboard-insights-page-heading");
+  });
+
+  it("renders a semantic heading with an inline copy control", () => {
+    render(
+      <PageHeadingLink headingId="insights-page-heading" label="Insights">
+        Insights
+      </PageHeadingLink>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Insights" })).toHaveAttribute(
+      "id",
+      "insights-page-heading",
+    );
+    expect(
+      screen.getByRole("button", { name: /copy link to insights/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("copies the canonical URL and resets its success state after the timeout", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", {
+      clipboard: { writeText },
+    });
+
+    render(
+      <PageHeadingLink headingId="insights-page-heading" label="Insights">
+        Insights
+      </PageHeadingLink>,
+    );
+
+    const button = screen.getByRole("button", { name: /copy link to insights/i });
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(writeText).toHaveBeenCalledWith("http://localhost:3000/insights#insights-page-heading");
+    expect(
+      screen.getByRole("button", { name: /copied link to insights/i }),
+    ).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(PAGE_HEADING_LINK_FEEDBACK_MS);
+    });
+
+    expect(
+      screen.getByRole("button", { name: /copy link to insights/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to execCommand when navigator.clipboard is unavailable", () => {
+    const execCommand = vi.fn(() => true);
+    vi.stubGlobal("navigator", {});
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(
+      <PageHeadingLink headingId="insights-page-heading" label="Insights">
+        Insights
+      </PageHeadingLink>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /copy link to insights/i }));
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("handles clipboard failures without throwing or staying stuck in the copied state", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("copy failed"));
+    vi.stubGlobal("navigator", {
+      clipboard: { writeText },
+    });
+
+    render(
+      <PageHeadingLink headingId="insights-page-heading" label="Insights">
+        Insights
+      </PageHeadingLink>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /copy link to insights/i }));
+
+    await Promise.resolve();
+
+    expect(writeText).toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: /copy link to insights/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/unit/transactions/page.test.tsx
+++ b/tests/unit/transactions/page.test.tsx
@@ -10,10 +10,14 @@ const revokeObjectURLMock = vi.fn();
 
 describe("TransactionsPage Export Component Integration", () => {
   beforeEach(() => {
-    vi.stubGlobal("URL", {
-      createObjectURL: createObjectURLMock,
-      revokeObjectURL: revokeObjectURLMock,
+    vi.spyOn(URL, "createObjectURL").mockImplementation(createObjectURLMock);
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(revokeObjectURLMock);
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
     });
+    window.history.replaceState({}, "", "/transactions?type=failed#group");
     // Mock anchor click behavior
     vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
     vi.useFakeTimers();
@@ -84,7 +88,7 @@ describe("TransactionsPage Export Component Integration", () => {
     renderComponent();
     
     // Type query that matches nothing in the search input
-    const searchInput = screen.getByPlaceholderText(/search id, recipient, type, status, amount/i);
+    const searchInput = screen.getByRole("searchbox");
     fireEvent.change(searchInput, { target: { value: "NonExistentTransactionXYZ" } });
 
     // Advance timer to trigger debounced filter update
@@ -128,5 +132,15 @@ describe("TransactionsPage Export Component Integration", () => {
     // Click outside
     fireEvent.mouseDown(document.body);
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("renders the page-heading copy button and copies the canonical URL", () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByRole("button", { name: /copy link to usdc activity/i }));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "http://localhost:3000/transactions#transactions-page-heading",
+    );
   });
 });

--- a/tests/unit/ui/page-header.test.tsx
+++ b/tests/unit/ui/page-header.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PageHeader from "@/components/PageHeader";
+
+const backMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    back: backMock,
+  }),
+}));
+
+describe("PageHeader deep links", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, "", "/bills?filter=all#old");
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it("renders a copy button for the primary page heading and copies the canonical URL", async () => {
+    render(
+      <PageHeader
+        title="Bill Payments"
+        subtitle="Manage and track your recurring bills"
+        ctaLabel="Add Bill"
+        headingId="bills-page-heading"
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Bill Payments" })).toHaveAttribute(
+      "id",
+      "bills-page-heading",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /copy link to bill payments/i }));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "http://localhost:3000/bills#bills-page-heading",
+    );
+  });
+});

--- a/tests/unit/ui/send-header.test.tsx
+++ b/tests/unit/ui/send-header.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SendHeader from "@/app/send/components/SendHeader";
+
+const backMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    back: backMock,
+  }),
+}));
+
+describe("SendHeader deep links", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, "", "/send?draft=1#review");
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it("copies the canonical URL from the fixed page title control", () => {
+    render(<SendHeader />);
+
+    fireEvent.click(screen.getByRole("button", { name: /copy link to send remittance/i }));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "http://localhost:3000/send#send-page-heading",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds inline deep-link copy buttons to primary page headings across the app. Each route-level page title now shows a small hash-link control that copies the canonical URL with a stable heading hash, while keeping the existing page layout and heading semantics intact.

Closes #766

## Type of change

- [x] `fix` — bug fix
- [x] `test` — adding or updating tests
- [x] `docs` — documentation updates

## What changed

- Added a shared `PageHeadingLink` component for primary page titles with inline copy feedback.
- Added shared deep-link helpers under `lib/client/` for:
  - canonical heading URL generation
  - clipboard copy handling
  - shared feedback timing
- Updated shared and direct page-title surfaces to use stable route-specific heading ids.
- Preserved existing public APIs by only adding optional `headingId` support where needed.
- Added focused unit coverage for:
  - the shared deep-link helper/component
  - shared-header integration
  - fixed-title header integration
  - direct page heading integration
- Documented the pattern in `README.md` and `docs/page-heading-deeplinks.md`.

## Acceptance criteria

- [x] Hash-link appears beside primary page headings
- [x] Clicking the control copies the canonical URL with a stable heading hash
- [x] Scope is limited to primary route-level page titles only
- [x] Existing public APIs remain backward-compatible
- [x] Docs updated alongside the code change

## Verification

- [x] Focused unit tests for the deep-link feature
- [x] `npm run lint`
- [ ] `npm run build`

## Notes

- `npm run lint` passes with one existing warning in `lib/hooks/useTransactionStatus.ts`.
- `npm run build` is currently blocked by a pre-existing unrelated build error in `lib/contracts/savings-goal.ts`.
- I fixed the pre-existing build errors in PR #825; this PR intentionally does not include those fixes to avoid conflicts.