### PR TITLE
feat(theme): persist theme preference across reloads and avoid FOUC

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,24 +6,41 @@
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;
   --background-end-rgb: 255, 255, 255;
+  --background: #ffffff;
+  --color-bg2: #f8fafc;
+  --color-bg3: #f1f5f9;
+  --card: linear-gradient(var(--color-bg2), var(--color-bg3));
+  --accent: #dc2626;
+  color-scheme: light;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-    --background: #010101;
-    --color-bg2: #0f0f0f;
-    --color-bg3: #0a0a0a;
-    --card: linear-gradient(var(--color-bg2), var(--color-bg3));
-    --accent: #dc2626;
-  }
+html.dark {
+  --foreground-rgb: 255, 255, 255;
+  --background-start-rgb: 0, 0, 0;
+  --background-end-rgb: 0, 0, 0;
+  --background: #010101;
+  --color-bg2: #0f0f0f;
+  --color-bg3: #0a0a0a;
+  --card: linear-gradient(var(--color-bg2), var(--color-bg3));
+  --accent: #dc2626;
+  color-scheme: dark;
+}
+
+html.light {
+  --foreground-rgb: 0, 0, 0;
+  --background-start-rgb: 214, 219, 220;
+  --background-end-rgb: 255, 255, 255;
+  --background: #ffffff;
+  --color-bg2: #f8fafc;
+  --color-bg3: #f1f5f9;
+  --card: linear-gradient(var(--color-bg2), var(--color-bg3));
+  --accent: #dc2626;
+  color-scheme: light;
 }
 
 body {
   color: rgb(var(--foreground-rgb));
-  background: black;
+  background: rgb(var(--background-start-rgb));
 }
 
 .starry-bg {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,8 @@ export const metadata: Metadata = {
     "A remittance app that helps families save, plan, and protect — not just send money.",
 };
 
+const themeScript = `(function(){try{var key='theme-preference';var theme=localStorage.getItem(key);if(theme!=='light'&&theme!=='dark'&&theme!=='system'){theme='system';}var root=document.documentElement;if(theme==='dark'){root.classList.add('dark');root.classList.remove('light');}else if(theme==='light'){root.classList.remove('dark');root.classList.add('light');}else{root.classList.remove('light');var mql=window.matchMedia('(prefers-color-scheme: dark)');root.classList.toggle('dark', mql.matches);} }catch(e){}})();`; 
+
 export default function RootLayout({
   children,
 }: {
@@ -19,6 +21,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${inter.className} starry-bg min-h-screen`}>
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -3,6 +3,7 @@
 import { ReactNode } from "react";
 import { WalletProvider } from "stellar-wallet-kit";
 import { DensityProvider } from "@/lib/context/DensityContext";
+import { ThemeProvider } from "@/lib/context/ThemeContext";
 import { ToastProvider } from "@/lib/context/ToastContext";
 import { AsyncOperationsProvider } from "@/lib/context/AsyncOperationsContext";
 import LayoutWrapper from "@/components/LayoutWrapper";
@@ -22,17 +23,19 @@ import CommandPalette from "@/components/CommandPalette";
 export default function Providers({ children }: { children: ReactNode }) {
   return (
     <WalletProvider>
-      <ToastProvider>
-        <DensityProvider>
-          <AsyncOperationsProvider>
-            <SessionExpiryProvider>
-              <LayoutWrapper>{children}</LayoutWrapper>
-              <ToastRegion />
-              <CommandPalette />
-            </SessionExpiryProvider>
-          </AsyncOperationsProvider>
-        </DensityProvider>
-      </ToastProvider>
+      <ThemeProvider>
+        <ToastProvider>
+          <DensityProvider>
+            <AsyncOperationsProvider>
+              <SessionExpiryProvider>
+                <LayoutWrapper>{children}</LayoutWrapper>
+                <ToastRegion />
+                <CommandPalette />
+              </SessionExpiryProvider>
+            </AsyncOperationsProvider>
+          </DensityProvider>
+        </ToastProvider>
+      </ThemeProvider>
     </WalletProvider>
   );
 }

--- a/components/settings/PreferencesSection.test.tsx
+++ b/components/settings/PreferencesSection.test.tsx
@@ -39,6 +39,14 @@ describe("PreferencesSection", () => {
     expect(comfortable).toHaveAttribute("aria-pressed", "true");
   });
 
+  it("restores the persisted theme preference and highlights the selected theme", () => {
+    renderWithProviders(<PreferencesSection />, { theme: "dark" });
+    const dark = screen.getByRole("button", {
+      name: "settings.preferences.theme_dark",
+    });
+    expect(dark).toHaveAttribute("aria-pressed", "true");
+  });
+
   it("updates density when the compact button is clicked", () => {
     renderWithProviders(<PreferencesSection />, { density: "comfortable" });
     const compact = screen.getByRole("button", {

--- a/components/settings/PreferencesSection.tsx
+++ b/components/settings/PreferencesSection.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
 import { Globe, Moon, Sun, Smartphone } from "lucide-react";
 import { useDensity } from "@/lib/context/DensityContext";
+import { useTheme } from "@/lib/context/ThemeContext";
 import { useClientTranslator } from "@/lib/i18n/client";
 import {
   SectionCard,
@@ -14,7 +14,7 @@ import {
 export function PreferencesSection() {
   const { t } = useClientTranslator();
   const { density, setDensity } = useDensity();
-  const [theme, setTheme] = useState<"system" | "light" | "dark">("system");
+  const { theme, setTheme } = useTheme();
   const themes = [
     { id: "system", labelKey: "settings.preferences.theme_system", Icon: Smartphone },
     { id: "light", labelKey: "settings.preferences.theme_light", Icon: Sun },

--- a/docs/settings-page-structure.md
+++ b/docs/settings-page-structure.md
@@ -62,8 +62,11 @@ fixed `id` matching `SECTIONS`:
   toggle, default-currency select, save button.
 - **`FamilySection`** (`#family`) — family member list with role badges and an
   invite button.
-- **`PreferencesSection`** (`#preferences`) — theme picker, **density controls
-  wired to `useDensity()`**, language/timezone selects, and date-format radios.
+- **`PreferencesSection`** (`#preferences`) — theme picker with persisted preference, **density controls wired to `useDensity()`**, language/timezone selects, and date-format radios.
+
+### Theme persistence
+- Theme preference is stored in `localStorage` under `theme-preference`.
+- The app reads the persisted preference before hydration to avoid flash-of-unstyled-content (FOUC) and uses the system preference as the fallback.
 
 ## Cross-cutting integrations
 

--- a/lib/config/theme.ts
+++ b/lib/config/theme.ts
@@ -1,0 +1,13 @@
+export type ThemePreference = "system" | "light" | "dark";
+
+export const THEME_STORAGE_KEY = "theme-preference";
+
+export const SUPPORTED_THEME_PREFERENCES: ThemePreference[] = [
+  "system",
+  "light",
+  "dark",
+];
+
+export function isThemePreference(value: unknown): value is ThemePreference {
+  return value === "system" || value === "light" || value === "dark";
+}

--- a/lib/context/ThemeContext.tsx
+++ b/lib/context/ThemeContext.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+} from "react";
+import {
+  THEME_STORAGE_KEY,
+  ThemePreference,
+  isThemePreference,
+} from "@/lib/config/theme";
+
+interface ThemeContextType {
+  theme: ThemePreference;
+  setTheme: (theme: ThemePreference) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+function applyThemePreference(theme: ThemePreference) {
+  const root = document.documentElement;
+  const updateClass = (isDark: boolean) => {
+    root.classList.toggle("dark", isDark);
+    root.classList.toggle("light", theme === "light");
+  };
+
+  if (theme === "dark") {
+    root.classList.add("dark");
+    root.classList.remove("light");
+    return;
+  }
+
+  if (theme === "light") {
+    root.classList.remove("dark");
+    root.classList.add("light");
+    return;
+  }
+
+  root.classList.remove("light");
+  const mediaQuery =
+    typeof window.matchMedia === "function"
+      ? window.matchMedia("(prefers-color-scheme: dark)")
+      : null;
+  const prefersDark = mediaQuery?.matches ?? false;
+  updateClass(prefersDark);
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<ThemePreference>(() => {
+    if (typeof window === "undefined") {
+      return "system";
+    }
+
+    const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+    return isThemePreference(storedTheme) ? storedTheme : "system";
+  });
+
+  useEffect(() => {
+    try {
+      applyThemePreference(theme);
+
+      if (theme === "system" && typeof window.matchMedia === "function") {
+        const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+        const listener = (event: MediaQueryListEvent) => {
+          applyThemePreference(theme);
+        };
+
+        if (typeof mediaQuery.addEventListener === "function") {
+          mediaQuery.addEventListener("change", listener);
+        } else {
+          mediaQuery.addListener(listener);
+        }
+
+        return () => {
+          if (typeof mediaQuery.removeEventListener === "function") {
+            mediaQuery.removeEventListener("change", listener);
+          } else {
+            mediaQuery.removeListener(listener);
+          }
+        };
+      }
+    } catch {
+      // Ignore DOM or localStorage failures silently.
+    }
+  }, [theme]);
+
+  const setTheme = useCallback((newTheme: ThemePreference) => {
+    setThemeState(newTheme);
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, newTheme);
+    } catch {
+      // Ignore localStorage write failures.
+    }
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextType {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error(
+      "useTheme must be used within a ThemeProvider. Did you forget to wrap your component in <ThemeProvider>?"
+    );
+  }
+  return context;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: ['class'],
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",

--- a/tests/react/renderWithProviders.tsx
+++ b/tests/react/renderWithProviders.tsx
@@ -1,23 +1,29 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import { DensityProvider, type Density } from "@/lib/context/DensityContext";
+import { ThemeProvider } from "@/lib/context/ThemeContext";
 import { ToastProvider } from "@/lib/context/ToastContext";
 
 export function renderWithProviders(
   ui: React.ReactElement,
   {
     density = "comfortable",
+    theme = "system",
   }: {
     density?: Density;
+    theme?: "system" | "light" | "dark";
   } = {},
 ) {
   // DensityProvider reads from localStorage on mount; keep deterministic.
   // jsdom localStorage is available.
   window.localStorage.setItem("display-density", density);
+  window.localStorage.setItem("theme-preference", theme);
 
   return render(
-    <DensityProvider>
-      <ToastProvider>{ui}</ToastProvider>
-    </DensityProvider>,
+    <ThemeProvider>
+      <DensityProvider>
+        <ToastProvider>{ui}</ToastProvider>
+      </DensityProvider>
+    </ThemeProvider>,
   );
 }

--- a/tests/unit/context/ThemeContext.test.tsx
+++ b/tests/unit/context/ThemeContext.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { ThemeProvider, useTheme } from "@/lib/context/ThemeContext";
+
+type MatchMediaStub = {
+  matches: boolean;
+  media: string;
+  onchange: null;
+  addListener: ReturnType<typeof vi.fn>;
+  removeListener: ReturnType<typeof vi.fn>;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  dispatchEvent: ReturnType<typeof vi.fn>;
+};
+
+function stubMatchMedia(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: (query: string): MatchMediaStub => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+}
+
+describe("ThemeContext", () => {
+  beforeEach(() => {
+    stubMatchMedia(false);
+    localStorage.clear();
+    document.documentElement.classList.remove("dark", "light");
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove("dark", "light");
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to system theme when no persisted preference exists", () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ({ children }) => <ThemeProvider>{children}</ThemeProvider>,
+    });
+
+    expect(result.current.theme).toBe("system");
+  });
+
+  it("restores a persisted dark theme and applies the dark class", () => {
+    localStorage.setItem("theme-preference", "dark");
+
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ({ children }) => <ThemeProvider>{children}</ThemeProvider>,
+    });
+
+    expect(result.current.theme).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.classList.contains("light")).toBe(false);
+  });
+
+  it("persists the selected theme preference to localStorage", () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ({ children }) => <ThemeProvider>{children}</ThemeProvider>,
+    });
+
+    act(() => {
+      result.current.setTheme("light");
+    });
+
+    expect(result.current.theme).toBe("light");
+    expect(localStorage.getItem("theme-preference")).toBe("light");
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+  });
+
+  it("adds or removes classes correctly when switching to system theme", () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ({ children }) => <ThemeProvider>{children}</ThemeProvider>,
+    });
+
+    act(() => {
+      result.current.setTheme("dark");
+    });
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+    act(() => {
+      result.current.setTheme("system");
+    });
+
+    expect(document.documentElement.classList.contains("dark")).toBe(
+      window.matchMedia("(prefers-color-scheme: dark)").matches,
+    );
+  });
+
+  it("throws when useTheme is used outside of ThemeProvider", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => renderHook(() => useTheme())).toThrow(
+      "useTheme must be used within a ThemeProvider. Did you forget to wrap your component in <ThemeProvider>?",
+    );
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #721

Summary:
- Persist theme preference in localStorage under `theme-preference`
- Add system-preference fallback for `system` theme
- Apply theme class before hydration to avoid FOUC
- Expose theme preference through `ThemeProvider` and `useTheme()`
- Update settings UI to read/write persisted theme
- Add tests for theme persistence and class behavior
- Document theme persistence in `docs/settings-page-structure.md`

Validation:
- Focused theme tests pass
- Lint passes with existing unrelated warning in `lib/hooks/useTransactionStatus.ts`
- Build is blocked by unrelated repo issues outside this change