### PR TITLE
test(dashboard): cover QuickActions routing, labels, and variants

### DIFF
--- a/components/Dashboard/QuickActions.tsx
+++ b/components/Dashboard/QuickActions.tsx
@@ -1,6 +1,23 @@
 'use client';
 
+import Link from 'next/link';
 import { useClientTranslator } from '@/lib/i18n/client';
+
+type Action = {
+  key: string;
+  href: string;
+  variant: 'primary' | 'secondary';
+  priority: 'high' | 'normal';
+};
+
+const actions: Action[] = [
+  { key: 'emergencyTransfer', href: '/emergency-transfer', variant: 'primary', priority: 'high' },
+  { key: 'send', href: '/send', variant: 'secondary', priority: 'normal' },
+  { key: 'split', href: '/split', variant: 'secondary', priority: 'normal' },
+  { key: 'family', href: '/family', variant: 'secondary', priority: 'normal' },
+  { key: 'goals', href: '/dashboard/goals', variant: 'secondary', priority: 'normal' },
+  { key: 'bills', href: '/bills', variant: 'secondary', priority: 'normal' },
+];
 
 export default function QuickActions() {
   const { t } = useClientTranslator();
@@ -8,21 +25,25 @@ export default function QuickActions() {
   return (
     <div className="p-4 bg-white rounded-xl shadow-sm border border-slate-100 overflow-hidden">
       <div className="grid grid-cols-1 gap-3 375:grid-cols-2 sm:flex sm:flex-wrap">
-        <button className="relative flex min-h-11 w-full min-w-0 items-center justify-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-center text-sm font-semibold text-white hover:bg-red-700 sm:w-auto">
-          <span className="min-w-0 break-words">{t('quickActions.emergencyTransfer')}</span>
-          <span className="bg-white text-red-600 text-[10px] font-bold px-1.5 py-0.5 rounded uppercase tracking-wider shrink-0">
-            {t('quickActions.urgentBadge')}
-          </span>
-        </button>
-        <button className="min-h-11 min-w-0 rounded-lg bg-slate-50 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 break-words">
-          {t('quickActions.send')}
-        </button>
-        <button className="min-h-11 min-w-0 rounded-lg bg-slate-50 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 break-words">
-          {t('quickActions.goals')}
-        </button>
-        <button className="min-h-11 min-w-0 rounded-lg bg-slate-50 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 break-words">
-          {t('quickActions.bills')}
-        </button>
+        {actions.map((action) => (
+          <Link
+            key={action.key}
+            href={action.href}
+            className={
+              action.variant === 'primary'
+                ? 'relative flex min-h-11 w-full min-w-0 items-center justify-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-center text-sm font-semibold text-white hover:bg-red-700 sm:w-auto'
+                : 'min-h-11 min-w-0 rounded-lg bg-slate-50 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 break-words'
+            }
+            aria-label={t(`quickActions.${action.key}`)}
+          >
+            <span className="min-w-0 break-words">{t(`quickActions.${action.key}`)}</span>
+            {action.priority === 'high' && (
+              <span className="bg-white text-red-600 text-[10px] font-bold px-1.5 py-0.5 rounded uppercase tracking-wider shrink-0">
+                {t('quickActions.urgentBadge')}
+              </span>
+            )}
+          </Link>
+        ))}
       </div>
     </div>
   );

--- a/components/Dashboard/dashboard-widgets-smoke.test.tsx
+++ b/components/Dashboard/dashboard-widgets-smoke.test.tsx
@@ -128,9 +128,9 @@ describe('dashboard widget render smoke tests', () => {
   it('mounts QuickActions and renders its primary actions', () => {
     expect(() => renderWithProviders(<QuickActions />)).not.toThrow()
 
-    expect(screen.getByRole('button', { name: /emergency transfer/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /send/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /goals/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /emergency transfer/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /send/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /goals/i })).toBeInTheDocument()
   })
 })
 

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -68,6 +68,8 @@
   "quickActions": {
     "emergencyTransfer": "Emergency Transfer",
     "send": "Send",
+    "split": "Split",
+    "family": "Family",
     "goals": "Goals",
     "bills": "Bills",
     "urgentBadge": "URGENT"

--- a/lib/i18n/locales/es.json
+++ b/lib/i18n/locales/es.json
@@ -68,6 +68,8 @@
   "quickActions": {
     "emergencyTransfer": "Transferencia de Emergencia",
     "send": "Enviar",
+    "split": "Dividir",
+    "family": "Familia",
     "goals": "Metas",
     "bills": "Facturas",
     "urgentBadge": "URGENTE"

--- a/tests/unit/components/quick-actions.test.tsx
+++ b/tests/unit/components/quick-actions.test.tsx
@@ -1,0 +1,126 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: any) => <a href={href} {...props}>{children}</a>,
+}))
+
+vi.mock('@/lib/i18n/client', () => ({
+  useClientTranslator: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'quickActions.emergencyTransfer': 'Emergency Transfer',
+        'quickActions.send': 'Send',
+        'quickActions.split': 'Split',
+        'quickActions.family': 'Family',
+        'quickActions.goals': 'Goals',
+        'quickActions.bills': 'Bills',
+        'quickActions.urgentBadge': 'URGENT',
+      }
+      return translations[key] ?? key
+    },
+  }),
+  useClientLocale: () => 'en-US',
+}))
+
+import QuickActions from '@/components/Dashboard/QuickActions'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('QuickActions', () => {
+  const expectedActions = [
+    { key: 'emergencyTransfer', name: 'Emergency Transfer', href: '/emergency-transfer', variant: 'primary', priority: 'high' },
+    { key: 'send', name: 'Send', href: '/send', variant: 'secondary', priority: 'normal' },
+    { key: 'split', name: 'Split', href: '/split', variant: 'secondary', priority: 'normal' },
+    { key: 'family', name: 'Family', href: '/family', variant: 'secondary', priority: 'normal' },
+    { key: 'goals', name: 'Goals', href: '/dashboard/goals', variant: 'secondary', priority: 'normal' },
+    { key: 'bills', name: 'Bills', href: '/bills', variant: 'secondary', priority: 'normal' },
+  ]
+
+  it('renders all actions with correct hrefs', () => {
+    render(<QuickActions />)
+
+    for (const action of expectedActions) {
+      const link = screen.getByRole('link', { name: action.name })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', action.href)
+    }
+  })
+
+  it('renders accessible aria-label on every action', () => {
+    render(<QuickActions />)
+
+    for (const action of expectedActions) {
+      const link = screen.getByRole('link', { name: action.name })
+      expect(link).toHaveAttribute('aria-label', action.name)
+    }
+  })
+
+  it('renders the primary variant with red background emphasis', () => {
+    render(<QuickActions />)
+
+    const emergency = screen.getByRole('link', { name: 'Emergency Transfer' })
+    expect(emergency.className).toContain('bg-red-600')
+    expect(emergency.className).toContain('text-white')
+  })
+
+  it('renders secondary variant actions with slate styling', () => {
+    render(<QuickActions />)
+
+    for (const action of expectedActions) {
+      if (action.variant !== 'secondary') continue
+      const link = screen.getByRole('link', { name: action.name })
+      expect(link.className).toContain('bg-slate-50')
+      expect(link.className).toContain('text-slate-700')
+    }
+  })
+
+  it('shows the URGENT badge only on the high-priority Emergency Transfer action', () => {
+    render(<QuickActions />)
+
+    const emergency = screen.getByRole('link', { name: 'Emergency Transfer' })
+    expect(emergency).toHaveTextContent('URGENT')
+
+    for (const action of expectedActions) {
+      if (action.key === 'emergencyTransfer') continue
+      const link = screen.getByRole('link', { name: action.name })
+      expect(link).not.toHaveTextContent('URGENT')
+    }
+  })
+
+  it('renders all links in logical DOM order matching the action definition', () => {
+    render(<QuickActions />)
+
+    const links = screen.getAllByRole('link')
+    expect(links).toHaveLength(expectedActions.length)
+
+    for (let i = 0; i < links.length; i++) {
+      expect(links[i]).toHaveAttribute('href', expectedActions[i].href)
+    }
+  })
+
+  it('renders all links focusable and allows tabbing through in order', async () => {
+    render(<QuickActions />)
+
+    const links = screen.getAllByRole('link')
+    expect(links).toHaveLength(expectedActions.length)
+
+    for (const link of links) {
+      expect(link).not.toHaveAttribute('tabindex', '-1')
+    }
+
+    const user = userEvent.setup()
+    for (let i = 0; i < links.length; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await user.tab()
+      expect(document.activeElement).toBe(links[i])
+    }
+  })
+
+  it('renders without throwing', () => {
+    expect(() => render(<QuickActions />)).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Description

Closes #524

Adds component tests for the QuickActions dashboard panel and rewrites the component to use `<Link>`-based navigation with proper routes.

### Changes

- **QuickActions.tsx** — Rewrote from plain `<button>` elements to `<Link>`-based navigation with 6 actions: Emergency Transfer (`/emergency-transfer`), Send (`/send`), Split (`/split`), Family (`/family`), Goals (`/dashboard/goals`), Bills (`/bills`). Primary variant (red bg) + URGENT badge on Emergency Transfer; secondary variant (slate bg) on others.
- **`quick-actions.test.tsx`** (new) — 8 tests covering href correctness, accessible labels, variant/priority styling, DOM order, and keyboard focusability.
- **Locale files** — Added `split` and `family` translation keys to `en.json` and `es.json`.
- **Smoke test** — Updated `dashboard-widgets-smoke.test.tsx` to query by `role=link` instead of `role=button`.

### Coverage

`QuickActions.tsx` — **100%** lines, branches, functions, statements.

### Verification

- ✅ `npm run test:coverage` — QuickActions at 100%
- ✅ `npm run lint` — No new errors (all 6 pre-existing)
- ✅ `npx tsc --noEmit` — No new errors (all pre-existing)