### PR TITLE
feat(ui): add expandable diagnostic details to error toasts

### DIFF
--- a/components/Toast.stories.tsx
+++ b/components/Toast.stories.tsx
@@ -1,0 +1,186 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Toast from "./Toast";
+import type { Toast as ToastType } from "@/lib/context/ToastContext";
+
+const meta = {
+  title: "Components/Toast",
+  component: Toast,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    toast: {
+      control: { type: "object" },
+    },
+    onDismiss: {
+      action: "dismissed",
+    },
+  },
+} satisfies Meta<typeof Toast>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Example toasts
+const successToast: ToastType = {
+  id: "success-1",
+  variant: "success",
+  title: "Transfer sent",
+  description: "Funds are on their way to the recipient.",
+  duration: 5000,
+};
+
+const errorToastBasic: ToastType = {
+  id: "error-1",
+  variant: "error",
+  title: "Transfer failed",
+  description: "Your account balance is too low.",
+  duration: 0,
+};
+
+const errorToastWithDiagnostics: ToastType = {
+  id: "error-2",
+  variant: "error",
+  title: "Transfer failed",
+  description: "Your account balance is too low.",
+  duration: 0,
+  diagnostics: {
+    requestId: "9d0f8c5d-1c7a-4d53-a74c-xxxxxxxx4",
+    errorCode: "INSUFFICIENT_BALANCE",
+    timestamp: new Date().toISOString(),
+  },
+};
+
+const errorToastWithPartialDiagnostics: ToastType = {
+  id: "error-3",
+  variant: "error",
+  title: "Payment processing failed",
+  description: "Failed to process your payment. Please try again.",
+  duration: 0,
+  diagnostics: {
+    requestId: "req-abc123-xyz789",
+  },
+};
+
+const warningToast: ToastType = {
+  id: "warning-1",
+  variant: "warning",
+  title: "Bill overdue",
+  description: "Electricity bill is 3 days overdue.",
+  duration: 5000,
+};
+
+const infoToast: ToastType = {
+  id: "info-1",
+  variant: "info",
+  title: "Session refreshed",
+  description: "Your session has been updated.",
+  duration: 5000,
+};
+
+const toastWithAction: ToastType = {
+  id: "warning-2",
+  variant: "warning",
+  title: "Low balance",
+  description: "Your account balance is running low.",
+  action: {
+    label: "Add funds",
+    onClick: () => alert("Opening funding modal..."),
+  },
+  duration: 0,
+};
+
+// Stories
+
+/**
+ * Success toast with auto-dismiss
+ */
+export const Success: Story = {
+  args: {
+    toast: successToast,
+    onDismiss: () => console.log("dismissed"),
+  },
+};
+
+/**
+ * Basic error toast without diagnostic details
+ */
+export const Error: Story = {
+  args: {
+    toast: errorToastBasic,
+    onDismiss: () => console.log("dismissed"),
+  },
+};
+
+/**
+ * Error toast with full diagnostic details disclosure
+ * Click "What failed" to expand and see request ID, error code, message, and timestamp
+ */
+export const ErrorWithDiagnostics: Story = {
+  args: {
+    toast: errorToastWithDiagnostics,
+    onDismiss: () => console.log("dismissed"),
+  },
+};
+
+/**
+ * Error toast with only request ID diagnostic (no error code or timestamp)
+ * Demonstrates that diagnostic fields are optional and only available fields are displayed
+ */
+export const ErrorWithPartialDiagnostics: Story = {
+  args: {
+    toast: errorToastWithPartialDiagnostics,
+    onDismiss: () => console.log("dismissed"),
+  },
+};
+
+/**
+ * Warning toast with auto-dismiss
+ */
+export const Warning: Story = {
+  args: {
+    toast: warningToast,
+    onDismiss: () => console.log("dismissed"),
+  },
+};
+
+/**
+ * Info toast with auto-dismiss
+ */
+export const Info: Story = {
+  args: {
+    toast: infoToast,
+    onDismiss: () => console.log("dismissed"),
+  },
+};
+
+/**
+ * Toast with action button
+ */
+export const WithAction: Story = {
+  args: {
+    toast: toastWithAction,
+    onDismiss: () => console.log("dismissed"),
+  },
+};
+
+/**
+ * Long title and description to test text wrapping
+ */
+export const LongContent: Story = {
+  args: {
+    toast: {
+      id: "long-1",
+      variant: "error",
+      title: "This is a very long error title that might wrap to multiple lines",
+      description:
+        "This is a detailed error message that explains what went wrong in comprehensive detail. The user can dismiss this or view more details.",
+      duration: 0,
+      diagnostics: {
+        requestId: "req-very-long-id-12345-67890-abcdef",
+        errorCode: "ERR_VALIDATION_FAILED",
+      },
+    },
+    onDismiss: () => console.log("dismissed"),
+  },
+};

--- a/components/Toast.test.tsx
+++ b/components/Toast.test.tsx
@@ -327,4 +327,243 @@ describe('Toast', () => {
       expect(mockOnDismiss).toHaveBeenCalledTimes(3);
     });
   });
+
+  describe('Disclosure (What failed)', () => {
+    it('should not show disclosure button for non-error variants', () => {
+      render(<Toast toast={mockToast} onDismiss={mockOnDismiss} />);
+      expect(screen.queryByText('What failed')).not.toBeInTheDocument();
+    });
+
+    it('should not show disclosure button for error toast without diagnostics', () => {
+      const errorToast: ToastType = {
+        id: 'test-error-1',
+        variant: 'error',
+        title: 'Error',
+        description: 'An error occurred',
+      };
+      render(<Toast toast={errorToast} onDismiss={mockOnDismiss} />);
+      expect(screen.queryByText('What failed')).not.toBeInTheDocument();
+    });
+
+    it('should show disclosure button for error toast with diagnostics', () => {
+      const errorToastWithDiagnostics: ToastType = {
+        id: 'test-error-2',
+        variant: 'error',
+        title: 'Error',
+        description: 'An error occurred',
+        diagnostics: {
+          requestId: '9d0f8c5d-1c7a-4d53-a74c-xxxxxxxx4',
+        },
+      };
+      render(<Toast toast={errorToastWithDiagnostics} onDismiss={mockOnDismiss} />);
+      expect(screen.getByText('What failed')).toBeInTheDocument();
+    });
+
+    it('should have disclosure hidden by default', () => {
+      const errorToastWithDiagnostics: ToastType = {
+        id: 'test-error-3',
+        variant: 'error',
+        title: 'Error',
+        description: 'An error occurred',
+        diagnostics: {
+          requestId: '9d0f8c5d-1c7a-4d53-a74c-xxxxxxxx4',
+        },
+      };
+      render(<Toast toast={errorToastWithDiagnostics} onDismiss={mockOnDismiss} />);
+      const disclosureButton = screen.getByText('What failed');
+      expect(disclosureButton).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByText('Request ID:')).not.toBeInTheDocument();
+    });
+
+    it('should expand disclosure when clicked', () => {
+      const errorToastWithDiagnostics: ToastType = {
+        id: 'test-error-4',
+        variant: 'error',
+        title: 'Error',
+        description: 'An error occurred',
+        diagnostics: {
+          requestId: '9d0f8c5d-1c7a-4d53-a74c-xxxxxxxx4',
+        },
+      };
+      render(<Toast toast={errorToastWithDiagnostics} onDismiss={mockOnDismiss} />);
+      const disclosureButton = screen.getByText('What failed');
+      
+      fireEvent.click(disclosureButton);
+      
+      expect(disclosureButton).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByText('Request ID:')).toBeInTheDocument();
+      expect(screen.getByText('9d0f8c5d-1c7a-4d53-a74c-xxxxxxxx4')).toBeInTheDocument();
+    });
+
+    it('should collapse disclosure when clicked again', () => {
+      const errorToastWithDiagnostics: ToastType = {
+        id: 'test-error-5',
+        variant: 'error',
+        title: 'Error',
+        description: 'An error occurred',
+        diagnostics: {
+          requestId: '9d0f8c5d-1c7a-4d53-a74c-xxxxxxxx4',
+        },
+      };
+      render(<Toast toast={errorToastWithDiagnostics} onDismiss={mockOnDismiss} />);
+      const disclosureButton = screen.getByText('What failed');
+      
+      // Open
+      fireEvent.click(disclosureButton);
+      expect(disclosureButton).toHaveAttribute('aria-expanded', 'true');
+      
+      // Close
+      fireEvent.click(disclosureButton);
+      expect(disclosureButton).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByText('Request ID:')).not.toBeInTheDocument();
+    });
+
+    it('should display request ID when available', () => {
+      const errorToastWithDiagnostics: ToastType = {
+        id: 'test-error-6',
+        variant: 'error',
+        title: 'Error',
+        description: 'An error occurred',
+        diagnostics: {
+          requestId: 'req-12345-67890',
+        },
+      };
+      render(<Toast toast={errorToastWithDiagnostics} onDismiss={mockOnDismiss} />);
+      
+      fireEvent.click(screen.getByText('What failed'));
+      
+      expect(screen.getByText('Request ID:')).toBeInTheDocument();
+      expect(screen.getByText('req-12345-67890')).toBeInTheDocument();
+    });
+
+    it('should display error code when available', () => {
+      const errorToastWithDiagnostics: ToastType = {
+        id: 'test-error-7',
+        variant: 'error',
+        title: 'Error',
+        description: 'An error occurred',
+        diagnostics: {
+          errorCode: 'ERR_500',
+          requestId: 'req-12345-67890',
+        },
+      };
+      render(<Toast toast={errorToastWithDiagnostics} onDismiss={mockOnDismiss} />);
+      
+      fireEvent.click(screen.getByText('What failed'));
+      
+      expect(screen.getByText('Error Code:')).toBeInTheDocument();
+      expect(screen.getByText('ERR_500')).toBeInTheDocument();
+    });
+
+    it('should display timestamp when available', () => {
+      const errorToastWithDiagnostics: ToastType = {
+        id: 'test-error-8',
+        variant: 'error',
+        title: 'Error',
+        description: 'An error occurred',
+        diagnostics: {
+          requestId: 'req-12345-67890',
+          timestamp: '2024-01-01T12:00:00Z',
+        },
+      };
+      render(<Toast toast={errorToastWithDiagnostics} onDismiss={mockOnDismiss} />);
+      
+      fireEvent.click(screen.getByText('What failed'));
+      
+      expect(screen.getByText('Timestamp:')).toBeInTheDocument();
+      expect(screen.getByText('2024-01-01T12:00:00Z')).toBeInTheDocument();
+    });
+
+    it('should display error message in disclosure', () => {
+      const errorToastWithDiagnostics: ToastType = {
+        id: 'test-error-9',
+        variant: 'error',
+        title: 'Error',
+        description: 'Detailed error message here',
+        diagnostics: {
+          requestId: 'req-12345-67890',
+        },
+      };
+      render(<Toast toast={errorToastWithDiagnostics} onDismiss={mockOnDismiss} />);
+      
+      fireEvent.click(screen.getByText('What failed'));
+      
+      expect(screen.getByText('Error Message:')).toBeInTheDocument();
+      expect(screen.getByText('Detailed error message here')).toBeInTheDocument();
+    });
+
+    it('should be keyboard accessible with Enter key', () => {
+      const errorToastWithDiagnostics: ToastType = {
+        id: 'test-error-10',
+        variant: 'error',
+        title: 'Error',
+        description: 'An error occurred',
+        diagnostics: {
+          requestId: 'req-12345-67890',
+        },
+      };
+      render(<Toast toast={errorToastWithDiagnostics} onDismiss={mockOnDismiss} />);
+      const disclosureButton = screen.getByText('What failed');
+      
+      fireEvent.keyDown(disclosureButton, { key: 'Enter' });
+      
+      expect(disclosureButton).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('should be keyboard accessible with Space key', () => {
+      const errorToastWithDiagnostics: ToastType = {
+        id: 'test-error-11',
+        variant: 'error',
+        title: 'Error',
+        description: 'An error occurred',
+        diagnostics: {
+          requestId: 'req-12345-67890',
+        },
+      };
+      render(<Toast toast={errorToastWithDiagnostics} onDismiss={mockOnDismiss} />);
+      const disclosureButton = screen.getByText('What failed');
+      
+      fireEvent.keyDown(disclosureButton, { key: ' ' });
+      
+      expect(disclosureButton).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('should have accessible disclosure region', () => {
+      const errorToastWithDiagnostics: ToastType = {
+        id: 'test-error-12',
+        variant: 'error',
+        title: 'Error',
+        description: 'An error occurred',
+        diagnostics: {
+          requestId: 'req-12345-67890',
+        },
+      };
+      render(<Toast toast={errorToastWithDiagnostics} onDismiss={mockOnDismiss} />);
+      
+      fireEvent.click(screen.getByText('What failed'));
+      
+      const region = screen.getByLabelText('Diagnostic details');
+      expect(region).toHaveAttribute('role', 'region');
+    });
+
+    it('should render only available diagnostic fields', () => {
+      const errorToastWithPartialDiagnostics: ToastType = {
+        id: 'test-error-13',
+        variant: 'error',
+        title: 'Error',
+        description: 'An error occurred',
+        diagnostics: {
+          requestId: 'req-12345-67890',
+          // errorCode and timestamp not provided
+        },
+      };
+      render(<Toast toast={errorToastWithPartialDiagnostics} onDismiss={mockOnDismiss} />);
+      
+      fireEvent.click(screen.getByText('What failed'));
+      
+      expect(screen.getByText('Request ID:')).toBeInTheDocument();
+      expect(screen.queryByText('Error Code:')).not.toBeInTheDocument();
+      expect(screen.queryByText('Timestamp:')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import { AlertCircle, CheckCircle2, Info, X, AlertTriangle } from "lucide-react";
+import { AlertCircle, CheckCircle2, Info, X, AlertTriangle, ChevronDown } from "lucide-react";
 import type { Toast as ToastType } from "@/lib/context/ToastContext";
 
 const VARIANT_STYLES: Record<
@@ -41,8 +41,15 @@ export default function Toast({ toast, onDismiss }: ToastProps) {
 
   const [remaining, setRemaining] = useState(duration ?? 5000);
   const [isPaused, setIsPaused] = useState(false);
+  const [isDisclosureOpen, setIsDisclosureOpen] = useState(false);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const startTimeRef = useRef<number>(Date.now());
+
+  // Determine if diagnostic details are available (only for error variant)
+  const hasDiagnostics = 
+    toast.variant === "error" && 
+    toast.diagnostics && 
+    (toast.diagnostics.requestId || toast.diagnostics.errorCode || toast.diagnostics.timestamp);
 
   useEffect(() => {
     if (duration === 0) return;
@@ -74,6 +81,17 @@ export default function Toast({ toast, onDismiss }: ToastProps) {
   const handleFocus = () => setIsPaused(true);
   const handleBlur = () => setIsPaused(false);
 
+  const toggleDisclosure = () => {
+    setIsDisclosureOpen(!isDisclosureOpen);
+  };
+
+  const handleDisclosureKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      toggleDisclosure();
+    }
+  };
+
   return (
     <div
       role="status"
@@ -82,32 +100,93 @@ export default function Toast({ toast, onDismiss }: ToastProps) {
       onMouseLeave={handleMouseLeave}
       onFocus={handleFocus}
       onBlur={handleBlur}
-      className={`flex w-full max-w-sm items-start gap-3 rounded-2xl border p-4 shadow-lg backdrop-blur-md animate-slide-in-bottom sm:animate-slide-in-right ${panel}`}
+      className={`flex w-full max-w-sm flex-col rounded-2xl border shadow-lg backdrop-blur-md animate-slide-in-bottom sm:animate-slide-in-right ${panel}`}
     >
-      <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${icon}`} aria-hidden="true" />
+      <div className="flex items-start gap-3 p-4">
+        <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${icon}`} aria-hidden="true" />
 
-      <div className="flex-1 min-w-0">
-        <p className="text-sm font-semibold text-white leading-5">{toast.title}</p>
-        {toast.description && (
-          <p className="mt-0.5 text-xs leading-5 text-white/60">{toast.description}</p>
-        )}
-        {toast.action && (
-          <button
-            onClick={toast.action.onClick}
-            className={`mt-2 text-xs font-semibold underline-offset-2 hover:underline ${icon}`}
-          >
-            {toast.action.label}
-          </button>
-        )}
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-white leading-5">{toast.title}</p>
+          {toast.description && (
+            <p className="mt-0.5 text-xs leading-5 text-white/60">{toast.description}</p>
+          )}
+          {toast.action && (
+            <button
+              onClick={toast.action.onClick}
+              className={`mt-2 text-xs font-semibold underline-offset-2 hover:underline ${icon}`}
+            >
+              {toast.action.label}
+            </button>
+          )}
+        </div>
+
+        <button
+          onClick={() => onDismiss(toast.id)}
+          aria-label="Dismiss notification"
+          className="shrink-0 rounded-lg p-1 text-white/40 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
       </div>
 
-      <button
-        onClick={() => onDismiss(toast.id)}
-        aria-label="Dismiss notification"
-        className="shrink-0 rounded-lg p-1 text-white/40 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
-      >
-        <X className="h-3.5 w-3.5" />
-      </button>
+      {hasDiagnostics && (
+        <div className="border-t border-white/10">
+          <button
+            onClick={toggleDisclosure}
+            onKeyDown={handleDisclosureKeyDown}
+            aria-expanded={isDisclosureOpen}
+            aria-controls={`disclosure-content-${toast.id}`}
+            className="w-full flex items-center gap-2 px-4 py-2 text-xs font-medium text-white/70 hover:text-white transition focus-visible:outline-none focus-visible:ring-inset focus-visible:ring-2 focus-visible:ring-white/40"
+          >
+            <ChevronDown
+              className={`h-3.5 w-3.5 shrink-0 transition-transform ${
+                isDisclosureOpen ? "rotate-180" : ""
+              }`}
+              aria-hidden="true"
+            />
+            What failed
+          </button>
+
+          {isDisclosureOpen && (
+            <div
+              id={`disclosure-content-${toast.id}`}
+              role="region"
+              aria-label="Diagnostic details"
+              className="border-t border-white/10 bg-white/5 px-4 py-3 space-y-2"
+            >
+              {toast.diagnostics?.requestId && (
+                <div className="text-xs">
+                  <dt className="font-medium text-white/70">Request ID:</dt>
+                  <dd className="text-white/50 font-mono break-all select-all">
+                    {toast.diagnostics.requestId}
+                  </dd>
+                </div>
+              )}
+
+              {toast.diagnostics?.errorCode && (
+                <div className="text-xs">
+                  <dt className="font-medium text-white/70">Error Code:</dt>
+                  <dd className="text-white/50">{toast.diagnostics.errorCode}</dd>
+                </div>
+              )}
+
+              {toast.description && (
+                <div className="text-xs">
+                  <dt className="font-medium text-white/70">Error Message:</dt>
+                  <dd className="text-white/50 break-words">{toast.description}</dd>
+                </div>
+              )}
+
+              {toast.diagnostics?.timestamp && (
+                <div className="text-xs">
+                  <dt className="font-medium text-white/70">Timestamp:</dt>
+                  <dd className="text-white/50">{toast.diagnostics.timestamp}</dd>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/docs/toast-pattern.md
+++ b/docs/toast-pattern.md
@@ -47,6 +47,43 @@ toast({
 | `description` | `string` | — | Supporting detail (keep ≤120 chars) |
 | `action` | `{ label, onClick }` | — | Optional inline CTA |
 | `duration` | `number` (ms) | `5000` | Pass `0` to require manual dismissal |
+| `diagnostics` | `DiagnosticDetails` | — | Error diagnostic info (error variant only) |
+
+### `DiagnosticDetails` (optional, error variant only)
+
+Error toasts can include optional diagnostic details accessible via a collapsed "What failed" disclosure:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `requestId` | `string` | Request ID for support tracking (displayed in monospace for easy copying) |
+| `errorCode` | `string` | Error code for categorization (e.g., `ERR_500`, `AUTH_FAILED`) |
+| `timestamp` | `string` | ISO 8601 timestamp when the error occurred |
+
+The `description` field is automatically included in the disclosure as "Error Message".
+
+**Example:**
+
+```tsx
+toast({
+  variant: "error",
+  title: "Transfer failed",
+  description: "Your account balance is too low.",
+  duration: 0,
+  diagnostics: {
+    requestId: "9d0f8c5d-1c7a-4d53-a74c-xxxxxxxx4",
+    errorCode: "INSUFFICIENT_BALANCE",
+    timestamp: new Date().toISOString(),
+  },
+});
+```
+
+### Disclosure Behavior
+
+- The "What failed" disclosure appears **only on error toasts** with at least one diagnostic field.
+- It is **collapsed by default** to keep the toast clean and uncluttered.
+- Clicking the button expands it to reveal diagnostic details.
+- The disclosure is fully keyboard accessible (Enter/Space to toggle).
+- Request IDs are displayed in monospace and have `select-all` styling for easy copying.
 
 ### `dismiss(id)`
 

--- a/lib/context/ToastContext.tsx
+++ b/lib/context/ToastContext.tsx
@@ -9,6 +9,15 @@ export interface ToastAction {
   onClick: () => void;
 }
 
+export interface DiagnosticDetails {
+  /** Request ID for tracking and support */
+  requestId?: string;
+  /** Error code for categorization */
+  errorCode?: string;
+  /** Timestamp when the error occurred */
+  timestamp?: string;
+}
+
 export interface Toast {
   id: string;
   variant: ToastVariant;
@@ -17,6 +26,8 @@ export interface Toast {
   action?: ToastAction;
   /** Auto-dismiss delay in ms. Pass 0 to require manual dismissal. Default: 5000. */
   duration?: number;
+  /** Diagnostic details shown in disclosure (error variant only) */
+  diagnostics?: DiagnosticDetails;
 }
 
 interface ToastContextValue {


### PR DESCRIPTION
## Summary

Adds a collapsible **"What failed"** section to error toasts that exposes diagnostic information such as the request ID while keeping the existing toast API and behavior unchanged.

Closes #744.