### PR TITLE
feat(a11y): add WCAG 2.1 AA arrow-key navigation to SubNav — Closes #731

### DIFF
--- a/components/Nav/SubNav.tsx
+++ b/components/Nav/SubNav.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { PieChart, Target, Zap, History, ChevronRight } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
 
 const SubNav = () => {
     const pathname = usePathname();
@@ -19,27 +20,85 @@ const SubNav = () => {
         return pathname.startsWith(href);
     };
 
+    const containerRef = useRef<HTMLUListElement>(null);
+    const activeIndex = links.findIndex(link => isActive(link.href));
+    const initialIndex = activeIndex !== -1 ? activeIndex : 0;
+    const [focusedIndex, setFocusedIndex] = useState(initialIndex);
+
+    // Sync focusedIndex with pathname changes (e.g. initial render or clicking a link)
+    useEffect(() => {
+        const activeIdx = links.findIndex(link => isActive(link.href));
+        if (activeIdx !== -1) {
+            setFocusedIndex(activeIdx);
+        }
+    }, [pathname]);
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLUListElement>) => {
+        let nextIndex = focusedIndex;
+        switch (e.key) {
+            case "ArrowLeft":
+            case "ArrowUp":
+                nextIndex = (focusedIndex - 1 + links.length) % links.length;
+                break;
+            case "ArrowRight":
+            case "ArrowDown":
+                nextIndex = (focusedIndex + 1) % links.length;
+                break;
+            case "Home":
+                nextIndex = 0;
+                break;
+            case "End":
+                nextIndex = links.length - 1;
+                break;
+            default:
+                return; // Let other keys propagate naturally
+        }
+
+        e.preventDefault();
+        setFocusedIndex(nextIndex);
+
+        // Move focus to the target link element
+        if (containerRef.current) {
+            const items = containerRef.current.querySelectorAll('[role="tab"]');
+            const targetEl = items[nextIndex] as HTMLElement;
+            if (targetEl) {
+                targetEl.focus();
+            }
+        }
+    };
+
     return (
         <nav aria-label="Dashboard sub-navigation" className="fixed top-16 z-40 w-full overflow-x-hidden border-b border-white/5 bg-[#0F0F0F]/80 py-3 backdrop-blur-md 375:top-20 375:py-4">
             <div className="mx-auto max-w-7xl overflow-x-hidden px-4 sm:px-6 lg:px-8">
-                <ul className="flex min-w-0 items-center gap-1 sm:gap-2">
-                    {links.map((link) => (
-                        <li key={link.name}>
-                            <Link
-                                href={link.href}
-                                aria-current={isActive(link.href) ? "page" : undefined}
-                                className={`flex items-center gap-1.5 rounded-full px-3 py-2 text-xs font-medium transition-all duration-300 whitespace-nowrap group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red/50 375:gap-2 375:px-4 sm:text-sm
-                                    ${isActive(link.href)
-                                        ? "text-brand-red bg-brand-red/10 border border-brand-red/20 shadow-[0_0_15px_rgba(215,35,35,0.1)]"
-                                        : "text-white/60 hover:text-white hover:bg-white/5 border border-transparent"
-                                    }`}
-                            >
-                                {link.icon}
-                                {link.name}
-                                {isActive(link.href) && <ChevronRight className="w-4 h-4 opacity-50" />}
-                            </Link>
-                        </li>
-                    ))}
+                <ul
+                    ref={containerRef}
+                    role="tablist"
+                    onKeyDown={handleKeyDown}
+                    className="flex min-w-0 items-center gap-1 sm:gap-2 focus:outline-none"
+                >
+                    {links.map((link, index) => {
+                        const isCurrent = isActive(link.href);
+                        return (
+                            <li key={link.name} role="presentation">
+                                <Link
+                                    href={link.href}
+                                    role="tab"
+                                    aria-selected={isCurrent}
+                                    aria-current={isCurrent ? "page" : undefined}
+                                    tabIndex={focusedIndex === index ? 0 : -1}
+                                    className={`flex items-center gap-1.5 rounded-full px-3 py-2 text-xs font-medium transition-all duration-300 whitespace-nowrap group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red/50 375:gap-2 375:px-4 sm:text-sm
+                                        ${isCurrent
+                                            ? "text-brand-red bg-brand-red/10 border border-brand-red/20 shadow-[0_0_15px_rgba(215,35,35,0.1)]"
+                                            : "text-white/60 hover:text-white hover:bg-white/5 border border-transparent"
+                                        }`}
+                                >
+                                    {link.icon}
+                                    {link.name}
+                                    {isCurrent && <ChevronRight className="w-4 h-4 opacity-50" />}
+                                </Link>
+                            </li>
+                        );
+                    })}
                 </ul>
             </div>
         </nav>

--- a/tests/unit/ui/navigation.test.tsx
+++ b/tests/unit/ui/navigation.test.tsx
@@ -157,6 +157,53 @@ describe("SubNav Component", () => {
     expect(inactiveLink).toBeInTheDocument();
     expect(inactiveLink).not.toHaveAttribute("aria-current");
   });
+
+  it("supports WCAG 2.1 AA keyboard arrow-key navigation (roving tabIndex)", () => {
+    mockUsePathname.mockReturnValue("/dashboard");
+    const { container } = renderWithProviders(<SubNav />);
+
+    const tabList = container.querySelector('ul[role="tablist"]');
+    expect(tabList).toBeInTheDocument();
+
+    const tabs = container.querySelectorAll('a[role="tab"]');
+    expect(tabs.length).toBe(4);
+
+    // Initial state: first tab has tabIndex="0", others "-1"
+    expect(tabs[0]).toHaveAttribute("tabindex", "0");
+    expect(tabs[1]).toHaveAttribute("tabindex", "-1");
+    expect(tabs[2]).toHaveAttribute("tabindex", "-1");
+    expect(tabs[3]).toHaveAttribute("tabindex", "-1");
+
+    // Press ArrowRight
+    fireEvent.keyDown(tabList!, { key: "ArrowRight" });
+    expect(tabs[0]).toHaveAttribute("tabindex", "-1");
+    expect(tabs[1]).toHaveAttribute("tabindex", "0");
+
+    // Press ArrowDown
+    fireEvent.keyDown(tabList!, { key: "ArrowDown" });
+    expect(tabs[1]).toHaveAttribute("tabindex", "-1");
+    expect(tabs[2]).toHaveAttribute("tabindex", "0");
+
+    // Press End
+    fireEvent.keyDown(tabList!, { key: "End" });
+    expect(tabs[2]).toHaveAttribute("tabindex", "-1");
+    expect(tabs[3]).toHaveAttribute("tabindex", "0");
+
+    // Press ArrowRight (wrap around)
+    fireEvent.keyDown(tabList!, { key: "ArrowRight" });
+    expect(tabs[3]).toHaveAttribute("tabindex", "-1");
+    expect(tabs[0]).toHaveAttribute("tabindex", "0");
+
+    // Press ArrowLeft (wrap around to end)
+    fireEvent.keyDown(tabList!, { key: "ArrowLeft" });
+    expect(tabs[0]).toHaveAttribute("tabindex", "-1");
+    expect(tabs[3]).toHaveAttribute("tabindex", "0");
+
+    // Press Home
+    fireEvent.keyDown(tabList!, { key: "Home" });
+    expect(tabs[3]).toHaveAttribute("tabindex", "-1");
+    expect(tabs[0]).toHaveAttribute("tabindex", "0");
+  });
 });
 
 describe("MobileNav Component", () => {


### PR DESCRIPTION
- Add role=tablist on <ul> and role=tab on <Link> elements in SubNav
- Implement roving tabIndex pattern (focused tab = 0, others = -1)
- Add onKeyDown handler supporting ArrowLeft/Right, ArrowUp/Down, Home, End
- Sync focusedIndex with pathname changes via useEffect
- Add unit tests verifying keyboard navigation behaviour in navigation.test.tsx