### PR TITLE
feat(remittance): add Zod query validation to the quote route

### DIFF
--- a/app/api/remittance/quote/route.ts
+++ b/app/api/remittance/quote/route.ts
@@ -38,19 +38,23 @@ import { jsonError } from "@/lib/api/types";
  * Coerce query-string strings into the right types.
  * `amount` arrives as a string from the URL — coerce to number first.
  */
+/** ISO-4217-like currency code: exactly 3 ASCII letters. */
+const currencyCode = z
+  .string()
+  .regex(/^[A-Za-z]{3}$/, "must be a 3-letter ISO currency code")
+  .toUpperCase();
+
+/** At most two decimal places (e.g. "10", "10.5", "10.50"). */
+const hasAtMostTwoDecimals = (n: number): boolean =>
+  Number.isFinite(n) && Math.round(n * 100) === n * 100;
+
 const quoteSchema = z.object({
   amount: z.coerce
     .number()
-    .gt(0, "amount must be greater than 0"),
-  currency: z
-    .string()
-    .length(3, "currency must be a 3-letter ISO code")
-    .toUpperCase(),
-
-  toCurrency: z
-    .string()
-    .length(3, "toCurrency must be a 3-letter ISO code")
-    .toUpperCase(),
+    .gt(0, "amount must be greater than 0")
+    .refine(hasAtMostTwoDecimals, "amount must have at most 2 decimal places"),
+  currency: currencyCode,
+  toCurrency: currencyCode,
 });
 
 type QuoteInput = z.infer<typeof quoteSchema>;

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -1,4 +1,4 @@
- # Idempotency Contract & Documentation
+# Idempotency Contract & Documentation
 
 This document describes the design, contract, constraints, and known limitations of the idempotency layer in the Remitwise application.
 

--- a/tests/integration/api/remittance-quote.test.ts
+++ b/tests/integration/api/remittance-quote.test.ts
@@ -36,6 +36,32 @@ describe("Remittance quote API", () => {
     expect(body.validationErrors.some((error: any) => error.path === "currency")).toBe(true);
   });
 
+  it("returns 400 for a non-positive amount", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/remittance/quote?amount=-5&currency=USD&toCurrency=PHP",
+      { method: "GET" }
+    );
+
+    const response = await quoteGET(req);
+    expect(response.status).toBe(400);
+
+    const body = await response.json();
+    expect(body.validationErrors.some((error: any) => error.path === "amount")).toBe(true);
+  });
+
+  it("returns 400 for an amount with more than 2 decimals", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/remittance/quote?amount=10.123&currency=USD&toCurrency=PHP",
+      { method: "GET" }
+    );
+
+    const response = await quoteGET(req);
+    expect(response.status).toBe(400);
+
+    const body = await response.json();
+    expect(body.validationErrors.some((error: any) => error.path === "amount")).toBe(true);
+  });
+
   it("returns a structured error when the anchor is unavailable", async () => {
     const req = new NextRequest(
       "http://localhost/api/remittance/quote?amount=100&currency=USD&toCurrency=PHP",


### PR DESCRIPTION
Closes #867.

Tightens the quote route's Zod schema to enforce the documented contract: `amount` must be a positive number with at most 2 decimal places, and `currency`/`toCurrency` must be 3-letter alphabetic ISO codes. Invalid input returns a structured 400 via the existing `validatedRoute` handler, and the cache key is still built from validated, lower-cased values. Adds integration tests covering the negative-amount and >2-decimals branches.