### PR TITLE
refactor(idempotency): make cleanup timer shutdown-aware and resettable

### DIFF
--- a/lib/idempotency/store.ts
+++ b/lib/idempotency/store.ts
@@ -54,6 +54,37 @@ function initializeCleanup(): void {
 initializeCleanup();
 
 /**
+ * Stop the periodic cleanup timer and reset lifecycle state.
+ *
+ * Primarily intended for tests so that a fresh timer can be (re)created via
+ * {@link initializeCleanup} and no interval leaks across test runs. Does not
+ * touch stored records — call {@link clearIdempotencyStore} for that.
+ */
+export function resetIdempotencyCleanup(): void {
+    if (cleanupTimer) {
+        clearInterval(cleanupTimer);
+        cleanupTimer = null;
+    }
+    cleanupInitialized = false;
+}
+
+/**
+ * Whether the periodic cleanup timer is currently active.
+ * Exposed for tests asserting that no timer dangles after shutdown.
+ */
+export function isCleanupActive(): boolean {
+    return cleanupTimer !== null;
+}
+
+/**
+ * (Re)start the periodic cleanup timer if it is not already running.
+ * Safe to call multiple times — re-initialization is a no-op while active.
+ */
+export function startIdempotencyCleanup(): void {
+    initializeCleanup();
+}
+
+/**
  * Store an idempotency record
  */
 export function storeIdempotencyRecord(

--- a/tests/unit/idempotency/idempotency.test.ts
+++ b/tests/unit/idempotency/idempotency.test.ts
@@ -15,6 +15,9 @@ const {
     checkIdempotency,
     storeIdempotentResponse,
     withIdempotency,
+    resetIdempotencyCleanup,
+    startIdempotencyCleanup,
+    isCleanupActive,
     IDEMPOTENCY_CONFIG,
 } = await import('../../../lib/idempotency');
 
@@ -400,6 +403,25 @@ describe('Timer & Lifecycle Integration Unit Tests', () => {
         storeIdempotencyRecord('key-c', 'hash-c', { status: 200, body: {} });
         expect(getStoreSize()).toBe(1);
         expect(checkIdempotencyKey('key-c', 'hash-c').exists).toBe(true);
+    });
+
+    it('should clear the cleanup timer on reset and leave no dangling interval', () => {
+        // Timer was started at import time via initializeCleanup().
+        expect(isCleanupActive()).toBe(true);
+
+        resetIdempotencyCleanup();
+        expect(isCleanupActive()).toBe(false);
+
+        // Records added after reset are NOT swept while the timer is stopped.
+        storeIdempotencyRecord('post-reset', 'h', { status: 200, body: {} }, 10 * 1000);
+        vi.advanceTimersByTime(60 * 60 * 1000);
+        expect(getStoreSize()).toBe(1);
+
+        // Re-initialise so the rest of the suite keeps a live sweeper.
+        startIdempotencyCleanup();
+        expect(isCleanupActive()).toBe(true);
+        vi.advanceTimersByTime(60 * 60 * 1000);
+        expect(checkIdempotencyKey('post-reset', 'h').exists).toBe(false);
     });
 
     it('should keep the same interval handle and not create duplicates when module is loaded once', () => {


### PR DESCRIPTION
Closes #861.

Adds `resetIdempotencyCleanup()`, `startIdempotencyCleanup()`, and `isCleanupActive()` to lib/idempotency/store.ts so the periodic cleanup timer can be torn down and re-created from tests, ensuring no interval dangles across runs. The timer is already registered with the background runtime's graceful-shutdown hook and unref'd; this fills the remaining test-injectability gap without changing the public record API. Adds a test covering reset (timer stops, no sweep) and re-init (sweep resumes).