### PR TITLE
Add a reusable useDebouncedValue hook and apply it to the remittance quote amount input

### DIFF
--- a/app/send/components/AmountCurrencySection.tsx
+++ b/app/send/components/AmountCurrencySection.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { ChevronDown, RefreshCw } from "lucide-react"
 import { CTA_TEST_IDS } from "@/lib/cta-testids"
 import { useExchangeRates } from "@/lib/context/RatesContext"
 import { useClientTranslator } from "@/lib/i18n/client"
+import { useDebouncedValue } from "@/lib/hooks/useDebouncedValue"
 
 interface AmountCurrencySectionProps {
   onReview?: (amount: number, currency: string) => void
@@ -15,9 +16,47 @@ export default function AmountCurrencySection({ onReview, onBack }: AmountCurren
   const [amount, setAmount] = useState<string>("")
   const [currency, setCurrency] = useState<string>("USDC")
   const [error, setError] = useState<string>("")
+  const [quote, setQuote] = useState<number | null>(null)
+  const [quotePending, setQuotePending] = useState(false)
+
+  // Debounce the raw amount so the quote API is only called after the user
+  // pauses typing, preventing one request per keystroke.
+  const debouncedAmount = useDebouncedValue(amount, 400)
 
   const { rates, loading, stale, error: ratesError, refresh } = useExchangeRates()
   const { t } = useClientTranslator()
+
+  // Fetch a quote whenever the debounced amount or currency changes.
+  // Using the latest debounced value ensures no stale quote is displayed.
+  useEffect(() => {
+    const numValue = parseFloat(debouncedAmount)
+    if (!debouncedAmount || isNaN(numValue) || numValue < 1 || numValue > 10000) {
+      setQuote(null)
+      return
+    }
+
+    let cancelled = false
+    setQuotePending(true)
+
+    fetch(`/api/remittance/quote?amount=${encodeURIComponent(debouncedAmount)}&currency=${encodeURIComponent(currency)}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: { quote?: number } | null) => {
+        if (!cancelled) {
+          setQuote(data?.quote ?? null)
+          setQuotePending(false)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setQuote(null)
+          setQuotePending(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [debouncedAmount, currency])
 
   // Build conversion map from live rates (sell USD, buy asset)
   const conversionRates: Record<string, number> = { USDC: 1.0 }
@@ -102,6 +141,14 @@ export default function AmountCurrencySection({ onReview, onBack }: AmountCurren
             </div>
             <p className="text-xs text-zinc-500 mt-2">Min: $1, Max: $10,000</p>
             {error && <p className="text-xs text-red-500 mt-2">{error}</p>}
+            {!error && quotePending && (
+              <p className="text-xs text-zinc-400 mt-2">Fetching quote…</p>
+            )}
+            {!error && !quotePending && quote !== null && (
+              <p className="text-xs text-green-400 mt-2">
+                Estimated receive: {quote.toFixed(2)} {currency}
+              </p>
+            )}
           </div>
         </div>
 

--- a/lib/hooks/useDebouncedValue.test.ts
+++ b/lib/hooks/useDebouncedValue.test.ts
@@ -1,0 +1,191 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDebouncedValue } from "./useDebouncedValue";
+
+// ---------------------------------------------------------------------------
+// Minimal hook harness using createRoot (no @testing-library/react needed)
+// ---------------------------------------------------------------------------
+function createHookHarness<T>(initialValue: T, delay = 300) {
+  let captured: T | undefined;
+  let rerender!: (value: T) => void;
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container) as Root;
+
+  function TestComponent({ value, d }: { value: T; d: number }) {
+    captured = useDebouncedValue(value, d);
+    return null;
+  }
+
+  act(() => {
+    root.render(React.createElement(TestComponent, { value: initialValue, d: delay }));
+  });
+
+  rerender = (value: T) => {
+    act(() => {
+      root.render(React.createElement(TestComponent, { value, d: delay }));
+    });
+  };
+
+  return {
+    get value() {
+      return captured as T;
+    },
+    rerender,
+    unmount() {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("useDebouncedValue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  it("returns the initial value immediately without waiting for the delay", () => {
+    const harness = createHookHarness("hello", 300);
+    try {
+      expect(harness.value).toBe("hello");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("does not update the debounced value before the delay elapses", () => {
+    const harness = createHookHarness("initial", 300);
+    try {
+      harness.rerender("updated");
+      // Advance time but not enough to trigger the debounce
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+      expect(harness.value).toBe("initial");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("updates the debounced value after the full delay has elapsed", () => {
+    const harness = createHookHarness("initial", 300);
+    try {
+      harness.rerender("updated");
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(harness.value).toBe("updated");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("resets the timer on rapid successive changes (latest wins)", () => {
+    const harness = createHookHarness("a", 300);
+    try {
+      harness.rerender("b");
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+      // Change again before the first delay completes
+      harness.rerender("c");
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+      // Only 200ms have passed since the last update — still no change
+      expect(harness.value).toBe("a");
+
+      // Advance the remaining 100ms to complete the second debounce
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+      expect(harness.value).toBe("c");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("does not fire an update after unmount (clears timer on unmount)", () => {
+    const harness = createHookHarness("start", 300);
+    harness.rerender("pending");
+
+    // Unmount before the debounce fires
+    harness.unmount();
+
+    // Advance time past the delay — should NOT throw or update state
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    // No assertion needed beyond no error being thrown; the mountedRef guard
+    // prevents setState on an unmounted component.
+  });
+
+  it("works with numeric values", () => {
+    const harness = createHookHarness(0, 400);
+    try {
+      harness.rerender(1000);
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+      expect(harness.value).toBe(1000);
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("uses the default delay of 300ms when no delay is provided", () => {
+    // Create harness without specifying a delay; the hook defaults to 300 ms.
+    let captured: string | undefined;
+    let rerender!: (value: string) => void;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container) as Root;
+
+    function TestComponent({ value }: { value: string }) {
+      // Call without explicit delay to exercise the default parameter.
+      captured = useDebouncedValue(value);
+      return null;
+    }
+
+    act(() => root.render(React.createElement(TestComponent, { value: "init" })));
+    rerender = (v: string) => {
+      act(() => root.render(React.createElement(TestComponent, { value: v })));
+    };
+
+    try {
+      rerender("changed");
+      act(() => vi.advanceTimersByTime(299));
+      expect(captured).toBe("init");
+      act(() => vi.advanceTimersByTime(1));
+      expect(captured).toBe("changed");
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+    }
+  });
+
+  it("handles object values without losing reference identity after debounce", () => {
+    const obj = { key: "value" };
+    const harness = createHookHarness(obj, 200);
+    try {
+      const newObj = { key: "updated" };
+      harness.rerender(newObj);
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+      expect(harness.value).toEqual({ key: "updated" });
+    } finally {
+      harness.unmount();
+    }
+  });
+});

--- a/lib/hooks/useDebouncedValue.ts
+++ b/lib/hooks/useDebouncedValue.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Returns a debounced snapshot of `value` that only updates after the user
+ * pauses for `delay` milliseconds.
+ *
+ * - Pending timers are cancelled on rapid value changes (latest wins).
+ * - The timer is cleared on unmount to prevent state updates on
+ *   unmounted components.
+ *
+ * @template T - The type of the value being debounced.
+ * @param value - The value to debounce.
+ * @param delay - Debounce delay in milliseconds (default: 300 ms).
+ * @returns The debounced value.
+ *
+ * @example
+ * ```tsx
+ * const [amount, setAmount] = useState("");
+ * const debouncedAmount = useDebouncedValue(amount, 400);
+ *
+ * useEffect(() => {
+ *   if (debouncedAmount) fetchQuote(debouncedAmount);
+ * }, [debouncedAmount]);
+ * ```
+ */
+export function useDebouncedValue<T>(value: T, delay = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (mountedRef.current) {
+        setDebouncedValue(value);
+      }
+    }, delay);
+
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
Fixes #870

## Summary
- Adds `lib/hooks/useDebouncedValue.ts`: a generic, TSDoc-annotated hook with configurable delay (default 300 ms), timer cleanup on rapid value changes (latest-wins), and a `mountedRef` guard to prevent `setState` on unmounted components — no external dependencies
- Applies `useDebouncedValue` to the amount input in `AmountCurrencySection` so the quote API (`/api/remittance/quote`) is only called after the user pauses typing, eliminating one request per keystroke
- Adds `lib/hooks/useDebouncedValue.test.ts` with vitest fake-timer tests covering: initial value passthrough, no update before delay, update after full delay, rapid-change timer reset (latest wins), unmount cleanup, numeric values, default delay, and object values

## Changes
- `lib/hooks/useDebouncedValue.ts` — new reusable hook
- `lib/hooks/useDebouncedValue.test.ts` — full test coverage with fake timers
- `app/send/components/AmountCurrencySection.tsx` — imports and applies `useDebouncedValue`; adds quote fetch effect using the debounced amount; shows quote/pending state in the UI