### PR TITLE
Add stale-while-revalidate semantics and a typed error path to the anchor rates cache route

### DIFF
--- a/app/api/anchor/rates/route.ts
+++ b/app/api/anchor/rates/route.ts
@@ -1,4 +1,21 @@
+/**
+ * @file app/api/anchor/rates/route.ts
+ * @description Next.js route handler for anchor exchange rates with
+ * stale-while-revalidate (SWR) semantics and a typed error path.
+ *
+ * ## Behaviour
+ * 1. **Cache fresh** — return cached rates immediately (`stale: false`).
+ * 2. **Cache expired, upstream OK** — fetch new rates, cache them, return (`stale: false`).
+ * 3. **Cache expired, upstream FAIL, stale data present** — return last-good
+ *    rates with `stale: true` so callers can warn users without breaking the UI.
+ * 4. **Cache empty, upstream FAIL** — return a typed 503 error body.
+ *
+ * > **Why SWR matters:** transient anchor outages should not break the rates
+ * > UI when slightly old rates are perfectly usable for display purposes.
+ */
+
 import { NextResponse } from 'next/server';
+import type { ExchangeRate } from '@/lib/anchor/client';
 import { anchorClient } from '@/lib/anchor/client';
 import {
     getAnchorRatesCache,
@@ -9,38 +26,68 @@ import {
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+/** Successful response body returned when rates are available. */
+export interface RatesSuccessBody {
+    /** The exchange rates returned by the anchor API (may be from cache). */
+    rates: ExchangeRate[];
+    /**
+     * `true` when the data was served from a stale cache because the upstream
+     * fetch failed. Callers should surface a soft warning to the user.
+     */
+    stale: boolean;
+}
+
+/** Error response body returned when no rates are available at all. */
+export interface RatesErrorBody {
+    /** Human-readable error description. */
+    error: string;
+    /** Machine-readable error code for programmatic handling. */
+    code: 'UPSTREAM_UNAVAILABLE';
+}
+
+/**
+ * GET /api/anchor/rates
+ *
+ * Returns anchor exchange rates using stale-while-revalidate semantics.
+ * Responds with {@link RatesSuccessBody} on success or {@link RatesErrorBody}
+ * (HTTP 503) when no cached data is available and the upstream is unreachable.
+ */
+export async function GET(): Promise<NextResponse<RatesSuccessBody | RatesErrorBody>> {
+    // Branch 1: cache is fresh — serve immediately without a network call.
     if (isCacheFresh()) {
         const rateCache = getAnchorRatesCache();
-        return NextResponse.json({
-            rates: rateCache.rates,
+        return NextResponse.json<RatesSuccessBody>({
+            rates: rateCache.rates as ExchangeRate[],
             stale: false,
         });
     }
 
+    // Branch 2: cache is expired — attempt revalidation from upstream.
     try {
         const fetchedRates = await anchorClient.getExchangeRates();
         setAnchorRatesCache(fetchedRates, Date.now());
 
-        return NextResponse.json({
+        return NextResponse.json<RatesSuccessBody>({
             rates: fetchedRates,
             stale: false,
         });
     } catch (error) {
         console.error('API /anchor/rates - Error fetching from Anchor Client:', error);
 
+        // Branch 3: upstream failed but we have stale data — serve it with a flag.
         if (isCacheStale()) {
             const rateCache = getAnchorRatesCache();
             console.warn('API /anchor/rates - Returning stale rate cache due to anchor failure.');
-            return NextResponse.json({
-                rates: rateCache.rates,
+            return NextResponse.json<RatesSuccessBody>({
+                rates: rateCache.rates as ExchangeRate[],
                 stale: true,
             });
         }
 
-        return NextResponse.json(
-            { error: 'Service Unavailable' },
-            { status: 503 }
+        // Branch 4: no cached data at all — surface a typed error.
+        return NextResponse.json<RatesErrorBody>(
+            { error: 'Service Unavailable', code: 'UPSTREAM_UNAVAILABLE' },
+            { status: 503 },
         );
     }
 }

--- a/tests/unit/anchor/rates-route.test.ts
+++ b/tests/unit/anchor/rates-route.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment node
+/**
+ * @file tests/unit/anchor/rates-route.test.ts
+ * @description Unit tests for app/api/anchor/rates/route.ts covering the four
+ * stale-while-revalidate branches required by issue #866.
+ *
+ * ## Branches under test
+ * 1. Fresh cache hit — returns rates without upstream fetch.
+ * 2. Expired cache, upstream succeeds — revalidates and returns fresh rates.
+ * 3. Expired cache, upstream fails, stale data present — returns stale rates + `stale: true`.
+ * 4. Empty cache, upstream fails — returns typed 503 error body.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    setAnchorRatesCache,
+    clearAnchorRatesCache,
+    RATES_CACHE_TTL_MS,
+} from '@/lib/anchor/rates-cache';
+import type { RatesSuccessBody, RatesErrorBody } from '@/app/api/anchor/rates/route';
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_RATES = [
+    { sell_asset: 'USD', buy_asset: 'USDC', price: '1.00' },
+    { sell_asset: 'EUR', buy_asset: 'USDC', price: '1.08' },
+];
+
+const NEW_RATES = [
+    { sell_asset: 'USD', buy_asset: 'USDC', price: '1.01' },
+];
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/anchor/client', () => ({
+    anchorClient: {
+        getExchangeRates: vi.fn(),
+    },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function callRoute() {
+    // Dynamic import ensures mocks are applied before module evaluation.
+    const { GET } = await import('@/app/api/anchor/rates/route');
+    return GET();
+}
+
+async function parseJson<T>(response: Response): Promise<T> {
+    return response.json() as Promise<T>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /api/anchor/rates — SWR semantics', () => {
+    beforeEach(async () => {
+        clearAnchorRatesCache();
+        vi.resetModules();
+        // Re-apply the mock after resetModules so the re-imported route still sees it.
+        vi.mock('@/lib/anchor/client', () => ({
+            anchorClient: {
+                getExchangeRates: vi.fn(),
+            },
+        }));
+    });
+
+    it('Branch 1: returns cached rates immediately when cache is fresh', async () => {
+        // Populate a fresh cache (timestamp = now).
+        setAnchorRatesCache(MOCK_RATES, Date.now());
+
+        const { anchorClient } = await import('@/lib/anchor/client');
+        const response = await callRoute();
+        const body = await parseJson<RatesSuccessBody>(response);
+
+        expect(response.status).toBe(200);
+        expect(body.stale).toBe(false);
+        expect(body.rates).toEqual(MOCK_RATES);
+        // Must NOT have called upstream while cache is fresh.
+        expect(anchorClient.getExchangeRates).not.toHaveBeenCalled();
+    });
+
+    it('Branch 2: revalidates and returns fresh rates when cache is expired', async () => {
+        // Set an expired cache entry.
+        const staleTs = Date.now() - RATES_CACHE_TTL_MS - 1000;
+        setAnchorRatesCache(MOCK_RATES, staleTs);
+
+        const { anchorClient } = await import('@/lib/anchor/client');
+        vi.mocked(anchorClient.getExchangeRates).mockResolvedValueOnce(NEW_RATES);
+
+        const response = await callRoute();
+        const body = await parseJson<RatesSuccessBody>(response);
+
+        expect(response.status).toBe(200);
+        expect(body.stale).toBe(false);
+        expect(body.rates).toEqual(NEW_RATES);
+        expect(anchorClient.getExchangeRates).toHaveBeenCalledOnce();
+    });
+
+    it('Branch 3: returns stale rates with stale:true when cache is expired and upstream fails', async () => {
+        // Populate a stale cache.
+        const staleTs = Date.now() - RATES_CACHE_TTL_MS - 1000;
+        setAnchorRatesCache(MOCK_RATES, staleTs);
+
+        const { anchorClient } = await import('@/lib/anchor/client');
+        vi.mocked(anchorClient.getExchangeRates).mockRejectedValueOnce(
+            new Error('Anchor API unreachable'),
+        );
+
+        const response = await callRoute();
+        const body = await parseJson<RatesSuccessBody>(response);
+
+        expect(response.status).toBe(200);
+        expect(body.stale).toBe(true);
+        expect(body.rates).toEqual(MOCK_RATES);
+    });
+
+    it('Branch 4: returns typed 503 error when cache is empty and upstream fails', async () => {
+        // Cache is empty (initial state after clearAnchorRatesCache).
+        const { anchorClient } = await import('@/lib/anchor/client');
+        vi.mocked(anchorClient.getExchangeRates).mockRejectedValueOnce(
+            new Error('Anchor API unreachable'),
+        );
+
+        const response = await callRoute();
+        const body = await parseJson<RatesErrorBody>(response);
+
+        expect(response.status).toBe(503);
+        expect(body.error).toBe('Service Unavailable');
+        expect(body.code).toBe('UPSTREAM_UNAVAILABLE');
+    });
+});


### PR DESCRIPTION
Fixes #866

## Summary
- Add typed response interfaces (`RatesSuccessBody`, `RatesErrorBody`) to the anchor rates route, eliminating implicit `any` in the response shape
- Add `code: 'UPSTREAM_UNAVAILABLE'` to the 503 error body for programmatic handling by callers
- Add TSDoc to the route documenting all four SWR branches and the exported types
- Add `tests/unit/anchor/rates-route.test.ts` covering all four branches: fresh cache hit, expired-cache upstream success (revalidation), expired-cache upstream failure with stale data (`stale: true`), and empty-cache upstream failure (typed 503)

## Changes
- `app/api/anchor/rates/route.ts` — typed response bodies, TSDoc, typed 503 error with `code` field
- `tests/unit/anchor/rates-route.test.ts` — new vitest suite, 4 tests covering all SWR branches