### PR TITLE
Implement the family-members GET and POST routes against the deployed family-wallet contract

### DIFF
--- a/app/api/family/members/route.ts
+++ b/app/api/family/members/route.ts
@@ -1,122 +1,132 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withAuth } from '@/lib/auth';
 import { getAllMembers, buildAddMemberTx } from '@/lib/contracts/family-wallet';
-import { AddMemberRequest } from '@/utils/types/family-wallet.types';
+import { resolveContractId } from '@/lib/contracts/network-resolution';
+
+// ---------------------------------------------------------------------------
+// Zod schema for AddMemberRequest body validation
+// ---------------------------------------------------------------------------
+
+const AddMemberSchema = z.object({
+    address: z
+        .string()
+        .regex(/^G[A-Z0-9]{55}$/, 'Invalid Stellar address format'),
+    role: z.enum(['admin', 'sender', 'recipient'], {
+        errorMap: () => ({ message: 'Role must be admin, sender, or recipient' }),
+    }),
+    spendingLimit: z
+        .number({ invalid_type_error: 'spendingLimit must be a number' })
+        .nonnegative('spendingLimit must be non-negative'),
+});
+
+// ---------------------------------------------------------------------------
+// Contract-id guard — returns a 503 response if the contract is unresolved
+// ---------------------------------------------------------------------------
+
+function getContractIdOrError(): NextResponse | null {
+    try {
+        resolveContractId('FAMILY_WALLET');
+        return null;
+    } catch {
+        return NextResponse.json(
+            {
+                error: 'Service Unavailable',
+                message: 'Family wallet contract ID is not configured for this network.',
+            },
+            { status: 503 },
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/family/members
+// ---------------------------------------------------------------------------
 
 /**
  * GET /api/family/members
- * Get all family members
- * Protected: Requires authentication
+ *
+ * Returns the list of family members for the authenticated user.
+ * Optionally accepts `?admin=<stellarAddress>` to filter by admin.
+ *
+ * Responses:
+ *   200 – { members: FamilyMember[] }
+ *   401 – Unauthorized (no valid session)
+ *   503 – Contract not configured on this network
+ *   500 – Unexpected server error
  */
-export async function GET(request: NextRequest) {
-    try {
-        // TODO: Get session/auth from request
-        // const session = await getSession(request);
-        // if (!session) {
-        //   return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-        // }
+async function getHandler(request: NextRequest): Promise<NextResponse> {
+    const contractError = getContractIdOrError();
+    if (contractError) return contractError;
 
-        // Contract not yet deployed - return 501
-        return NextResponse.json(
-            {
-                error: 'Not Implemented',
-                message: 'Family wallet contract not yet deployed. This endpoint will be available once the contract is deployed.',
-                documentation: 'Use getAllMembers(adminAddress?) from lib/contracts/family-wallet.ts'
-            },
-            { status: 501 }
-        );
-
-        // TODO: Uncomment when contract is deployed
-        // const adminAddress = request.nextUrl.searchParams.get('admin');
-        // const members = await getAllMembers(adminAddress || undefined);
-        // return NextResponse.json({ members });
-
-    } catch (error) {
-        console.error('Error fetching family members:', error);
-        return NextResponse.json(
-            { error: 'Internal Server Error' },
-            { status: 500 }
-        );
-    }
+    const adminAddress = request.nextUrl.searchParams.get('admin') ?? undefined;
+    const members = await getAllMembers(adminAddress);
+    return NextResponse.json({ members });
 }
+
+export const GET = withAuth(async (request: NextRequest) =>
+    getHandler(request),
+) as (request: NextRequest) => Promise<NextResponse>;
+
+// ---------------------------------------------------------------------------
+// POST /api/family/members
+// ---------------------------------------------------------------------------
 
 /**
  * POST /api/family/members
- * Add a new family member
- * Protected: Requires admin authentication
+ *
+ * Builds a Stellar transaction XDR to add a new family member.
+ * The caller must sign and submit the returned XDR.
+ *
+ * Request body (JSON): { address, role, spendingLimit }
+ *
+ * Responses:
+ *   200 – { transactionXdr: string, message: string }
+ *   400 – Validation error
+ *   401 – Unauthorized (no valid session)
+ *   503 – Contract not configured on this network
+ *   500 – Unexpected server error
  */
-export async function POST(request: NextRequest) {
+async function postHandler(
+    request: NextRequest,
+    adminAddress: string,
+): Promise<NextResponse> {
+    const contractError = getContractIdOrError();
+    if (contractError) return contractError;
+
+    let rawBody: unknown;
     try {
-        // TODO: Get session/auth from request
-        // const session = await getSession(request);
-        // if (!session) {
-        //   return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-        // }
-        // if (session.role !== 'admin') {
-        //   return NextResponse.json({ error: 'Forbidden - Admin only' }, { status: 403 });
-        // }
-
-        // Contract not yet deployed - return 501
+        rawBody = await request.json();
+    } catch {
         return NextResponse.json(
-            {
-                error: 'Not Implemented',
-                message: 'Family wallet contract not yet deployed. This endpoint will be available once the contract is deployed.',
-                documentation: 'Use buildAddMemberTx(adminAddress, memberAddress, role, spendingLimit) from lib/contracts/family-wallet.ts'
-            },
-            { status: 501 }
-        );
-
-        // TODO: Uncomment when contract is deployed
-        // const body: AddMemberRequest = await request.json();
-        // 
-        // // Validate request body
-        // if (!body.address || !body.role || body.spendingLimit === undefined) {
-        //   return NextResponse.json(
-        //     { error: 'Missing required fields: address, role, spendingLimit' },
-        //     { status: 400 }
-        //   );
-        // }
-        //
-        // // Validate Stellar address format
-        // if (!/^G[A-Z0-9]{55}$/.test(body.address)) {
-        //   return NextResponse.json(
-        //     { error: 'Invalid Stellar address format' },
-        //     { status: 400 }
-        //   );
-        // }
-        //
-        // // Validate role
-        // if (!['admin', 'sender', 'recipient'].includes(body.role)) {
-        //   return NextResponse.json(
-        //     { error: 'Invalid role. Must be: admin, sender, or recipient' },
-        //     { status: 400 }
-        //   );
-        // }
-        //
-        // // Validate spending limit
-        // if (body.spendingLimit < 0) {
-        //   return NextResponse.json(
-        //     { error: 'Spending limit must be non-negative' },
-        //     { status: 400 }
-        //   );
-        // }
-        //
-        // const txXdr = await buildAddMemberTx(
-        //   session.address,
-        //   body.address,
-        //   body.role,
-        //   body.spendingLimit
-        // );
-        //
-        // return NextResponse.json({ 
-        //   transactionXdr: txXdr,
-        //   message: 'Transaction built successfully. Sign and submit to add member.'
-        // });
-
-    } catch (error) {
-        console.error('Error adding family member:', error);
-        return NextResponse.json(
-            { error: 'Internal Server Error' },
-            { status: 500 }
+            { error: 'Bad Request', message: 'Request body must be valid JSON' },
+            { status: 400 },
         );
     }
+
+    const parseResult = AddMemberSchema.safeParse(rawBody);
+    if (!parseResult.success) {
+        const issues = parseResult.error.issues.map((i) => i.message).join('; ');
+        return NextResponse.json(
+            { error: 'Validation Error', message: issues },
+            { status: 400 },
+        );
+    }
+
+    const { address, role, spendingLimit } = parseResult.data;
+    const transactionXdr = await buildAddMemberTx(
+        adminAddress,
+        address,
+        role,
+        spendingLimit,
+    );
+
+    return NextResponse.json({
+        transactionXdr,
+        message: 'Transaction built successfully. Sign and submit to add member.',
+    });
 }
+
+export const POST = withAuth(async (request: NextRequest, address: string) =>
+    postHandler(request, address),
+) as (request: NextRequest) => Promise<NextResponse>;

--- a/tests/unit/family-members-route.test.ts
+++ b/tests/unit/family-members-route.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks – must be declared before any import of the module under test
+// ---------------------------------------------------------------------------
+
+const mockGetAllMembers = vi.hoisted(() => vi.fn());
+const mockBuildAddMemberTx = vi.hoisted(() => vi.fn());
+const mockResolveContractId = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/contracts/family-wallet', () => ({
+    getAllMembers: mockGetAllMembers,
+    buildAddMemberTx: mockBuildAddMemberTx,
+}));
+
+vi.mock('@/lib/contracts/network-resolution', () => ({
+    resolveContractId: mockResolveContractId,
+}));
+
+// Stub withAuth so it forwards the request and injects a fixed address
+vi.mock('@/lib/auth', () => ({
+    withAuth: (handler: (req: NextRequest, address: string) => Promise<Response>) =>
+        (req: NextRequest) => {
+            const authHeader = req.headers.get('authorization') ?? '';
+            if (!authHeader.startsWith('Bearer ')) {
+                return Promise.resolve(
+                    new Response(JSON.stringify({ error: 'Unauthorized' }), {
+                        status: 401,
+                        headers: { 'Content-Type': 'application/json' },
+                    }),
+                );
+            }
+            return handler(req, 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+        },
+}));
+
+// Import after mocks are registered
+import { GET, POST } from '@/app/api/family/members/route';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_ADMIN = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const VALID_MEMBER = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+function makeGetRequest(opts: { auth?: boolean; admin?: string } = {}): NextRequest {
+    const url = new URL('http://localhost/api/family/members');
+    if (opts.admin) url.searchParams.set('admin', opts.admin);
+    const headers: HeadersInit = opts.auth !== false ? { authorization: 'Bearer token' } : {};
+    return new NextRequest(url.toString(), { method: 'GET', headers });
+}
+
+function makePostRequest(body: unknown, auth = true): NextRequest {
+    const headers: HeadersInit = {
+        'content-type': 'application/json',
+        ...(auth ? { authorization: 'Bearer token' } : {}),
+    };
+    return new NextRequest('http://localhost/api/family/members', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /api/family/members', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns 401 when no auth header is provided', async () => {
+        const res = await GET(makeGetRequest({ auth: false }));
+        expect(res.status).toBe(401);
+        const body = await res.json();
+        expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 503 when the contract id is not configured', async () => {
+        mockResolveContractId.mockImplementation(() => {
+            throw new Error('Missing contract ID');
+        });
+
+        const res = await GET(makeGetRequest());
+        expect(res.status).toBe(503);
+        const body = await res.json();
+        expect(body.error).toBe('Service Unavailable');
+    });
+
+    it('returns 200 with members list for authenticated request', async () => {
+        mockResolveContractId.mockReturnValue('CCONTRACT123');
+        const mockMembers = [
+            { id: '1', address: VALID_MEMBER, role: 'recipient', spendingLimit: 500 },
+        ];
+        mockGetAllMembers.mockResolvedValue(mockMembers);
+
+        const res = await GET(makeGetRequest());
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.members).toEqual(mockMembers);
+    });
+
+    it('passes the admin query param to getAllMembers', async () => {
+        mockResolveContractId.mockReturnValue('CCONTRACT123');
+        mockGetAllMembers.mockResolvedValue([]);
+
+        await GET(makeGetRequest({ admin: VALID_ADMIN }));
+        expect(mockGetAllMembers).toHaveBeenCalledWith(VALID_ADMIN);
+    });
+
+    it('calls getAllMembers without admin when no query param', async () => {
+        mockResolveContractId.mockReturnValue('CCONTRACT123');
+        mockGetAllMembers.mockResolvedValue([]);
+
+        await GET(makeGetRequest());
+        expect(mockGetAllMembers).toHaveBeenCalledWith(undefined);
+    });
+});
+
+describe('POST /api/family/members', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns 401 when no auth header is provided', async () => {
+        const res = await POST(makePostRequest({ address: VALID_MEMBER, role: 'recipient', spendingLimit: 100 }, false));
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 503 when the contract id is not configured', async () => {
+        mockResolveContractId.mockImplementation(() => {
+            throw new Error('Missing contract ID');
+        });
+
+        const res = await POST(makePostRequest({ address: VALID_MEMBER, role: 'recipient', spendingLimit: 100 }));
+        expect(res.status).toBe(503);
+        const body = await res.json();
+        expect(body.error).toBe('Service Unavailable');
+    });
+
+    it('returns 400 for missing required fields', async () => {
+        mockResolveContractId.mockReturnValue('CCONTRACT123');
+
+        const res = await POST(makePostRequest({ address: VALID_MEMBER }));
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toBe('Validation Error');
+    });
+
+    it('returns 400 for invalid Stellar address format', async () => {
+        mockResolveContractId.mockReturnValue('CCONTRACT123');
+
+        const res = await POST(makePostRequest({ address: 'not-a-stellar-address', role: 'recipient', spendingLimit: 100 }));
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toBe('Validation Error');
+    });
+
+    it('returns 400 for invalid role', async () => {
+        mockResolveContractId.mockReturnValue('CCONTRACT123');
+
+        const res = await POST(makePostRequest({ address: VALID_MEMBER, role: 'owner', spendingLimit: 100 }));
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for negative spendingLimit', async () => {
+        mockResolveContractId.mockReturnValue('CCONTRACT123');
+
+        const res = await POST(makePostRequest({ address: VALID_MEMBER, role: 'recipient', spendingLimit: -1 }));
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 200 with transactionXdr for valid add-member request', async () => {
+        mockResolveContractId.mockReturnValue('CCONTRACT123');
+        mockBuildAddMemberTx.mockResolvedValue('AAAA...XDR...');
+
+        const res = await POST(makePostRequest({ address: VALID_MEMBER, role: 'sender', spendingLimit: 200 }));
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.transactionXdr).toBe('AAAA...XDR...');
+        expect(body.message).toContain('Transaction built successfully');
+    });
+
+    it('calls buildAddMemberTx with correct args', async () => {
+        mockResolveContractId.mockReturnValue('CCONTRACT123');
+        mockBuildAddMemberTx.mockResolvedValue('XDR_STRING');
+
+        await POST(makePostRequest({ address: VALID_MEMBER, role: 'admin', spendingLimit: 1000 }));
+
+        expect(mockBuildAddMemberTx).toHaveBeenCalledWith(
+            VALID_ADMIN,
+            VALID_MEMBER,
+            'admin',
+            1000,
+        );
+    });
+
+    it('returns 400 when request body is not valid JSON', async () => {
+        mockResolveContractId.mockReturnValue('CCONTRACT123');
+
+        const req = new NextRequest('http://localhost/api/family/members', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json', authorization: 'Bearer token' },
+            body: 'not json {',
+        });
+
+        const res = await POST(req);
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toBe('Bad Request');
+    });
+});


### PR DESCRIPTION
Fixes #869

## Summary
- Replace 501 stubs in `app/api/family/members/route.ts` with real GET/POST handlers using `getAllMembers` and `buildAddMemberTx`
- Add `withAuth` session guard returning 401 for unauthenticated requests
- Return 503 when `FAMILY_WALLET` contract ID is not resolved via `resolveContractId` from `lib/contracts/network-resolution.ts`
- Validate POST body with Zod schema (`address` Stellar format, `role` enum, non-negative `spendingLimit`)
- Add 14 unit tests covering: unauthenticated → 401, missing contract id → 503, valid list, valid add-member build, all validation error cases

## Changes
Implements the feature as described in the issue, following existing code patterns (`withAuth`, `resolveContractId`, Zod validation).