### PR TITLE
feat(hooks): add abortable timeout and retry to useFormAction

### DIFF
--- a/lib/hooks/useFormAction.test.ts
+++ b/lib/hooks/useFormAction.test.ts
@@ -17,14 +17,20 @@ const flushPromises = () => new Promise<void>((r) => setTimeout(r, 0));
 // ---------------------------------------------------------------------------
 // Minimal hook harness using createRoot (no @testing-library/react needed)
 // ---------------------------------------------------------------------------
-function createHookHarness(url = "/api/test") {
+type HookOptions = Parameters<typeof useFormAction<TestState>>[2];
+
+function createHookHarness(
+  url = "/api/test",
+  method: Parameters<typeof useFormAction<TestState>>[1] = "POST",
+  options?: HookOptions
+) {
   let captured: readonly [TestState, (fd: FormData) => void, boolean] | undefined;
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container) as Root;
 
   function TestComponent() {
-    const hook = useFormAction<TestState>(url);
+    const hook = useFormAction<TestState>(url, method, options);
     captured = hook;
     return null;
   }
@@ -63,6 +69,7 @@ describe("useFormAction", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     document.body.innerHTML = "";
   });
 
@@ -272,6 +279,109 @@ describe("useFormAction", () => {
       });
       expect(harness.hook[0]).toMatchObject({
         error: "Network error. Please try again.",
+      });
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("sets a timeout error and aborts the request when timeoutMs elapses", async () => {
+    vi.useFakeTimers();
+    let capturedSignal: AbortSignal | undefined;
+
+    vi.spyOn(apiClient, "request").mockImplementationOnce((_url, opts) => {
+      capturedSignal = opts?.signal as AbortSignal | undefined;
+      return new Promise(() => {});
+    });
+
+    const harness = createHookHarness("/api/test", "POST", {
+      timeoutMs: 100,
+    });
+    try {
+      await act(async () => {
+        harness.hook[1](new FormData());
+        await vi.advanceTimersByTimeAsync(100);
+      });
+
+      expect(capturedSignal?.aborted).toBe(true);
+      expect(harness.hook[0]).toMatchObject({
+        error: "Request timed out. Please try again.",
+      });
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("retries transient 5xx responses for idempotent methods within the configured bound", async () => {
+    const spy = vi
+      .spyOn(apiClient, "request")
+      .mockResolvedValueOnce(jsonResponse({ success: false }, 503))
+      .mockResolvedValueOnce(jsonResponse({ success: "Retried successfully" }));
+
+    const harness = createHookHarness("/api/test", "PUT", {
+      maxRetries: 1,
+      retryDelayMs: 0,
+    });
+    try {
+      await act(async () => {
+        harness.hook[1](new FormData());
+        await flushPromises();
+        await flushPromises();
+      });
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(harness.hook[0]).toMatchObject({
+        success: "Retried successfully",
+      });
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("retries network failures for idempotent methods within the configured bound", async () => {
+    const spy = vi
+      .spyOn(apiClient, "request")
+      .mockRejectedValueOnce(new Error("temporary offline"))
+      .mockResolvedValueOnce(jsonResponse({ success: "Recovered" }));
+
+    const harness = createHookHarness("/api/test", "PUT", {
+      maxRetries: 1,
+      retryDelayMs: 0,
+    });
+    try {
+      await act(async () => {
+        harness.hook[1](new FormData());
+        await flushPromises();
+        await flushPromises();
+      });
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(harness.hook[0]).toMatchObject({
+        success: "Recovered",
+      });
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("does not retry non-idempotent POST submissions even when maxRetries is configured", async () => {
+    const spy = vi
+      .spyOn(apiClient, "request")
+      .mockResolvedValueOnce(jsonResponse({ success: false }, 503));
+
+    const harness = createHookHarness("/api/test", "POST", {
+      maxRetries: 1,
+      retryDelayMs: 0,
+    });
+    try {
+      await act(async () => {
+        harness.hook[1](new FormData());
+        await flushPromises();
+      });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(harness.hook[0]).toMatchObject({
+        error: "Request failed with status 503",
       });
     } finally {
       harness.unmount();

--- a/lib/hooks/useFormAction.ts
+++ b/lib/hooks/useFormAction.ts
@@ -20,7 +20,21 @@ interface ErrorPayload {
 }
 
 const NETWORK_ERROR_MESSAGE = "Network error. Please try again.";
+const TIMEOUT_ERROR_MESSAGE = "Request timed out. Please try again.";
 const DEFAULT_SUCCESS_MESSAGE = "Request completed successfully.";
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_RETRY_DELAY_MS = 250;
+
+type FormActionMethod = "POST" | "PUT" | "PATCH" | "DELETE";
+
+interface UseFormActionOptions {
+  /** Timeout for the full submission, including configured retry attempts. */
+  timeoutMs?: number;
+  /** Additional attempts after the initial request. Defaults to no retry. */
+  maxRetries?: number;
+  /** Delay between retry attempts in milliseconds. */
+  retryDelayMs?: number;
+}
 
 function isApiErrorPayload(payload: unknown): payload is ApiErrorResponse {
   return Boolean(
@@ -57,6 +71,73 @@ async function parseResponseBody(response: Response): Promise<unknown> {
   }
 }
 
+function isRetryableMethod(method: FormActionMethod): boolean {
+  return method === "PUT" || method === "DELETE";
+}
+
+function isRetryableResponse(response: Response): boolean {
+  return response.status >= 500;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  if (signal.aborted) return Promise.reject(signal.reason);
+
+  return new Promise((resolve, reject) => {
+    const cleanup = () => signal.removeEventListener("abort", abort);
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    const abort = () => {
+      clearTimeout(timer);
+      cleanup();
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", abort, { once: true });
+  });
+}
+
+async function submitWithRetry(
+  url: string,
+  method: FormActionMethod,
+  formData: FormData,
+  signal: AbortSignal,
+  options: Required<Pick<UseFormActionOptions, "maxRetries" | "retryDelayMs">>
+): Promise<Response | null> {
+  const maxRetries = isRetryableMethod(method) ? Math.max(0, options.maxRetries) : 0;
+
+  for (let attempt = 0; ; attempt += 1) {
+    let res: Response | null;
+    try {
+      res = await apiClient.request(url, {
+        method,
+        body: formData,
+        signal,
+        retries: 0,
+        timeout: 0,
+      });
+    } catch (error) {
+      if (signal.aborted || isAbortError(error) || attempt >= maxRetries) {
+        throw error;
+      }
+
+      await sleep(options.retryDelayMs, signal);
+      continue;
+    }
+
+    if (!res || !isRetryableResponse(res) || attempt >= maxRetries) {
+      return res;
+    }
+
+    await sleep(options.retryDelayMs, signal);
+  }
+}
+
 /**
  * Shared form-submission hook used across Send, Split, NewPolicy, and Savings
  * Goal flows.
@@ -76,6 +157,14 @@ async function parseResponseBody(response: Response): Promise<unknown> {
  * return <form action={formAction}>…</form>;
  * ```
  *
+ * @example Opt into timeout and bounded retry for an idempotent update
+ * ```tsx
+ * const [state, formAction] = useFormAction('/api/settings', 'PUT', {
+ *   timeoutMs: 8000,
+ *   maxRetries: 1,
+ * });
+ * ```
+ *
  * @bug (fixed) Previously a submit that resolved after unmount would call
  * `setState` on an unmounted component, triggering a React warning and
  * potentially interfering with re-mounted siblings. The `mountedRef` guard
@@ -83,12 +172,16 @@ async function parseResponseBody(response: Response): Promise<unknown> {
  */
 export function useFormAction<T extends ActionState = ActionState>(
   url: string,
-  method: "POST" | "PUT" | "PATCH" | "DELETE" = "POST"
+  method: FormActionMethod = "POST",
+  options: UseFormActionOptions = {}
 ) {
   const [state, setState] = useState<T>({} as T);
   const [isPending, startTransition] = useTransition();
   const abortRef = useRef<AbortController | null>(null);
   const mountedRef = useRef(true);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxRetries = options.maxRetries ?? 0;
+  const retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
 
   useEffect(() => {
     mountedRef.current = true;
@@ -106,12 +199,28 @@ export function useFormAction<T extends ActionState = ActionState>(
       abortRef.current = controller;
 
       startTransition(async () => {
+        let timedOut = false;
+        const timeout =
+          timeoutMs > 0
+            ? setTimeout(() => {
+                timedOut = true;
+                controller.abort(new DOMException(TIMEOUT_ERROR_MESSAGE, "AbortError"));
+                if (mountedRef.current) {
+                  setState({ error: TIMEOUT_ERROR_MESSAGE } as T);
+                }
+              }, timeoutMs)
+            : null;
+
         try {
-          const res = await apiClient.request(url, {
-            method,
-            body: formData,
-            signal: controller.signal,
+          const res = await submitWithRetry(url, method, formData, controller.signal, {
+            maxRetries,
+            retryDelayMs,
           });
+
+          if (timedOut && mountedRef.current) {
+            setState({ error: TIMEOUT_ERROR_MESSAGE } as T);
+            return;
+          }
 
           // apiClient returns null when session-expiry flow has been triggered.
           if (!res || controller.signal.aborted || !mountedRef.current) return;
@@ -162,18 +271,25 @@ export function useFormAction<T extends ActionState = ActionState>(
 
           setState(payload as T);
         } catch (error) {
+          if (timedOut && mountedRef.current) {
+            setState({ error: TIMEOUT_ERROR_MESSAGE } as T);
+            return;
+          }
+
           if (
             controller.signal.aborted ||
-            (error instanceof DOMException && error.name === "AbortError") ||
+            isAbortError(error) ||
             !mountedRef.current
           ) {
             return;
           }
           setState({ error: NETWORK_ERROR_MESSAGE } as T);
+        } finally {
+          if (timeout) clearTimeout(timeout);
         }
       });
     },
-    [method, url]
+    [maxRetries, method, retryDelayMs, timeoutMs, url]
   );
 
   return [state, formAction, isPending] as const;


### PR DESCRIPTION
## Summary
- add configurable `timeoutMs`, `maxRetries`, and `retryDelayMs` options to `useFormAction` without changing its `[state, formAction, isPending]` tuple API
- abort hung submissions on timeout and surface a distinct timeout error
- add bounded opt-in retries for idempotent form methods on transient 5xx/network failures, while keeping POST non-retryable

## Tests
- `node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner lib/hooks/useFormAction.test.ts`
- `node node_modules/eslint/bin/eslint.js lib/hooks/useFormAction.ts lib/hooks/useFormAction.test.ts`

Note: `tsc --noEmit --pretty false` is currently blocked by existing unrelated TSX syntax errors in `app/settings/page.tsx` and `components/Nav/PrimaryNav.tsx`.

Closes #858