### PR TITLE
refactor(tutorial): extract typed tutorials catalog to lib/tutorials.ts

### DIFF
--- a/app/tutorial/[tutorialId]/page.tsx
+++ b/app/tutorial/[tutorialId]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Metadata } from "next";
 import PageHeadingLink from "@/components/PageHeadingLink";
+import { getTutorialById, TUTORIALS } from "@/lib/tutorials";
 
 type Props = {
   params: Promise<{ tutorialId: string }>;
@@ -8,18 +9,27 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { tutorialId } = await params;
-  const formattedTitle = tutorialId
+  const tutorial = getTutorialById(tutorialId);
+  const title = tutorial?.title ?? tutorialId
     .replace(/-/g, ' ')
     .replace(/\b\w/g, (c) => c.toUpperCase());
   return {
-    title: `${formattedTitle} Tutorial | RemitWise`,
-    description: `Step-by-step tutorial for ${formattedTitle} on RemitWise. Track your progress chapter by chapter.`,
+    title: `${title} | RemitWise`,
+    description: tutorial?.description ??
+      `Step-by-step tutorial for ${title} on RemitWise. Track your progress chapter by chapter.`,
   };
+}
+
+export async function generateStaticParams() {
+  return TUTORIALS.map((t) => ({ tutorialId: t.id }));
 }
 
 export default async function TutorialOverviewPage({ params }: Props) {
   const { tutorialId } = await params;
-  const chapters = Array.from({ length: 5 }).map((_, i) => ({
+  const tutorial = getTutorialById(tutorialId);
+
+  const chaptersCount = tutorial?.chaptersCount ?? 5;
+  const chapters = Array.from({ length: chaptersCount }).map((_, i) => ({
     id: String(i),
     title: `Chapter ${i + 1}`,
     description: "Short chapter summary",
@@ -36,6 +46,8 @@ export default async function TutorialOverviewPage({ params }: Props) {
   const resumeIndex = chapters.findIndex((chapter) => chapter.progress < 100);
   const resumeChapter = resumeIndex >= 0 ? resumeIndex : 0;
 
+  const displayTitle = tutorial?.title ?? tutorialId;
+
   return (
     <div className="min-h-screen bg-bg1 py-8">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -46,15 +58,15 @@ export default async function TutorialOverviewPage({ params }: Props) {
             </Link>
             <PageHeadingLink
               headingId="tutorial-overview-page-heading"
-              label={`${tutorialId} tutorial`}
+              label={`${displayTitle} tutorial`}
               wrapperClassName="mt-3 flex min-w-0 items-center gap-2"
               headingClassName="text-3xl font-bold text-foreground"
               buttonClassName="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-current/15 text-current/70 transition-colors hover:bg-current/10 hover:text-current focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#101010]"
             >
-              {tutorialId}
+              {displayTitle}
             </PageHeadingLink>
             <p className="mt-2 text-sm text-muted max-w-2xl">
-              Continue your learning path and resume the next available chapter when you’re ready.
+              {tutorial?.description ?? "Continue your learning path and resume the next available chapter when you're ready."}
             </p>
           </div>
 

--- a/app/tutorial/page.tsx
+++ b/app/tutorial/page.tsx
@@ -5,52 +5,13 @@ import { ArrowLeft, BookOpen } from "lucide-react";
 import TutorialList from "../../components/tutorials/TutorialList";
 import PageHeadingLink from "@/components/PageHeadingLink";
 import { useSeo } from "@/lib/hooks/useSeo";
+import { TUTORIALS } from "@/lib/tutorials";
 
 export default function TutorialPage() {
   useSeo({
     title: "Tutorials | RemitWise",
     description: "Learn how to use RemitWise with step-by-step tutorials for sending money, managing wallets, savings goals, and more.",
   });
-
-  const tutorials = [
-    {
-      id: "getting-started",
-      title: "Getting Started with RemitWise",
-      description:
-        "Learn the basics of sending money and managing your account",
-      duration: "5 min",
-      progress: 0,
-    },
-    {
-      id: "family-wallets",
-      title: "Setting Up Family Wallets",
-      description:
-        "Connect and manage family member wallets for easy transfers",
-      duration: "3 min",
-      progress: 20,
-    },
-    {
-      id: "savings-goals",
-      title: "Creating Savings Goals",
-      description: "Set up and track your financial goals with RemitWise",
-      duration: "4 min",
-      progress: 60,
-    },
-    {
-      id: "emergency-transfers",
-      title: "Emergency Transfers",
-      description: "How to use emergency transfer for urgent situations",
-      duration: "2 min",
-      progress: 0,
-    },
-    {
-      id: "bill-payments",
-      title: "Bill Payments",
-      description: "Pay bills directly from your RemitWise wallet",
-      duration: "3 min",
-      progress: 0,
-    },
-  ];
 
   return (
     <div className="min-h-screen bg-bg1">
@@ -86,7 +47,7 @@ export default function TutorialPage() {
           </p>
         </div>
 
-        <TutorialList tutorials={tutorials} />
+        <TutorialList tutorials={TUTORIALS} />
 
         <div className="mt-12 bg-gradient-to-br from-bg2 to-bg3 rounded-2xl p-8 border border-border">
           <div className="flex items-start gap-6">

--- a/lib/tutorials.ts
+++ b/lib/tutorials.ts
@@ -1,0 +1,94 @@
+/**
+ * Typed tutorials catalog — single source of truth for all tutorial routes.
+ *
+ * Mirrors the structure of {@link lib/changelog.ts} so contributors can follow
+ * the same pattern when adding new tutorials.
+ *
+ * User-facing strings are grouped under the `title` and `description` fields.
+ * When i18n is wired up, replace these string literals with translation-key
+ * lookups (e.g. `t('tutorials.getting-started.title')`).
+ *
+ * @module lib/tutorials
+ */
+
+/** A single tutorial entry in the catalog. */
+export interface Tutorial {
+  /** URL-safe identifier; matches the `[tutorialId]` route segment. */
+  id: string;
+  /**
+   * Display title.
+   * i18n-ready: key `tutorials.<id>.title`
+   */
+  title: string;
+  /**
+   * Short description shown in the list view.
+   * i18n-ready: key `tutorials.<id>.description`
+   */
+  description: string;
+  /** Approximate read/watch time shown to the user (e.g. "5 min"). */
+  duration: string;
+  /** Number of chapters in this tutorial. */
+  chaptersCount: number;
+  /** User's current progress percentage (0-100). Defaults to 0 for new users. */
+  progress: number;
+}
+
+/** Complete catalog of RemitWise tutorials. */
+export const TUTORIALS: Tutorial[] = [
+  {
+    id: 'getting-started',
+    title: 'Getting Started with RemitWise',
+    description: 'Learn the basics of sending money and managing your account',
+    duration: '5 min',
+    chaptersCount: 5,
+    progress: 0,
+  },
+  {
+    id: 'family-wallets',
+    title: 'Setting Up Family Wallets',
+    description: 'Connect and manage family member wallets for easy transfers',
+    duration: '3 min',
+    chaptersCount: 5,
+    progress: 20,
+  },
+  {
+    id: 'savings-goals',
+    title: 'Creating Savings Goals',
+    description: 'Set up and track your financial goals with RemitWise',
+    duration: '4 min',
+    chaptersCount: 5,
+    progress: 60,
+  },
+  {
+    id: 'emergency-transfers',
+    title: 'Emergency Transfers',
+    description: 'How to use emergency transfer for urgent situations',
+    duration: '2 min',
+    chaptersCount: 5,
+    progress: 0,
+  },
+  {
+    id: 'bill-payments',
+    title: 'Bill Payments',
+    description: 'Pay bills directly from your RemitWise wallet',
+    duration: '3 min',
+    chaptersCount: 5,
+    progress: 0,
+  },
+];
+
+/**
+ * Look up a tutorial by its id segment.
+ *
+ * @param id - The `[tutorialId]` route segment (e.g. `"getting-started"`).
+ * @returns The matching {@link Tutorial}, or `undefined` when not found.
+ *
+ * @example
+ * ```ts
+ * const tutorial = getTutorialById('savings-goals');
+ * if (!tutorial) notFound();
+ * ```
+ */
+export function getTutorialById(id: string): Tutorial | undefined {
+  return TUTORIALS.find((t) => t.id === id);
+}


### PR DESCRIPTION
## Summary

- Creates `lib/tutorials.ts` exporting a typed `Tutorial[]` catalog and a `getTutorialById(id)` helper, following the `lib/changelog.ts` pattern.
- Updates `app/tutorial/page.tsx` to import `TUTORIALS` from the catalog instead of hardcoding the array inline.
- Updates `app/tutorial/[tutorialId]/page.tsx` to call `getTutorialById()` to resolve the tutorial's title, description, and chapter count — fixing the mismatch between list and detail routes.
- Adds `generateStaticParams()` so the detail route pre-renders all known tutorial IDs at build time.
- User-facing strings carry i18n-ready comments (`tutorials.<id>.title`, `tutorials.<id>.description`).

Closes #882

## Test plan

- [ ] `/tutorial` renders the same five tutorials as before with no visible change.
- [ ] `/tutorial/savings-goals` shows the correct title "Creating Savings Goals" (resolved from catalog, not slug-formatting).
- [ ] Adding a new tutorial to `lib/tutorials.ts` propagates to both the list and detail routes automatically.
- [ ] `getTutorialById('getting-started')` returns the entry; `getTutorialById('nonexistent')` returns `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)