### PR TITLE
test: cover Unicode CSV escaping

### DIFF
--- a/tests/unit/utils/export-serializer.test.ts
+++ b/tests/unit/utils/export-serializer.test.ts
@@ -31,6 +31,11 @@ describe("export-serializer", () => {
       expect(escapeCsvField("Line 1\nLine 2")).toBe('"Line 1\nLine 2"');
       expect(escapeCsvField("Line 1\rLine 2")).toBe('"Line 1\rLine 2"');
     });
+
+    it("preserves Unicode characters when escaping fields", () => {
+      expect(escapeCsvField("José 東京")).toBe("José 東京");
+      expect(escapeCsvField('José, "東京"')).toBe('"José, ""東京"""');
+    });
   });
 
   describe("serializeToCsv", () => {


### PR DESCRIPTION
## Summary

- add coverage for Unicode CSV fields that do not require quoting
- verify Unicode content is preserved when commas and quotes trigger RFC 4180 escaping

## Verification

- `node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/unit/utils/export-serializer.test.ts` (13 tests passed)
- `npx eslint tests/unit/utils/export-serializer.test.ts`

Repository-wide lint and build were also attempted. They are currently blocked by unrelated errors already present on `main`, including JSX parsing errors, duplicate declarations, and missing modules.

Closes #940