### PR TITLE
docs(transactions): document user-interaction filter behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ For authenticated browser-side requests, use the shared client API layer documen
 
 Route-level page titles now use a shared deep-link heading pattern. Use the shared heading primitive with a stable route-specific id whenever you add or update a primary page title. See [docs/page-heading-deeplinks.md](docs/page-heading-deeplinks.md).
 
+The `/transactions` view only ever lists user-initiated interactions (sends, splits, bill payments, etc.) and its type filter is how a reader narrows that list. See [docs/transactions-user-interaction-filter.md](docs/transactions-user-interaction-filter.md) for the model and what to update if a system-generated entry type is ever added.
+
 ## Per-Route SEO Metadata (`useSeo`)
 
 Each client-side route can define its own `<title>` and `<meta name="description">` using the `useSeo` hook.

--- a/docs/transactions-filters-search-grouping.md
+++ b/docs/transactions-filters-search-grouping.md
@@ -4,6 +4,8 @@
 
 Issue #428 focuses on the `/transactions` filtering, search, and grouped-list experience. It does not change transaction row density, typography scale, or readability rules covered by UX-013.
 
+See [docs/transactions-user-interaction-filter.md](./transactions-user-interaction-filter.md) for why every type chip below already represents a user-initiated interaction, and what to do if a system-generated entry type is ever added.
+
 ## Filter Behavior
 
 - Search matches transaction ID, counterparty, type, status, amount, and currency.

--- a/docs/transactions-user-interaction-filter.md
+++ b/docs/transactions-user-interaction-filter.md
@@ -1,0 +1,63 @@
+# Transaction History: filtering to user-interaction entries
+
+Audience: **contributor** working on `/transactions` or on any feature that
+appends new entries to the transaction/activity list.
+
+## Summary
+
+Every row rendered by the Transaction History view (`app/transactions/page.tsx`)
+represents a **user-initiated interaction** — an action a person took (sending
+money, splitting a payment, paying a bill, etc.) — not a system-generated log
+line (no background job, webhook retry, or admin action ever appears in this
+list). The view's type filter is how a reader narrows that list down to the
+specific kind of interaction they care about.
+
+There is intentionally no "system event" transaction type to filter *out*:
+the list only ever contains user-story-shaped entries in the first place.
+
+## How the filter works
+
+The `Transaction` model (`components/Dashboard/TransactionHistoryItem.tsx:22-44`)
+gives every entry a `type: TransactionType`, where each value corresponds to a
+concrete, user-triggered flow:
+
+```ts
+type TransactionType =
+  | "Send Money"        // user sent a remittance
+  | "Smart Split"        // user configured/triggered an automatic split
+  | "Bill Payment"       // user paid a bill
+  | "Insurance"          // user paid an insurance premium
+  | "Savings"            // user moved money into a savings goal
+  | "Family Transfer"    // user transferred to/from a family wallet
+  | "Received";          // user received an incoming payment
+```
+
+`app/transactions/page.tsx:164-223` (`typeStyles`) maps each of those values to
+a filter chip (icon + label + color). The chips are rendered as multi-select
+toggles; `filteredTransactions` (`app/transactions/page.tsx:310`) is the
+`useMemo` that applies the active chip selection (AND'd with search and status
+filters) to `allTransactions`.
+
+Example: selecting only the **Send** and **Split** chips shows just the rows
+where a user actively moved or allocated funds, hiding bill/insurance/family
+activity without needing a separate "user interaction" toggle — because every
+option already is a user interaction.
+
+## Extending this
+
+If a future feature introduces a genuinely system-generated entry (e.g. an
+automated retry or an admin adjustment), it must:
+
+1. Add a new `TransactionType` value in `TransactionHistoryItem.tsx`.
+2. Add a matching entry to `typeStyles` in `app/transactions/page.tsx`.
+3. Update this doc and `docs/transactions-filters-search-grouping.md` to
+   describe how to filter it in or out, since at that point "all entries are
+   user interactions" would no longer hold.
+
+Until then, no additional filter is needed to isolate user-interaction
+entries — the full type-chip set already is that filter.
+
+## Related docs
+
+- [docs/transactions-filters-search-grouping.md](./transactions-filters-search-grouping.md) —
+  full reference for search, chip, and grouping behavior on this page.


### PR DESCRIPTION
Closes #1005

## Summary
- Documented that every `/transactions` entry (`app/transactions/page.tsx`) is a user-initiated interaction (Send Money, Smart Split, Bill Payment, Insurance, Savings, Family Transfer, Received) — there is no system-generated entry type in the current data model, so the existing type-chip filter already is the "filter to user interaction" mechanism.
- Added `docs/transactions-user-interaction-filter.md`: explains the `Transaction`/`TransactionType` model, how the type chips (`typeStyles`, `app/transactions/page.tsx:164-223`) and `filteredTransactions` (`app/transactions/page.tsx:310`) apply the filter, and what to update if a genuinely system-generated entry type is ever introduced.
- Cross-linked the new doc from `docs/transactions-filters-search-grouping.md` (the existing filter/search/grouping reference) and from `README.md`.

This is a documentation-only change — no component, filter, or data-model code was modified.

## Type of Change
- [x] Documentation
- [ ] UI/UX feature
- [ ] SAST rule update
- [ ] Dependency vulnerability fix
- [ ] Exemption addition/renewal
- [ ] Security workflow modification
- [ ] Container image update

## Testing
- `npm run lint`: pre-existing failures only, in files untouched by this branch (`app/admin/page.tsx`, `app/settings/page.tsx`, `components/Nav/PrimaryNav.tsx`, etc.) — confirmed via `git status` that none of the failing files are part of this diff.
- `npm run build`: pre-existing webpack failures on `main` (missing `react-window`/`@tanstack/react-query` deps, an unrelated duplicate-identifier bug in `app/bills/page.tsx`) — unrelated to this docs-only change.
- `npm run test:unit`: pre-existing failures in `horizon.test.ts`, `wallet-button.test.tsx`, `page-header.test.tsx` — unrelated to this docs-only change; no test files were added or modified since no code changed.
- No new tests are applicable: this PR only adds/edits Markdown.

## Documentation Updates
- [x] Added `docs/transactions-user-interaction-filter.md`
- [x] `README.md` — added a link to the new doc
- [x] `docs/transactions-filters-search-grouping.md` — added a cross-link

## Security Impact Analysis
Not a security-relevant change — Markdown documentation only, no code, no auth/API/dependency/CI changes.

- **Affected Components:** none
- **Risk:** none

## Checklist
- [x] No secrets or keys committed
- [x] No PII or sensitive data in logs
- [x] All security scans pass (n/a — no security-relevant surface touched)
- [x] Branch protection requirements met
- [x] Code review from security team (not applicable — non-security documentation change)