### PR TITLE
docs(api): add one-page reference for route handler decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ remitwise-frontend/
 
 See [API Routes Documentation](./docs/API_ROUTES.md) for details on authentication and available endpoints.
 
+Every route handler under `app/api/` is composed from a small set of reusable decorators (`withAuth`, `validatedRoute`, `withApiErrorHandler`). See [docs/api-route-decorators.md](./docs/api-route-decorators.md) for what each one does and when to use it.
+
 For authenticated browser-side requests, use the shared client API layer documented in [docs/client-api.md](docs/client-api.md). That guide covers when to use `apiClient` instead of raw `fetch`, the `401 -> refresh -> retry once` flow, session-expiry UI surfacing, and logout behavior.
 
 Route-level page titles now use a shared deep-link heading pattern. Use the shared heading primitive with a stable route-specific id whenever you add or update a primary page title. See [docs/page-heading-deeplinks.md](docs/page-heading-deeplinks.md).

--- a/docs/API_MIDDLEWARE.md
+++ b/docs/API_MIDDLEWARE.md
@@ -4,6 +4,8 @@
 
 Implemented CORS, security headers, and request body size validation for all `/api` routes in the Next.js application. The implementation follows best practices with modular helper functions, proper header ordering, and comprehensive test coverage.
 
+For the per-route handler decorators (`withAuth`, `validatedRoute`, `withApiErrorHandler`) that individual routes opt into on top of this global middleware, see [docs/api-route-decorators.md](./api-route-decorators.md).
+
 ## Implementation Details
 
 ### 1. **middleware.ts** - Core Implementation

--- a/docs/api-route-decorators.md
+++ b/docs/api-route-decorators.md
@@ -1,0 +1,120 @@
+# API route decorators
+
+Audience: **contributor** adding or editing a route handler under `app/api/`.
+
+This page is the one-stop list of every route-handler decorator (higher-order
+function that wraps a Next.js route handler) in this codebase, and when to
+reach for each one. For the global CORS/security-header/body-size middleware
+that runs ahead of all of these on every `/api` request, see
+[docs/API_MIDDLEWARE.md](./API_MIDDLEWARE.md) — that's a different layer and
+is not covered here.
+
+## `withAuth` — require an authenticated caller
+
+**File:** `lib/auth.ts:47`
+
+Wraps a handler so it only runs for an authenticated request, and hands the
+handler the caller's Stellar address. It accepts, in order:
+
+1. `Authorization: Bearer <AUTH_SECRET>` (service-to-service calls)
+2. `x-user` / `x-stellar-public-key` headers (used in tests/tooling)
+3. The `iron-session` cookie session (normal browser requests)
+
+If none match, it returns a `401` via `unauthorizedResponse()` — the handler
+body never runs.
+
+**Use it when:** the route must only be reachable by a signed-in wallet
+address, and the handler needs that address.
+
+```ts
+// app/api/goals/route.ts
+import { withAuth } from "@/lib/auth";
+
+async function getHandler(request: NextRequest, address: string) {
+  return NextResponse.json(await getGoalsForAddress(address));
+}
+
+export const GET = withAuth(getHandler);
+```
+
+Real call sites: `app/api/split/route.ts`, `app/api/goals/route.ts`,
+`app/api/bills/route.ts`, `app/api/family/route.ts`, `app/api/send/route.ts`.
+
+> There is a second, unused `withAuth`/`compose` pair in
+> `lib/auth/middleware.ts:133,157`. Nothing in `app/api` imports them — prefer
+> the `lib/auth.ts` version above for new routes.
+
+## `validatedRoute` — parse and validate input with Zod
+
+**File:** `lib/auth/middleware.ts:84`
+
+Wraps a handler so the request body (or query string) is parsed and validated
+against a Zod schema before the handler runs. On failure it returns a `400`
+with a `validationErrors` array; on success the handler receives the typed,
+parsed data instead of the raw request.
+
+**Use it when:** the route accepts a POST/PUT/PATCH body or GET query params
+that need schema validation, and you want the `400` handling done for you.
+
+```ts
+// app/api/insurance/route.ts
+import { validatedRoute } from "@/lib/auth/middleware";
+
+const billSchema = z.object({
+  policyName: z.string().min(4, "Name is too short"),
+  coverageType: z.enum(["Health", "Emergency", "Life"]),
+  monthlyPremium: z.coerce.number().positive(),
+  coverageAmount: z.coerce.number().positive(),
+});
+
+export const POST = validatedRoute(billSchema, "body", async (req, data) => {
+  return NextResponse.json({ success: "Insurance added", ...data });
+});
+```
+
+Pass `"query"` as the second argument for `GET` routes that validate search
+params instead of a JSON body (see `app/api/remittance/quote/route.ts`).
+
+## `withApiErrorHandler` — normalize thrown errors into an error envelope
+
+**File:** `lib/api/error-handler.ts:66`
+
+Wraps a handler in a `try/catch`. Any thrown `ContractError`/`ApiRouteError`/
+generic `Error` is converted (via `mapError`) into a consistent JSON error
+envelope (`{ success: false, error: { code, message } }`) with the right HTTP
+status, and every response — success or failure — gets an `x-request-id`
+header for tracing.
+
+**Use it when:** the handler calls into contract/service code that throws on
+failure (instead of returning a response itself), and you want uniform error
+shapes without a `try/catch` in every handler.
+
+```ts
+// app/api/v1/bills/route.ts
+import { withApiErrorHandler } from "@/lib/api/error-handler";
+
+export const POST = withApiErrorHandler(async function POST(req: NextRequest) {
+  const result = await payBill(req); // throws ContractError on failure
+  return NextResponse.json({ success: true, result });
+});
+```
+
+Real call sites: `app/api/v1/bills/route.ts`, `app/api/v1/bills/[id]/pay/route.ts`,
+`app/api/v1/insurance/route.ts`.
+
+## Combining decorators
+
+These three answer different questions (*who's calling?*, *is the input
+valid?*, *what if it throws?*) and are not mutually exclusive, but no current
+route composes more than one — each `app/api/**/route.ts` file picks whichever
+one matches what the handler needs. If a route needs more than one, wrap
+outermost-first, e.g. `withApiErrorHandler(withAuth(handler))` so auth failures
+still get a request ID.
+
+## Quick reference
+
+| Decorator | File | Problem it solves | Failure response |
+| --- | --- | --- | --- |
+| `withAuth` | `lib/auth.ts:47` | Require a signed-in caller | `401` |
+| `validatedRoute` | `lib/auth/middleware.ts:84` | Validate body/query with Zod | `400` |
+| `withApiErrorHandler` | `lib/api/error-handler.ts:66` | Normalize thrown errors | Mapped status via `mapError` |


### PR DESCRIPTION
Closes #994

## Summary
- Added `docs/api-route-decorators.md`: a single-page reference listing every route-handler decorator (higher-order function wrapping an `app/api/**/route.ts` handler) in this codebase, with what problem each solves and a real usage example pulled from the codebase:
  - `withAuth` (`lib/auth.ts:47`) — require an authenticated caller, injects the Stellar address
  - `validatedRoute` (`lib/auth/middleware.ts:84`) — parse/validate body or query params with Zod
  - `withApiErrorHandler` (`lib/api/error-handler.ts:66`) — normalize thrown errors into a consistent JSON error envelope + `x-request-id`
- Noted that a second `withAuth`/`compose` pair exists in `lib/auth/middleware.ts` but has no call sites in `app/api` — flagged as unused rather than silently duplicated, so contributors don't reach for the wrong one.
- Cross-linked the new doc from `README.md` and from `docs/API_MIDDLEWARE.md` (which covers the separate, global CORS/security-header middleware layer, not these per-route decorators).

This is a documentation-only change — no handler, middleware, or route code was modified.

## Type of Change
- [x] Documentation
- [ ] UI/UX feature
- [ ] SAST rule update
- [ ] Dependency vulnerability fix
- [ ] Exemption addition/renewal
- [ ] Security workflow modification
- [ ] Container image update

## Testing
- `npm run lint`: pre-existing failures only, in files untouched by this branch (`app/admin/page.tsx`, `app/settings/page.tsx`, `components/Nav/PrimaryNav.tsx`, etc.).
- `npm run build`: pre-existing webpack failures on `main` (missing `react-window`/`@tanstack/react-query` deps, an unrelated duplicate-identifier bug in `app/bills/page.tsx`) — unrelated to this docs-only change.
- `npm run test:unit`: pre-existing failures in `horizon.test.ts`, `wallet-button.test.tsx`, `page-header.test.tsx` — unrelated to this docs-only change.
- No new tests are applicable: this PR only adds/edits Markdown, and all code examples in the doc are copied verbatim from existing, already-tested route handlers.

## Documentation Updates
- [x] Added `docs/api-route-decorators.md`
- [x] `README.md` — added a link to the new doc
- [x] `docs/API_MIDDLEWARE.md` — added a cross-link

## Security Impact Analysis
Not a security-relevant change — Markdown documentation only, no code, no auth/API/dependency/CI changes.

- **Affected Components:** none
- **Risk:** none

## Checklist
- [x] No secrets or keys committed
- [x] No PII or sensitive data in logs
- [x] All security scans pass (n/a — no security-relevant surface touched)
- [x] Branch protection requirements met
- [x] Code review from security team (not applicable — non-security documentation change)