### PR TITLE
test(WalletDropdown): cover Enter/Space keyboard activation

### DIFF
--- a/components/WalletDropdown.test.tsx
+++ b/components/WalletDropdown.test.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 // Mock the useFocusTrap hook
 vi.mock('../src/lib/hooks/useFocusTrap', () => ({
@@ -149,6 +150,56 @@ describe('WalletDropdown', () => {
       menuItems[0].focus();
       fireEvent.keyDown(document, { key: 'End' });
       expect(document.activeElement).toBe(menuItems[menuItems.length - 1]);
+    });
+  });
+
+  describe('keyboard activation', () => {
+    it('activates the focused menuitem on Enter', async () => {
+      const user = userEvent.setup();
+      render(<WalletDropdown {...defaultProps} />);
+      const disconnectBtn = screen.getByText('Disconnect').closest('button')!;
+
+      disconnectBtn.focus();
+      await user.keyboard('{Enter}');
+
+      expect(defaultProps.onDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('activates the focused menuitem on Space', async () => {
+      const user = userEvent.setup();
+      render(<WalletDropdown {...defaultProps} />);
+      const disconnectBtn = screen.getByText('Disconnect').closest('button')!;
+
+      disconnectBtn.focus();
+      await user.keyboard(' ');
+
+      expect(defaultProps.onDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not activate a disabled menuitem on Enter or Space', async () => {
+      const user = userEvent.setup();
+      render(
+        <WalletDropdown {...defaultProps} isConnected={false} isConnecting />,
+      );
+      const connectBtn = screen.getByText('Connecting...').closest('button')!;
+      expect(connectBtn).toBeDisabled();
+
+      connectBtn.focus();
+      await user.keyboard('{Enter}');
+      await user.keyboard(' ');
+
+      expect(defaultProps.onConnect).not.toHaveBeenCalled();
+    });
+
+    it('does not activate a menuitem on unrelated keys', async () => {
+      const user = userEvent.setup();
+      render(<WalletDropdown {...defaultProps} />);
+      const disconnectBtn = screen.getByText('Disconnect').closest('button')!;
+
+      disconnectBtn.focus();
+      await user.keyboard('a');
+
+      expect(defaultProps.onDisconnect).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Closes #1011

## Summary
`components/WalletDropdown.tsx` implements the WAI-ARIA menu keyboard pattern: `ArrowDown`/`ArrowUp`/`Home`/`End` move focus between `role="menuitem"` buttons (`handleArrowKeys`, `components/WalletDropdown.tsx:106-142`), and `Enter`/`Space` activation relies on native `<button>` semantics. `components/WalletDropdown.test.tsx` already covered arrow-key/Home/End navigation, but had no test asserting that the focused item actually activates on `Enter`/`Space`, or that it doesn't activate when disabled or on an unrelated key.

Added 4 tests to `components/WalletDropdown.test.tsx` under a new `keyboard activation` block:
- `activates the focused menuitem on Enter` — happy path
- `activates the focused menuitem on Space` — happy path
- `does not activate a disabled menuitem on Enter or Space` — sad path (Connect button while `isConnecting`)
- `does not activate a menuitem on unrelated keys` — sad path

Uses `@testing-library/user-event` (already a project dependency, already used in `tests/unit/ui/wallet-button.test.tsx`) since its `keyboard()` helper simulates the browser's native Enter/Space → click activation for buttons, which plain `fireEvent.keyDown` does not.

No source code changed — this is test-only, locking in existing (correct) keyboard-activation behavior.

## Testing
- `vitest run components/WalletDropdown.test.tsx`: **21 passed** (17 existing + 4 new).
- `eslint components/WalletDropdown.test.tsx`: clean.
- `npm run test:unit`: same 13 pre-existing failures / 317 passed as on `main` before this change (in `horizon.test.ts`, `wallet-button.test.tsx`, `page-header.test.tsx` — unrelated to this file). Note: `components/*.test.tsx` (including this file) isn't part of `test:unit`'s explicit file glob in `package.json` — that's a pre-existing repo quirk, out of scope here; the full `vitest.config.mjs` `include` list does cover it (used by `npm run test:coverage`), and I verified directly via `vitest run components/WalletDropdown.test.tsx` above.
- `npm run build`: pre-existing webpack failures on `main` (missing `react-window`/`@tanstack/react-query` deps, unrelated duplicate-identifier bug in `app/bills/page.tsx`) — unrelated to this change.

## Type of Change
- [x] Test coverage
- [ ] UI/UX feature
- [ ] SAST rule update
- [ ] Dependency vulnerability fix
- [ ] Exemption addition/renewal
- [ ] Security workflow modification
- [ ] Container image update

## Security Impact Analysis
Not a security-relevant change — test file only, no source/behavior change.

- **Affected Components:** none
- **Risk:** none

## Checklist
- [x] No secrets or keys committed
- [x] No PII or sensitive data in logs
- [x] All security scans pass (n/a — no security-relevant surface touched)
- [x] Branch protection requirements met
- [x] Code review from security team (not applicable — non-security test change)