### PR TITLE
test(SubNav): cover isActive() boolean across route boundaries

### DIFF
--- a/tests/unit/SubNav.test.tsx
+++ b/tests/unit/SubNav.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SubNav from "@/components/Nav/SubNav";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(),
+}));
+
+import { usePathname } from "next/navigation";
+
+describe("SubNav", () => {
+  it("renders all dashboard sub-nav links", () => {
+    vi.mocked(usePathname).mockReturnValue("/dashboard");
+    render(<SubNav />);
+
+    expect(screen.getByRole("link", { name: /Overview/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Savings Goals/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Insights/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /History/ })).toBeInTheDocument();
+  });
+
+  it("marks the exact-match root route (/dashboard) as active with aria-current=page", () => {
+    vi.mocked(usePathname).mockReturnValue("/dashboard");
+    render(<SubNav />);
+
+    expect(screen.getByRole("link", { name: /Overview/ })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  it("marks a nested sub-route (/dashboard/goals) as active with aria-current=page", () => {
+    vi.mocked(usePathname).mockReturnValue("/dashboard/goals");
+    render(<SubNav />);
+
+    expect(screen.getByRole("link", { name: /Savings Goals/ })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  it("does not mark the root Overview link active for a nested sub-route", () => {
+    vi.mocked(usePathname).mockReturnValue("/dashboard/goals");
+    render(<SubNav />);
+
+    expect(
+      screen.getByRole("link", { name: /Overview/ }),
+    ).not.toHaveAttribute("aria-current");
+  });
+
+  it("does not mark any link active for an unrelated route", () => {
+    vi.mocked(usePathname).mockReturnValue("/send");
+    render(<SubNav />);
+
+    for (const name of [/Overview/, /Savings Goals/, /Insights/, /History/]) {
+      expect(screen.getByRole("link", { name })).not.toHaveAttribute(
+        "aria-current",
+      );
+    }
+  });
+
+  it("keeps a deeper nested route (/dashboard/goals/123) active on its parent sub-nav link", () => {
+    vi.mocked(usePathname).mockReturnValue("/dashboard/goals/123");
+    render(<SubNav />);
+
+    expect(screen.getByRole("link", { name: /Savings Goals/ })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+});


### PR DESCRIPTION
Closes #1000

## Summary
`components/Nav/SubNav.tsx` computes `isActive(href): boolean` per link and drives `aria-current="page"`. Since sub-nav items only get `tabIndex`/focus via keyboard when a user tabs through them (there's no other way to discover the active item without a pointer), this boolean is the whole signal a keyboard-only user has for "where am I" — and it had no direct test coverage (only `components/Nav.tsx`'s equivalent, simpler `isActive` is tested, via `tests/unit/Nav.test.tsx`).

Added `tests/unit/SubNav.test.tsx` with 6 tests:
- renders all four sub-nav links (sanity/happy path)
- exact-match root route (`/dashboard`) → `aria-current="page"` on Overview
- nested sub-route (`/dashboard/goals`) → `aria-current="page"` on Savings Goals
- nested sub-route does **not** also mark the root Overview link active (the boundary `isActive("/dashboard")` specifically guards against via exact match, vs. the `startsWith` used for the other links)
- unrelated route (`/send`) → no link gets `aria-current`
- a route nested two levels deep (`/dashboard/goals/123`) still resolves active on its parent link

No source code changed — this is test-only, locking in existing (correct) behavior.

## Testing
- `vitest run tests/unit/SubNav.test.tsx`: **6 passed**.
- `eslint tests/unit/SubNav.test.tsx`: clean.
- Full `vitest run` (uses `vitest.config.mjs`'s complete `include` list): no new failures introduced by this file; pre-existing failures are unrelated (`horizon.test.ts`, `DensityContext.test.tsx`, `anchor/rates-route.test.ts`, etc. — all pre-existing on `main`).
- Note: `npm run test:unit:vitest`'s explicit glob args (`tests/unit/**/*.test.ts tests/unit/**/*.test.tsx`) don't expand under `sh` the way they do in an interactive shell with globstar enabled, so that script under-reports the files it actually runs — a pre-existing repo/shell quirk, unrelated to and out of scope for this change. Running vitest directly (as above) is the reliable way to confirm this file runs and passes.
- `npm run build`: pre-existing webpack failures on `main` (missing `react-window`/`@tanstack/react-query` deps, unrelated duplicate-identifier bug in `app/bills/page.tsx`) — unrelated to this change.

## Type of Change
- [x] Test coverage
- [ ] UI/UX feature
- [ ] SAST rule update
- [ ] Dependency vulnerability fix
- [ ] Exemption addition/renewal
- [ ] Security workflow modification
- [ ] Container image update

## Security Impact Analysis
Not a security-relevant change — test file only, no source/behavior change.

- **Affected Components:** none
- **Risk:** none

## Checklist
- [x] No secrets or keys committed
- [x] No PII or sensitive data in logs
- [x] All security scans pass (n/a — no security-relevant surface touched)
- [x] Branch protection requirements met
- [x] Code review from security team (not applicable — non-security test change)