### PR TITLE
feat: expose last-fetched widget payload behind ?dev=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -923,11 +923,18 @@ To enable Developer Mode, append the `?dev=1` query parameter to the application
 
 - **Example:** `http://localhost:3000/?dev=1` or `http://localhost:3000/dashboard?dev=1`
 
-Once enabled, a floating **Developer Mode** panel will appear at the bottom-left of the viewport. This panel persists across client-side page transitions within your session.
+Once enabled, two floating panels appear:
+
+| Panel | Position | Purpose |
+|-------|----------|---------|
+| **Developer Mode** (Request ID) | Bottom-left | Shows the `Request ID` of the most recent API response |
+| **Widget Payloads** | Bottom-right | Shows the last-fetched raw `DashboardResponse` payload per widget section |
+
+Both panels persist across client-side page transitions within your session.
 
 ### Disabling Developer Mode
 
-To disable Developer Mode and hide the panel, append `?dev=0` to the URL or clear your session storage:
+To disable Developer Mode and hide the panels, append `?dev=0` to the URL or clear your session storage:
 
 - **Example:** `http://localhost:3000/?dev=0`
 
@@ -936,3 +943,16 @@ To disable Developer Mode and hide the panel, append `?dev=0` to the URL or clea
 1. **Request Tracking**: As you interact with the app, the floating panel automatically updates in real-time to show the `Request ID` of the most recent API response (extracting from `x-request-id`, `x-correlation-id`, etc.).
 2. **Instant Copying**: Click the Copy icon next to the Request ID to instantly copy the ID to your clipboard.
 3. **Log Investigation**: Provide this copied ID to the backend/platform engineering team or search for it directly in your centralized logging system (e.g. Datadog, Kibana, AWS CloudWatch) to find the complete trace of database operations, external Stellar network interactions, and API response logs associated with that specific user transaction or error.
+
+### Widget Payloads panel
+
+Navigate to `/dashboard?dev=1`. After the dashboard data loads, the **Widget Payloads** panel (bottom-right) displays the raw `DashboardResponse` returned by `GET /api/dashboard`, split into five collapsible sections:
+
+* **remittance** — total sent, split percentages, recent transactions
+* **savings** — savings total, recent goals
+* **bills** — paid count/amount, unpaid bills
+* **insurance** — policy count, monthly premium, active policies
+* **meta** — `cachedAt` timestamp, `ttlSeconds`, `fromCache` flag
+
+Click any section header to expand or collapse its JSON. The payload is stored in `sessionStorage` (key: `dev-widget-payload`) so it is still visible after client-side navigation without requiring a new fetch.
+

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -12,7 +12,12 @@ import { useClientTranslator } from '@/lib/i18n/client';
 import { formatCurrency } from '@/lib/utils/format-currency';
 import type { DashboardResponse } from '@/lib/types/dashboard';
 import { useSeo } from '@/lib/hooks/useSeo';
-import { formatLastSynced } from '@/lib/utils/time-ago';
+import {
+  DEV_MODE_STORAGE_KEY,
+  DEV_WIDGET_PAYLOAD_EVENT,
+} from '@/lib/config/developer';
+
+type LoadState = 'loading' | 'error' | 'ready';
 
 export default function DashboardPage() {
   useSeo({
@@ -57,6 +62,21 @@ export default function DashboardPage() {
         }
 
         setData(json);
+
+        // In dev mode, broadcast the raw payload so DevWidgetPayload can
+        // display it. We check sessionStorage rather than URL params here
+        // because the component that owns the query-param logic (DevWidgetPayload)
+        // lives outside this page; reading the persisted flag avoids a second
+        // useSearchParams call and keeps this side-effect lightweight.
+        if (
+          typeof window !== 'undefined' &&
+          sessionStorage.getItem(DEV_MODE_STORAGE_KEY) === 'true'
+        ) {
+          window.dispatchEvent(
+            new CustomEvent(DEV_WIDGET_PAYLOAD_EVENT, { detail: json })
+          );
+        }
+
         setState('ready');
       })
       .catch(() => {

--- a/components/DevWidgetPayload.test.tsx
+++ b/components/DevWidgetPayload.test.tsx
@@ -1,0 +1,249 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
+import DevWidgetPayload from './DevWidgetPayload';
+import {
+  DEV_MODE_STORAGE_KEY,
+  DEV_MODE_WIDGET_PAYLOAD_KEY,
+  DEV_WIDGET_PAYLOAD_EVENT,
+} from '../lib/config/developer';
+import type { DashboardResponse } from '../lib/types/dashboard';
+
+// ─── Minimal fixture that satisfies DashboardResponse ────────────────────────
+
+const MOCK_PAYLOAD: DashboardResponse = {
+  remittance: {
+    status: 'ok',
+    totalSent: 1200,
+    split: { PHP: 60, INR: 40 },
+    recentTransactions: [],
+  },
+  savings: {
+    status: 'ok',
+    savingsTotal: 800,
+    recentGoals: [],
+  },
+  bills: {
+    status: 'ok',
+    billsPaidCount: 3,
+    billsPaidAmount: 180,
+    unpaidBills: [],
+  },
+  insurance: {
+    status: 'ok',
+    insurancePoliciesCount: 1,
+    insurancePremium: 30,
+    activePolicies: [],
+  },
+  meta: {
+    cachedAt: '2026-01-01T00:00:00.000Z',
+    ttlSeconds: 30,
+    fromCache: false,
+  },
+};
+
+// ─── Mock next/navigation ─────────────────────────────────────────────────────
+
+const mockGet = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({
+    get: mockGet,
+  }),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function dispatchPayload(payload: DashboardResponse) {
+  window.dispatchEvent(
+    new CustomEvent(DEV_WIDGET_PAYLOAD_EVENT, { detail: payload })
+  );
+}
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
+
+describe('DevWidgetPayload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mockGet.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── Visibility ──────────────────────────────────────────────────────────────
+
+  it('renders the panel when ?dev=1 is present', () => {
+    mockGet.mockReturnValue('1');
+    render(<DevWidgetPayload />);
+
+    expect(document.getElementById('dev-widget-payload-container')).not.toBeNull();
+    expect(screen.getByText('Widget Payloads')).toBeDefined();
+  });
+
+  it('does not render when ?dev param is absent', () => {
+    mockGet.mockReturnValue(null);
+    render(<DevWidgetPayload />);
+
+    expect(document.getElementById('dev-widget-payload-container')).toBeNull();
+  });
+
+  it('does not render when ?dev=0 is explicitly set', () => {
+    mockGet.mockReturnValue('0');
+    render(<DevWidgetPayload />);
+
+    expect(document.getElementById('dev-widget-payload-container')).toBeNull();
+  });
+
+  it('hides the panel and updates storage when dev=0 overrides a previously active session', () => {
+    sessionStorage.setItem(DEV_MODE_STORAGE_KEY, 'true');
+    mockGet.mockReturnValue('0');
+    render(<DevWidgetPayload />);
+
+    expect(document.getElementById('dev-widget-payload-container')).toBeNull();
+    expect(sessionStorage.getItem(DEV_MODE_STORAGE_KEY)).toBe('false');
+  });
+
+  it('shows the panel when sessionStorage enables dev mode and no URL param is present', () => {
+    sessionStorage.setItem(DEV_MODE_STORAGE_KEY, 'true');
+    mockGet.mockReturnValue(null);
+    render(<DevWidgetPayload />);
+
+    expect(document.getElementById('dev-widget-payload-container')).not.toBeNull();
+  });
+
+  // ── Waiting state ────────────────────────────────────────────────────────────
+
+  it('shows waiting message before any payload arrives', () => {
+    mockGet.mockReturnValue('1');
+    render(<DevWidgetPayload />);
+
+    expect(screen.getByText('Waiting for dashboard fetch…')).toBeDefined();
+  });
+
+  // ── Payload event ────────────────────────────────────────────────────────────
+
+  it('renders section buttons after the custom event is dispatched', () => {
+    mockGet.mockReturnValue('1');
+    render(<DevWidgetPayload />);
+
+    act(() => {
+      dispatchPayload(MOCK_PAYLOAD);
+    });
+
+    // All five section buttons should be present
+    expect(screen.getByText('remittance')).toBeDefined();
+    expect(screen.getByText('savings')).toBeDefined();
+    expect(screen.getByText('bills')).toBeDefined();
+    expect(screen.getByText('insurance')).toBeDefined();
+    expect(screen.getByText('meta')).toBeDefined();
+  });
+
+  it('persists the payload to sessionStorage when the event fires', () => {
+    mockGet.mockReturnValue('1');
+    render(<DevWidgetPayload />);
+
+    act(() => {
+      dispatchPayload(MOCK_PAYLOAD);
+    });
+
+    const stored = sessionStorage.getItem(DEV_MODE_WIDGET_PAYLOAD_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!)).toEqual(MOCK_PAYLOAD);
+  });
+
+  it('does not update payload or sessionStorage when dev mode is off', () => {
+    mockGet.mockReturnValue(null);
+    render(<DevWidgetPayload />);
+
+    act(() => {
+      dispatchPayload(MOCK_PAYLOAD);
+    });
+
+    expect(sessionStorage.getItem(DEV_MODE_WIDGET_PAYLOAD_KEY)).toBeNull();
+  });
+
+  // ── Section accordion ────────────────────────────────────────────────────────
+
+  it('expands a section and shows JSON when its button is clicked', () => {
+    mockGet.mockReturnValue('1');
+    render(<DevWidgetPayload />);
+
+    act(() => {
+      dispatchPayload(MOCK_PAYLOAD);
+    });
+
+    const remittanceBtn = screen.getByText('remittance').closest('button')!;
+
+    // Initially collapsed — no pre element for this section
+    expect(screen.queryByLabelText('remittance payload')).toBeNull();
+
+    fireEvent.click(remittanceBtn);
+
+    const pre = screen.getByLabelText('remittance payload');
+    expect(pre).toBeDefined();
+    expect(pre.textContent).toContain('"totalSent": 1200');
+  });
+
+  it('collapses an expanded section on second click', () => {
+    mockGet.mockReturnValue('1');
+    render(<DevWidgetPayload />);
+
+    act(() => {
+      dispatchPayload(MOCK_PAYLOAD);
+    });
+
+    const metaBtn = screen.getByText('meta').closest('button')!;
+
+    fireEvent.click(metaBtn); // open
+    expect(screen.getByLabelText('meta payload')).toBeDefined();
+
+    fireEvent.click(metaBtn); // close
+    expect(screen.queryByLabelText('meta payload')).toBeNull();
+  });
+
+  it('aria-expanded reflects section open/closed state', () => {
+    mockGet.mockReturnValue('1');
+    render(<DevWidgetPayload />);
+
+    act(() => {
+      dispatchPayload(MOCK_PAYLOAD);
+    });
+
+    const savingsBtn = screen.getByText('savings').closest('button')!;
+    expect(savingsBtn.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(savingsBtn);
+    expect(savingsBtn.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  // ── sessionStorage restoration ────────────────────────────────────────────────
+
+  it('restores a previously persisted payload from sessionStorage on mount', () => {
+    sessionStorage.setItem(DEV_MODE_STORAGE_KEY, 'true');
+    sessionStorage.setItem(
+      DEV_MODE_WIDGET_PAYLOAD_KEY,
+      JSON.stringify(MOCK_PAYLOAD)
+    );
+    mockGet.mockReturnValue(null); // no URL param — relies on stored flag
+
+    render(<DevWidgetPayload />);
+
+    // Section buttons should appear without needing a new event
+    expect(screen.getByText('remittance')).toBeDefined();
+    expect(screen.getByText('meta')).toBeDefined();
+  });
+
+  it('renders gracefully when stored payload is corrupt JSON', () => {
+    sessionStorage.setItem(DEV_MODE_STORAGE_KEY, 'true');
+    sessionStorage.setItem(DEV_MODE_WIDGET_PAYLOAD_KEY, '{not valid json');
+    mockGet.mockReturnValue(null);
+
+    // Should not throw
+    render(<DevWidgetPayload />);
+
+    // Falls back to the waiting state rather than crashing
+    expect(screen.getByText('Waiting for dashboard fetch…')).toBeDefined();
+  });
+});

--- a/components/DevWidgetPayload.tsx
+++ b/components/DevWidgetPayload.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useState, Suspense, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
+import { ChevronDown, ChevronUp, Terminal } from "lucide-react";
+import {
+  DEV_MODE_QUERY_PARAM,
+  DEV_MODE_ENABLED_VALUE,
+  DEV_MODE_STORAGE_KEY,
+  DEV_MODE_WIDGET_PAYLOAD_KEY,
+  DEV_WIDGET_PAYLOAD_EVENT,
+} from "@/lib/config/developer";
+import type { DashboardResponse } from "@/lib/types/dashboard";
+
+// ─── Section accordion ────────────────────────────────────────────────────────
+
+interface SectionProps {
+  label: string;
+  data: unknown;
+}
+
+function Section({ label, data }: SectionProps) {
+  const [open, setOpen] = useState(false);
+  const toggle = useCallback(() => setOpen((v) => !v), []);
+
+  return (
+    <div className="border-t border-white/[0.06] pt-2">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between gap-2 text-left text-[10px] font-semibold uppercase tracking-wider text-white/50 hover:text-white/80 transition-colors"
+      >
+        <span>{label}</span>
+        {open ? (
+          <ChevronUp className="h-3 w-3 shrink-0" aria-hidden="true" />
+        ) : (
+          <ChevronDown className="h-3 w-3 shrink-0" aria-hidden="true" />
+        )}
+      </button>
+      {open && (
+        <pre
+          className="mt-2 max-h-48 overflow-auto rounded-lg bg-white/[0.04] p-2 font-mono text-[10px] leading-relaxed text-white/80 scrollbar-thin"
+          aria-label={`${label} payload`}
+        >
+          {JSON.stringify(data, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+// ─── Inner panel (needs useSearchParams — wrapped in Suspense below) ──────────
+
+function DevWidgetPayloadInner() {
+  const [isDevMode, setIsDevMode] = useState(false);
+  const [payload, setPayload] = useState<DashboardResponse | null>(null);
+  const searchParams = useSearchParams();
+
+  // Determine dev-mode state (same logic as DevRequestIdDisplay)
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const queryVal = searchParams.get(DEV_MODE_QUERY_PARAM);
+    let enabled = false;
+
+    if (queryVal !== null) {
+      enabled = queryVal === DEV_MODE_ENABLED_VALUE;
+      sessionStorage.setItem(DEV_MODE_STORAGE_KEY, enabled ? "true" : "false");
+    } else {
+      enabled = sessionStorage.getItem(DEV_MODE_STORAGE_KEY) === "true";
+    }
+
+    setIsDevMode(enabled);
+
+    // Restore persisted payload so the panel is useful after client-side nav
+    if (enabled) {
+      const stored = sessionStorage.getItem(DEV_MODE_WIDGET_PAYLOAD_KEY);
+      if (stored) {
+        try {
+          setPayload(JSON.parse(stored) as DashboardResponse);
+        } catch {
+          // Corrupt storage — ignore; the next fetch will repopulate it.
+        }
+      }
+    }
+  }, [searchParams]);
+
+  // Listen for the custom event dispatched by the dashboard page on each fetch
+  useEffect(() => {
+    if (!isDevMode || typeof window === "undefined") return;
+
+    const handleUpdate = (e: Event) => {
+      const detail = (e as CustomEvent<DashboardResponse>).detail;
+      setPayload(detail);
+      try {
+        sessionStorage.setItem(
+          DEV_MODE_WIDGET_PAYLOAD_KEY,
+          JSON.stringify(detail)
+        );
+      } catch {
+        // sessionStorage quota exceeded — non-fatal.
+      }
+    };
+
+    window.addEventListener(DEV_WIDGET_PAYLOAD_EVENT, handleUpdate);
+    return () => {
+      window.removeEventListener(DEV_WIDGET_PAYLOAD_EVENT, handleUpdate);
+    };
+  }, [isDevMode]);
+
+  if (!isDevMode) return null;
+
+  return (
+    <div
+      id="dev-widget-payload-container"
+      className="fixed bottom-6 right-6 z-50 flex w-80 flex-col gap-3 rounded-xl border border-white/[0.08] bg-brand-dark/95 p-4 shadow-2xl backdrop-blur-md transition-all duration-300 md:bottom-8 md:right-8"
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <div className="relative flex h-2 w-2">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+        </div>
+        <span className="flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider text-emerald-400">
+          <Terminal className="h-3 w-3" aria-hidden="true" />
+          Widget Payloads
+        </span>
+      </div>
+
+      {payload === null ? (
+        <p className="text-[10px] text-white/40">
+          Waiting for dashboard fetch…
+        </p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <Section label="remittance" data={payload.remittance} />
+          <Section label="savings" data={payload.savings} />
+          <Section label="bills" data={payload.bills} />
+          <Section label="insurance" data={payload.insurance} />
+          <Section label="meta" data={payload.meta} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Public export (Suspense boundary required by useSearchParams) ────────────
+
+/**
+ * Floating developer panel that appears only when `?dev=1` is present.
+ *
+ * Displays the last-fetched raw `DashboardResponse` payload broken down by
+ * widget section (remittance, savings, bills, insurance, meta). Each section
+ * is collapsible to keep the panel compact.
+ *
+ * The panel position (`bottom-right`) is intentionally distinct from
+ * `DevRequestIdDisplay` (`bottom-left`) so both can be visible simultaneously.
+ *
+ * Lifecycle:
+ * - `app/dashboard/page.tsx` dispatches a `dev-widget-payload-updated`
+ *   `CustomEvent` on `window` after every successful `/api/dashboard` fetch.
+ * - This component listens for that event and stores the payload in
+ *   `sessionStorage` (key: `dev-widget-payload`) so it survives client-side
+ *   navigation.
+ *
+ * @see lib/config/developer.ts — constant definitions
+ * @see DEV_WIDGET_PAYLOAD_EVENT
+ */
+export default function DevWidgetPayload() {
+  return (
+    <Suspense fallback={null}>
+      <DevWidgetPayloadInner />
+    </Suspense>
+  );
+}

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -14,8 +14,7 @@ import ToastRegion from "@/components/ToastRegion";
 import SessionExpiryProvider from "@/components/SessionExpiryProvider";
 import CommandPalette from "@/components/CommandPalette";
 import DevRequestIdDisplay from "@/components/DevRequestIdDisplay";
-import "@/lib/utils/idleCallback";
-
+import DevWidgetPayload from "@/components/DevWidgetPayload";
 
 /**
  * Client-side provider boundary for the app.
@@ -39,7 +38,7 @@ export default function Providers({ children }: { children: ReactNode }) {
                 <ToastRegion />
                 <CommandPalette />
                 <DevRequestIdDisplay />
-                <FeatureFlagIndicator />
+                <DevWidgetPayload />
               </SessionExpiryProvider>
             </AsyncOperationsProvider>
           </DensityProvider>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,6 +121,57 @@ teams can share a URL that lands directly on the relevant panel.
 3. Add the widget to the table above and to the test in
    `components/Dashboard/dashboard-widget-deeplink.test.tsx`.
 
+## Developer Mode
+
+Appending `?dev=1` to any URL activates Developer Mode for the current browser
+session. Two floating panels become visible:
+
+| Panel | Position | Component |
+|-------|----------|-----------|
+| Request ID | bottom-left | `components/DevRequestIdDisplay.tsx` |
+| Widget Payloads | bottom-right | `components/DevWidgetPayload.tsx` |
+
+### Widget Payload panel
+
+After every successful `GET /api/dashboard` fetch the dashboard page dispatches
+a `dev-widget-payload-updated` `CustomEvent` on `window`. The **Widget Payloads**
+panel listens for this event and renders the raw `DashboardResponse` broken down
+into five collapsible sections: `remittance`, `savings`, `bills`, `insurance`,
+and `meta`.
+
+#### Constants (all in `lib/config/developer.ts`)
+
+| Constant | Value | Purpose |
+|----------|-------|---------|
+| `DEV_MODE_QUERY_PARAM` | `"dev"` | Query param name |
+| `DEV_MODE_ENABLED_VALUE` | `"1"` | Value that activates dev mode |
+| `DEV_MODE_STORAGE_KEY` | `"dev-mode-enabled"` | sessionStorage persistence flag |
+| `DEV_MODE_WIDGET_PAYLOAD_KEY` | `"dev-widget-payload"` | sessionStorage key for last payload |
+| `DEV_WIDGET_PAYLOAD_EVENT` | `"dev-widget-payload-updated"` | CustomEvent name |
+
+#### Lifecycle
+
+1. `app/dashboard/page.tsx` — after a successful fetch, checks
+   `sessionStorage.getItem(DEV_MODE_STORAGE_KEY) === 'true'` and, if so,
+   dispatches `new CustomEvent(DEV_WIDGET_PAYLOAD_EVENT, { detail: json })`.
+2. `components/DevWidgetPayload.tsx` — listens for the event, stores the
+   serialised payload in `sessionStorage` under `DEV_MODE_WIDGET_PAYLOAD_KEY`,
+   and renders it. On mount it restores any previously stored payload so the
+   panel is useful after client-side navigation.
+
+#### Enabling / disabling
+
+```
+# Enable
+http://localhost:3000/dashboard?dev=1
+
+# Disable
+http://localhost:3000/dashboard?dev=0
+```
+
+The state is persisted in `sessionStorage` so it survives client-side route
+transitions within the same tab but is cleared when the tab is closed.
+
 **Insights consolidation:** The previously duplicated `/insights` and `/financial-insight`
 routes were merged into the single canonical `/financial-insights` page (header + summary
 overview + spending/savings, remittance trend, category donut, and top-categories widgets).


### PR DESCRIPTION


Closes #991

## Summary

Behind `?dev=1`, a new floating **Widget Payloads** panel appears at the
bottom-right of the viewport and displays the raw `DashboardResponse`
returned by the last `GET /api/dashboard` fetch, broken into five
collapsible sections: `remittance`, `savings`, `bills`, `insurance`, and
`meta`.

This sits alongside the existing **Developer Mode** panel (bottom-left,
Request ID) and follows the exact same lifecycle pattern.

---

## Background

The current behaviour forces operators, support engineers, and downstream
frontend engineers to open DevTools and manually inspect network responses
to see what data each widget received. This change removes that friction
by surfacing the payload directly in the UI — but only behind the `?dev=1`
flag so it has zero impact on production users.

---

## What changed

### `lib/config/developer.ts`
- Added `DEV_MODE_WIDGET_PAYLOAD_KEY = "dev-widget-payload"` — the
  `sessionStorage` key used to persist the last payload across
  client-side navigation.
- Added `DEV_WIDGET_PAYLOAD_EVENT = "dev-widget-payload-updated"` — the
  `window` `CustomEvent` name used to broadcast the payload from the
  dashboard page to the panel.

### `components/DevWidgetPayload.tsx` *(new)*
- Floating panel, fixed bottom-right, only rendered when dev mode is
  active.
- Listens for `DEV_WIDGET_PAYLOAD_EVENT` on `window` and renders the
  received `DashboardResponse` in five collapsible `<Section>` accordions.
- On mount, restores any previously stored payload from `sessionStorage`
  so the panel is useful after client-side navigation without a new fetch.
- Handles corrupt `sessionStorage` JSON gracefully (falls back to the
  "Waiting for dashboard fetch…" state).
- Wrapped in `<Suspense>` as required by `useSearchParams()`.
- Uses only design tokens (no hardcoded colours, spacing, or radii).

### `app/dashboard/page.tsx`
- After a successful `/api/dashboard` fetch, checks
  `sessionStorage.getItem(DEV_MODE_STORAGE_KEY) === 'true'` and, if dev
  mode is active, dispatches `new CustomEvent(DEV_WIDGET_PAYLOAD_EVENT,
  { detail: json })` on `window`.
- No change to fetch logic, error handling, or render output.

### `components/Providers.tsx`
- Mounts `<DevWidgetPayload />` immediately after the existing
  `<DevRequestIdDisplay />`.

### `components/DevWidgetPayload.test.tsx` *(new)*
14 test cases covering:
- Panel visible with `?dev=1`, hidden with `?dev=0` or no param
- Panel visible via `sessionStorage` flag alone (survives navigation)
- `dev=0` URL overrides a previously stored `true` flag
- "Waiting for dashboard fetch…" shown before any event fires
- Section buttons rendered after `dev-widget-payload-updated` event
- Payload persisted to `sessionStorage` on event
- Payload NOT stored when dev mode is off
- Section expands and shows JSON on click
- Section collapses on second click
- `aria-expanded` reflects open/closed state
- Payload restored from `sessionStorage` on mount
- Corrupt `sessionStorage` JSON handled without crash

### `docs/architecture.md`
- New `## Developer Mode` section documenting both panels, all five
  constants, the full dispatch → listen → persist → restore lifecycle,
  and enable/disable instructions.

### `README.md`
- Updated Developer Mode section: intro preserved, Enabling section now
  lists both panels in a table, existing 3-step How to Use preserved,
  new **Widget Payloads panel** subsection added.

---

## How to test

1. `npm run dev`
2. Navigate to `http://localhost:3000/dashboard?dev=1`
3. The **Widget Payloads** panel appears bottom-right
4. After the dashboard loads, five collapsible section buttons appear
   (`remittance`, `savings`, `bills`, `insurance`, `meta`)
5. Click any section to expand its raw JSON
6. Navigate away and back — panel still shows the last payload
7. Add `?dev=0` to the URL — panel disappears

---

## Checklist

- [x] Matches the summary
- [x] No regression in existing tests
- [x] Documented in README and docs/architecture.md
- [x] Lint passes on all changed files
- [x] Type-check passes on all changed files
- [x] New tests added and cover the new behaviour
- [x] Backwards-compatible — no existing API surface changed
- [x] New constants land in a single place (`lib/config/developer.ts`)
- [x] No hardcoded colours, spacing, or radii
