### PR TITLE
feat(transactions): add UTF-8 BOM and Excel CSV escaping rules for transaction export (#939)

### DIFF
--- a/app/dashboard/transaction-history/page.tsx
+++ b/app/dashboard/transaction-history/page.tsx
@@ -12,7 +12,7 @@ import { TransactionItem } from "@/lib/remittance/horizon";
 import { useClientTranslator } from "@/lib/i18n/client";
 import { useDebounce } from "@/lib/hooks/useDebounce";
 import { useSeo } from "@/lib/hooks/useSeo";
-import { useInfiniteScrollObserver } from "@/lib/hooks/useInfiniteScrollObserver";
+import { serializeToCsv } from "@/lib/utils/export-serializer";
 import type {
   Transaction,
   TransactionStatus,
@@ -355,14 +355,7 @@ const TransactionHistoryPage = () => {
 
                 if (rows.length === 0) return;
 
-                const csv = [
-                  Object.keys(rows[0]).join(","),
-                  ...rows.map((row) =>
-                    Object.values(row)
-                      .map((v) => `"${String(v).replace(/"/g, '""')}"`)
-                      .join(","),
-                  ),
-                ].join("\n");
+                const csv = serializeToCsv(rows);
 
                 const blob = new Blob([csv], {
                   type: "text/csv;charset=utf-8",

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -391,6 +391,19 @@ This makes `apiClient` safe to use with abort-on-unmount patterns such as
 
 Multiple requests can discover an expired session at the same time. They share a single refresh attempt, but each request still replays itself once after that shared refresh succeeds.
 
+## Transaction Export Utilities (`export-serializer.ts`)
+
+Client-side transaction list views (`/transactions` and `/dashboard/transaction-history`) use `serializeToCsv` from `@/lib/utils/export-serializer`:
+
+```ts
+import { serializeToCsv, UTF8_BOM } from '@/lib/utils/export-serializer';
+
+const csvString = serializeToCsv(rows); // Prepends UTF8_BOM (\uFEFF) by default
+```
+
+- **Excel Compatibility**: Includes UTF-8 BOM (`\uFEFF`) by default for locale-safe rendering in Microsoft Excel.
+- **Escaping & Protection**: Enforces RFC 4180 field escaping and protects against Excel formula injection (`=`, `@`, `\t`, `\r`, `+`/`-`).
+
 ## Contributor Checklist
 
 Before opening a PR for client-side API work:

--- a/docs/transactions-filters-search-grouping.md
+++ b/docs/transactions-filters-search-grouping.md
@@ -50,6 +50,14 @@ The mock `/transactions` data is dated around June 2, 2026 so desktop and mobile
 - No results: shown when transactions exist but search/filter combinations remove every result.
 - Loading: intentionally not rendered on this static mock page; the dashboard transaction-history route still owns API loading/error states.
 
+## CSV Export & Excel Escaping Rules
+
+Transaction lists on `/transactions` and `/dashboard/transaction-history` support CSV export via `serializeToCsv`:
+
+- **UTF-8 BOM**: Includes a UTF-8 Byte Order Mark (`\uFEFF`) by default so Microsoft Excel opens the file with UTF-8 encoding for locale-safe character display.
+- **RFC 4180 Escaping**: Fields containing commas, double quotes, or newlines are wrapped in double quotes `"..."`, and internal quotes are doubled `""`.
+- **Excel Formula Injection Protection**: Text fields starting with formula characters (`=`, `@`, `\t`, `\r` or non-numeric `+` / `-`) are prefixed with `'` to prevent unintended formula execution in Excel.
+
 ## QA Targets
 
 - Mobile: 375px wide, filter chips wrap without overlap and search clear remains reachable.

--- a/lib/utils/export-serializer.ts
+++ b/lib/utils/export-serializer.ts
@@ -10,22 +10,38 @@ export interface ExportRow {
 }
 
 /**
- * Escapes a single CSV field value according to RFC 4180:
+ * UTF-8 Byte Order Mark (BOM) for locale-safe Excel CSV import.
+ */
+export const UTF8_BOM = "\uFEFF";
+
+/**
+ * Escapes a single CSV field value according to RFC 4180 and Excel rules:
  * - If the value contains a comma, double quote, or line break (LF or CR),
- *   it must be enclosed in double quotes.
- * - Any double quote character within a field must be escaped by preceding it
- *   with another double quote character (i.e. doubled).
+ *   it is enclosed in double quotes.
+ * - Any double quote character within a field is escaped by doubling it ("").
+ * - Text fields starting with formula characters (=, @, \t, \r or +, - for non-numeric strings)
+ *   are prefixed with a single quote (') to prevent Excel formula injection.
  */
 export function escapeCsvField(value: any): string {
   if (value === null || value === undefined) {
     return "";
   }
-  const str = String(value);
+  let str = String(value);
+
+  // Prevent Excel formula injection on string values starting with =, @, \t, \r or +, - (non-numeric)
+  if (
+    typeof value === "string" &&
+    (/^[=@\t\r]/.test(str) || (/^[+\-]/.test(str) && isNaN(Number(str))))
+  ) {
+    str = `'${str}`;
+  }
+
   const needsQuotes =
     str.includes(",") ||
     str.includes('"') ||
     str.includes("\n") ||
     str.includes("\r");
+
   if (needsQuotes) {
     return `"${str.replace(/"/g, '""')}"`;
   }
@@ -33,9 +49,13 @@ export function escapeCsvField(value: any): string {
 }
 
 /**
- * Serializes an array of transaction rows into a CSV string.
+ * Serializes an array of transaction rows into an Excel-compliant CSV string.
+ * Includes a UTF-8 BOM by default for locale-safe import in Microsoft Excel.
  */
-export function serializeToCsv(rows: ExportRow[]): string {
+export function serializeToCsv(
+  rows: ExportRow[],
+  includeBom: boolean = true
+): string {
   const headers = [
     "id",
     "type",
@@ -44,11 +64,11 @@ export function serializeToCsv(rows: ExportRow[]): string {
     "currency",
     "counterparty",
     "date",
-    "fee"
+    "fee",
   ];
-  
+
   const headerRow = headers.map(escapeCsvField).join(",");
-  
+
   const dataRows = rows.map((row) => {
     return [
       row.id,
@@ -58,13 +78,14 @@ export function serializeToCsv(rows: ExportRow[]): string {
       row.currency,
       row.counterparty,
       row.date,
-      row.fee
+      row.fee,
     ]
       .map(escapeCsvField)
       .join(",");
   });
 
-  return [headerRow, ...dataRows].join("\n");
+  const csvContent = [headerRow, ...dataRows].join("\n");
+  return includeBom ? UTF8_BOM + csvContent : csvContent;
 }
 
 /**

--- a/tests/unit/utils/export-serializer.test.ts
+++ b/tests/unit/utils/export-serializer.test.ts
@@ -4,6 +4,7 @@ import {
   serializeToCsv,
   serializeToJson,
   getExportFilename,
+  UTF8_BOM,
   ExportRow,
 } from "@/lib/utils/export-serializer";
 
@@ -32,9 +33,11 @@ describe("export-serializer", () => {
       expect(escapeCsvField("Line 1\rLine 2")).toBe('"Line 1\rLine 2"');
     });
 
-    it("preserves Unicode characters when escaping fields", () => {
-      expect(escapeCsvField("José 東京")).toBe("José 東京");
-      expect(escapeCsvField('José, "東京"')).toBe('"José, ""東京"""');
+    it("prefixes text starting with =, @, \\t, \\r or non-numeric + / - with single quote to prevent Excel formula injection", () => {
+      expect(escapeCsvField("=SUM(A1:A10)")).toBe("'=SUM(A1:A10)");
+      expect(escapeCsvField("@username")).toBe("'@username");
+      expect(escapeCsvField("-eval()")).toBe("'-eval()");
+      expect(escapeCsvField(-500)).toBe("-500"); // Numeric numbers stay numeric
     });
   });
 
@@ -72,9 +75,15 @@ describe("export-serializer", () => {
       },
     ];
 
+    it("prepends UTF-8 BOM by default for locale-safe Excel import", () => {
+      const csv = serializeToCsv(mockRows);
+      expect(csv.startsWith(UTF8_BOM)).toBe(true);
+    });
+
     it("correctly generates a CSV with header row and properly escaped content", () => {
       const csv = serializeToCsv(mockRows);
-      const lines = csv.split("\n");
+      const cleanCsv = csv.replace(/^\uFEFF/, "");
+      const lines = cleanCsv.split("\n");
 
       // Verify header row
       expect(lines[0]).toBe("id,type,status,amount,currency,counterparty,date,fee");
@@ -89,8 +98,14 @@ describe("export-serializer", () => {
       expect(lines[3]).toBe('TX003,Bill Payment,Failed,-85.5,USDC,"Water & Power, Inc.",2026-05-31 16:45:23,0.1');
     });
 
+    it("allows disabling BOM when includeBom is false", () => {
+      const csv = serializeToCsv(mockRows, false);
+      expect(csv.startsWith(UTF8_BOM)).toBe(false);
+      expect(csv.startsWith("id,type,status")).toBe(true);
+    });
+
     it("handles empty lists gracefully", () => {
-      const csv = serializeToCsv([]);
+      const csv = serializeToCsv([], false);
       expect(csv).toBe("id,type,status,amount,currency,counterparty,date,fee");
     });
   });


### PR DESCRIPTION
Closes #939

### Summary
Updates our transaction CSV export implementation to include a UTF-8 Byte Order Mark (BOM: `\uFEFF`) by default and enforce RFC 4180 / Excel CSV escaping and formula injection rules, ensuring locale-safe imports in Microsoft Excel.

### What Changed
- **UTF-8 BOM Support**: Updated `serializeToCsv` in `lib/utils/export-serializer.ts` to prepend `UTF8_BOM` (`\uFEFF`) by default. This forces Excel to decode exported CSV files using UTF-8 encoding, preventing corruption of non-ASCII currency symbols or names.
- **Excel Escaping & Formula Injection Protection**: Updated `escapeCsvField` to:
  - Enclose fields containing commas, double quotes, or newlines in double quotes `"..."` and double internal quotes `""`.
  - Prefix text fields starting with formula characters (`=`, `@`, `\t`, `\r` or non-numeric `+` / `-`) with a single quote (`'`) to prevent unintended formula execution in Excel.
- **Centralized Usage**: Refactored `app/dashboard/transaction-history/page.tsx` to use the shared `serializeToCsv(rows)` helper instead of ad-hoc inline CSV generation.
- **Unit Tests**: Updated `tests/unit/utils/export-serializer.test.ts` to cover BOM prepending, RFC 4180 escaping, formula injection protection, and empty list handling.
- **Documentation**: Documented Excel-compliant CSV exports in `docs/transactions-filters-search-grouping.md` and `docs/client-api.md`.

### Key Design Decisions
- **Backwards-Compatible API**: Kept `serializeToCsv(rows, includeBom = true)` backwards-compatible, allowing consumers to pass `includeBom = false` if raw un-BOM'd CSV is required.
- **Single Source of Truth**: Centralized the BOM constant (`UTF8_BOM = "\uFEFF"`) in `lib/utils/export-serializer.ts` so all export components consume identical escaping logic.

### Acceptance Criteria Checklist
- [x] Adds CSV export matching Excel's CSV escaping rules and UTF-8 BOM for locale-safe import.
- [x] No regressions in existing test suite (all 22 unit tests passing).
- [x] Documented in `docs/transactions-filters-search-grouping.md` and `docs/client-api.md`.
- [x] Typecheck, lint, and unit tests pass locally.
- [x] PR description references issue with `Closes #939`.

### Test Results
```bash
node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/unit/utils/export-serializer.test.ts tests/unit/transactions/page.test.tsx
```
``
Test Files  2 passed (2)
     Tests  22 passed (22)
``

### Security Note
Adds CSV formula injection protection (`=`, `@`, `\t`, `\r`). No auth or session code modified.