### PR TITLE
feat: add safe-reload prompt when saving fails

### DIFF
--- a/components/settings/NotificationsSection.tsx
+++ b/components/settings/NotificationsSection.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from "react";
 import { Bell } from "lucide-react";
 import { useClientTranslator } from "@/lib/i18n/client";
 import { useAutosave } from "@/lib/hooks/useAutosave";
+import { useSafeReload } from "@/lib/hooks/useSafeReload";
 import {
   SectionCard,
   SectionHeader,
@@ -54,7 +55,8 @@ export function NotificationsSection() {
     await new Promise((resolve) => setTimeout(resolve, 300));
   }, []);
 
-  const { saveState, triggerSave } = useAutosave(onSave);
+  const { saveState, isDirty, triggerSave } = useAutosave(onSave);
+  useSafeReload(isDirty);
 
   const handleToggle = (key: keyof NotificationsState) => {
     toggle(key);

--- a/components/settings/PreferencesSection.tsx
+++ b/components/settings/PreferencesSection.tsx
@@ -6,6 +6,7 @@ import { useDensity } from "@/lib/context/DensityContext";
 import { useTheme } from "@/lib/context/ThemeContext";
 import { useClientTranslator } from "@/lib/i18n/client";
 import { useAutosave } from "@/lib/hooks/useAutosave";
+import { useSafeReload } from "@/lib/hooks/useSafeReload";
 import {
   SectionCard,
   SectionHeader,
@@ -39,7 +40,8 @@ export function PreferencesSection() {
     await new Promise((resolve) => setTimeout(resolve, 300));
   }, []);
 
-  const { saveState, triggerSave } = useAutosave(onSave);
+  const { saveState, isDirty, triggerSave } = useAutosave(onSave);
+  useSafeReload(isDirty);
 
   const handleThemeChange = (id: "system" | "light" | "dark") => {
     setTheme(id);

--- a/components/settings/ProfileSection.tsx
+++ b/components/settings/ProfileSection.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from "react";
 import { User } from "lucide-react";
 import { useClientTranslator } from "@/lib/i18n/client";
 import { useAutosave } from "@/lib/hooks/useAutosave";
+import { useSafeReload } from "@/lib/hooks/useSafeReload";
 import {
   SectionCard,
   SectionHeader,
@@ -22,7 +23,8 @@ export function ProfileSection() {
     await new Promise((resolve) => setTimeout(resolve, 300));
   }, []);
 
-  const { saveState, triggerSave } = useAutosave(onSave);
+  const { saveState, isDirty, triggerSave } = useAutosave(onSave);
+  useSafeReload(isDirty);
 
   const handleNameChange = (value: string) => {
     setName(value);

--- a/components/settings/WalletSection.tsx
+++ b/components/settings/WalletSection.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, type ChangeEvent } from "react";
 import { Wallet } from "lucide-react";
 import { useClientTranslator } from "@/lib/i18n/client";
 import { useAutosave } from "@/lib/hooks/useAutosave";
+import { useSafeReload } from "@/lib/hooks/useSafeReload";
 import {
   SectionCard,
   SectionHeader,
@@ -29,7 +30,8 @@ export function WalletSection() {
     await new Promise((resolve) => setTimeout(resolve, 300));
   }, []);
 
-  const { saveState, triggerSave } = useAutosave(onSave);
+  const { saveState, isDirty, triggerSave } = useAutosave(onSave);
+  useSafeReload(isDirty);
 
   const handleRpcChange = (value: string) => {
     setRpcUrl(value);

--- a/lib/hooks/useSafeReload.test.ts
+++ b/lib/hooks/useSafeReload.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useSafeReload } from './useSafeReload'
+
+describe('useSafeReload', () => {
+  const originalAddEventListener = window.addEventListener
+  const originalRemoveEventListener = window.removeEventListener
+
+  let addEventListenerSpy: ReturnType<typeof vi.spyOn>
+  let removeEventListenerSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    addEventListenerSpy = vi.spyOn(window, 'addEventListener')
+    removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('registers beforeunload when isDirty is true', () => {
+    renderHook(() => useSafeReload(true))
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'beforeunload',
+      expect.any(Function),
+    )
+  })
+
+  it('does not register beforeunload when isDirty is false', () => {
+    renderHook(() => useSafeReload(false))
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith(
+      'beforeunload',
+      expect.any(Function),
+    )
+  })
+
+  it('removes the listener on unmount when isDirty was true', () => {
+    const { unmount } = renderHook(() => useSafeReload(true))
+    unmount()
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'beforeunload',
+      expect.any(Function),
+    )
+  })
+
+  it('re-registers when isDirty changes from false to true', () => {
+    const { rerender } = renderHook(({ dirty }) => useSafeReload(dirty), {
+      initialProps: { dirty: false },
+    })
+
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith(
+      'beforeunload',
+      expect.any(Function),
+    )
+
+    rerender({ dirty: true })
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'beforeunload',
+      expect.any(Function),
+    )
+  })
+
+  it('removes old listener and registers new one when isDirty changes from true to false then back', () => {
+    const { rerender } = renderHook(({ dirty }) => useSafeReload(dirty), {
+      initialProps: { dirty: true },
+    })
+
+    const handler1 = addEventListenerSpy.mock.calls.find(
+      ([event]) => event === 'beforeunload',
+    )?.[1]
+
+    rerender({ dirty: false })
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('beforeunload', handler1)
+
+    rerender({ dirty: true })
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('registered handler calls preventDefault and sets returnValue', () => {
+    const mockEvent = {
+      preventDefault: vi.fn(),
+      returnValue: 'non-empty',
+    } as unknown as BeforeUnloadEvent
+
+    renderHook(() => useSafeReload(true))
+
+    const handler = addEventListenerSpy.mock.calls.find(
+      ([event]) => event === 'beforeunload',
+    )?.[1] as (e: BeforeUnloadEvent) => void
+
+    handler(mockEvent)
+    expect(mockEvent.preventDefault).toHaveBeenCalled()
+    expect(mockEvent.returnValue).toBe('')
+  })
+})

--- a/lib/hooks/useSafeReload.ts
+++ b/lib/hooks/useSafeReload.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Registers a `beforeunload` event listener when `isDirty` is `true`,
+ * causing the browser to display a standard "unsaved changes" prompt when
+ * the user tries to reload, close the tab, or navigate away.
+ *
+ * The prompt text is controlled by the browser and cannot be customised.
+ *
+ * @param isDirty - Whether there are unsaved changes.
+ *
+ * @example
+ * ```tsx
+ * const { isDirty } = useAutosave(onSave);
+ * useSafeReload(isDirty);
+ * ```
+ */
+export function useSafeReload(isDirty: boolean): void {
+  useEffect(() => {
+    if (!isDirty) return;
+
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [isDirty]);
+}


### PR DESCRIPTION
## Summary

Register a `beforeunload` handler when settings have unsaved changes, so the browser warns the user with a standard "Your changes are unsaved. Reload anyway?" prompt before they accidentally reload or close the tab.

## What changed

- **`lib/hooks/useSafeReload.ts`** (new) — A hook that takes an `isDirty` boolean and registers/unregisters a `beforeunload` event listener. When `isDirty` is `true`, the handler calls `event.preventDefault()` and sets `event.returnValue = ""`, triggering the browser's built-in unsaved-changes dialog.
- **`lib/hooks/useSafeReload.test.ts`** (new) — 6 tests covering: registration when dirty, no registration when clean, cleanup on unmount, re-registration on dirty→true transition, handler behaviour (preventDefault + returnValue).
- **`components/settings/ProfileSection.tsx`** — Import `useSafeReload`, destructure `isDirty` from `useAutosave`, call `useSafeReload(isDirty)`.
- **`components/settings/NotificationsSection.tsx`** — Same pattern.
- **`components/settings/PreferencesSection.tsx`** — Same pattern.
- **`components/settings/WalletSection.tsx`** — Same pattern.

## Key design decisions

1. **Hook, not a component** — The `beforeunload` API is imperative (addEventListener), so a hook is the natural React binding. No wrapper component needed.
2. **Reuses existing `isDirty` from `useAutosave`** — The `useAutosave` hook already tracks dirty state. This hook simply consumes it, adding zero new state management.
3. **Browser-standard message** — The `beforeunload` event is the standard browser API for this. Modern browsers ignore custom `returnValue` strings and show their own generic message, which is fine — the prompt still prevents accidental navigation.
4. **Scope: settings sections only** — The four sections using `useAutosave` are the only forms with auto-save behaviour. Other forms (send, split, insurance) use `useFormAction` which doesn't track dirty state.

## Acceptance criteria checklist

- [x] Change matches the summary — browser-standard `beforeunload` alert when unsaved changes exist
- [x] No regression — 6 new tests pass, existing suite unaffected
- [x] Lint, type-check, and tests all pass locally
- [x] PR references this issue — Closes #948

## Test output

```
✓ lib/hooks/useSafeReload.test.ts (6 tests)
```

## How to verify locally

1. Navigate to `/settings`
2. Make a change in any section (e.g. edit profile name)
3. Try to reload the page — the browser should show a confirmation dialog
4. After the auto-save completes (watch for the green "Saved" indicator), the prompt should no longer appear

## Follow-ups

- None. The hook is generic and can be dropped into any component that has an `isDirty` flag.

## Security

No authentication, secrets, or sensitive data are involved. The hook only registers a browser-standard event listener.

Closes #948
