### PR TITLE
feat(issue #969): add pretty-URLs for shareable transaction receipts

### DIFF
--- a/app/receipt/[txHash]/page.tsx
+++ b/app/receipt/[txHash]/page.tsx
@@ -1,0 +1,91 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import {
+  fetchTransactionReceipt,
+  isValidTxHash,
+} from "@/lib/remittance/horizon";
+import { RECEIPT_SEO, SITE_URL } from "@/lib/config/seo";
+import ReceiptPageContent from "@/components/ReceiptPageContent";
+import type { ReceiptData } from "@/lib/remittance/horizon";
+
+type Props = {
+  params: Promise<{ txHash: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { txHash } = await params;
+  const isValid = isValidTxHash(txHash);
+  const title = isValid
+    ? `Receipt ${txHash.substring(0, 8)}… | RemitWise`
+    : RECEIPT_SEO.titlePrefix;
+  const description = isValid
+    ? `View receipt for transaction ${txHash.substring(0, 8)}… on RemitWise.`
+    : RECEIPT_SEO.description;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: "website",
+      url: `${SITE_URL}/receipt/${txHash}`,
+      siteName: "RemitWise",
+      images: [
+        {
+          url: `${SITE_URL}${RECEIPT_SEO.ogImagePath}`,
+          width: 1200,
+          height: 630,
+          alt: "Transaction Receipt",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: RECEIPT_SEO.twitterHandle,
+      title,
+      description,
+      images: [`${SITE_URL}${RECEIPT_SEO.ogImagePath}`],
+    },
+  };
+}
+
+export default async function ReceiptPage({ params }: Props) {
+  const { txHash } = await params;
+  let receiptData: ReceiptData | null = null;
+  let notFound = false;
+
+  if (isValidTxHash(txHash)) {
+    try {
+      receiptData = await fetchTransactionReceipt(txHash);
+      if (!receiptData) {
+        notFound = true;
+      }
+    } catch {
+      notFound = true;
+    }
+  } else {
+    notFound = true;
+  }
+
+  return (
+    <main className="min-h-screen bg-[#010101]">
+      <div className="mx-auto max-w-2xl px-4 py-8 sm:px-6 lg:px-8">
+        <nav className="mb-6">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-white transition-colors"
+          >
+            ← Back to Home
+          </Link>
+        </nav>
+
+        <ReceiptPageContent
+          txHash={txHash}
+          receiptData={receiptData}
+          notFound={notFound}
+        />
+      </div>
+    </main>
+  );
+}

--- a/components/ReceiptPageContent.tsx
+++ b/components/ReceiptPageContent.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import {
+  CheckCircle2,
+  ExternalLink,
+  AlertCircle,
+  Clock,
+  Copy,
+  Share2,
+  ArrowLeft,
+} from "lucide-react";
+import { useState } from "react";
+import Link from "next/link";
+import { useSeo } from "@/lib/hooks/useSeo";
+import { isValidTxHash } from "@/lib/remittance/horizon";
+import type { ReceiptData } from "@/lib/remittance/horizon";
+
+interface ReceiptPageContentProps {
+  txHash: string;
+  receiptData: ReceiptData | null;
+  notFound: boolean;
+}
+
+function truncate(str: string, start = 6, end = 6) {
+  if (str.length <= start + end + 3) return str;
+  return `${str.substring(0, start)}...${str.substring(str.length - end)}`;
+}
+
+function formatDate(iso: string) {
+  const d = new Date(iso);
+  return d.toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}
+
+export default function ReceiptPageContent({
+  txHash,
+  receiptData,
+  notFound,
+}: ReceiptPageContentProps) {
+  useSeo({
+    title: receiptData
+      ? `Receipt ${truncate(txHash)} | RemitWise`
+      : "Receipt | RemitWise",
+    description: receiptData
+      ? `View receipt for transaction ${truncate(txHash)} on RemitWise.`
+      : "View transaction details and confirmation on RemitWise.",
+  });
+
+  const [copied, setCopied] = useState(false);
+
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const truncatedHash = truncate(txHash);
+  const isKnownHash = isValidTxHash(txHash);
+
+  if (notFound || !isKnownHash) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-2xl border border-white/10 bg-[linear-gradient(180deg,rgba(18,18,18,0.98),rgba(10,10,10,0.98))] p-12 text-center">
+        <AlertCircle className="h-16 w-16 text-amber-500 mb-4" />
+        <h1 className="text-2xl font-bold text-white mb-2">
+          {!isKnownHash
+            ? "Invalid Transaction Hash"
+            : "Transaction Not Found"}
+        </h1>
+        <p className="text-gray-400 mb-6 max-w-md">
+          {!isKnownHash
+            ? `"${truncatedHash}" is not a valid Stellar transaction hash.`
+            : "This transaction could not be found on the Stellar network. It may still be pending or the hash may be incorrect."}
+        </p>
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center gap-2 rounded-xl bg-red-600 px-5 py-3 text-sm font-semibold text-white hover:bg-red-500 transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Return to Dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  const statusLabel =
+    receiptData.status === "completed" ? "Completed" : "Failed";
+  const StatusIcon =
+    receiptData.status === "completed" ? CheckCircle2 : AlertCircle;
+  const statusColor =
+    receiptData.status === "completed"
+      ? "text-emerald-500 bg-emerald-500/10 border-emerald-500/20"
+      : "text-rose-500 bg-rose-500/10 border-rose-500/20";
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-[linear-gradient(180deg,rgba(18,18,18,0.98),rgba(10,10,10,0.98))] overflow-hidden shadow-2xl">
+      <div className="absolute top-0 right-0 w-[300px] h-[300px] bg-red-600/10 blur-[100px] rounded-full -mr-32 -mt-32 pointer-events-none" />
+
+      <div className="relative z-0 p-6 sm:p-8">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <div
+            className={`mx-auto flex items-center justify-center w-20 h-20 rounded-full mb-4 border ${statusColor}`}
+          >
+            <StatusIcon className="w-10 h-10" />
+          </div>
+          <h1 className="text-2xl font-bold text-white mb-1">
+            Transfer {statusLabel === "Completed" ? "Successful" : "Failed"}
+          </h1>
+          <p className="text-gray-500 text-sm">
+            {statusLabel === "Completed"
+              ? "Your money is on its way!"
+              : "The transaction did not complete successfully."}
+          </p>
+        </div>
+
+        {/* Status Badge */}
+        <div className="flex justify-center mb-8">
+          <span
+            className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium ${statusColor}`}
+          >
+            <StatusIcon className="h-4 w-4" />
+            {statusLabel}
+          </span>
+        </div>
+
+        {/* Amount Hero */}
+        <div className="bg-white/5 border border-white/5 rounded-2xl p-6 text-center mb-8">
+          <div className="text-sm text-gray-400 mb-1">Amount</div>
+          <div className="flex items-baseline justify-center gap-2">
+            <span className="text-4xl font-bold text-white">
+              {receiptData.amount}
+            </span>
+            <span className="text-lg font-medium text-gray-500">
+              {receiptData.currency}
+            </span>
+          </div>
+        </div>
+
+        {/* Transaction Details */}
+        <div className="space-y-4 mb-8">
+          <DetailRow
+            label="Transaction Hash"
+            value={txHash}
+            truncated={truncatedHash}
+            onCopy={() => copyToClipboard(txHash)}
+            copied={copied}
+            mono
+          />
+          <DetailRow
+            label="Recipient"
+            value={receiptData.recipient}
+            truncated={truncate(receiptData.recipient)}
+            mono
+          />
+          <DetailRow
+            label="Sender"
+            value={receiptData.sender}
+            truncated={truncate(receiptData.sender)}
+            mono
+          />
+          <DetailRow label="Date & Time" value={formatDate(receiptData.date)} />
+          <DetailRow label="Network Fee" value={`${receiptData.fee} XLM`} />
+          {receiptData.memo && (
+            <DetailRow label="Memo" value={receiptData.memo} />
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="grid grid-cols-2 gap-3 mb-6">
+          <button
+            onClick={() => {
+              const url = window.location.href;
+              if (navigator.share) {
+                navigator.share({
+                  title: "Transaction Receipt",
+                  text: `View receipt for ${truncatedHash}`,
+                  url,
+                });
+              } else {
+                copyToClipboard(url);
+              }
+            }}
+            className="flex items-center justify-center gap-2 rounded-xl bg-white/5 border border-white/10 px-4 py-3 text-sm font-semibold text-white hover:bg-white/10 transition-colors"
+          >
+            <Share2 className="h-4 w-4" />
+            Share
+          </button>
+          <a
+            href={`https://stellar.expert/explorer/public/tx/${txHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-center gap-2 rounded-xl bg-white/5 border border-white/10 px-4 py-3 text-sm font-semibold text-white hover:bg-white/10 transition-colors"
+          >
+            <ExternalLink className="h-4 w-4" />
+            Explorer
+          </a>
+        </div>
+
+        <a
+          href={`https://stellar.expert/explorer/public/tx/${txHash}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="w-full flex items-center justify-center gap-2 bg-red-600 hover:bg-red-500 text-white font-semibold py-4 rounded-xl transition-all shadow-lg shadow-red-600/20 mb-6"
+        >
+          View on Stellar Explorer
+          <ExternalLink className="h-4 w-4" />
+        </a>
+
+        <div className="text-center">
+          <Link
+            href="/dashboard"
+            className="text-gray-500 hover:text-white text-sm font-medium inline-flex items-center gap-1 transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Return to Dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  truncated,
+  onCopy,
+  copied,
+  mono,
+}: {
+  label: string;
+  value: string;
+  truncated?: string;
+  onCopy?: () => void;
+  copied?: boolean;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex justify-between items-center text-sm">
+      <span className="text-gray-500 font-medium">{label}</span>
+      <div className="flex items-center gap-1.5 text-right">
+        {truncated ? (
+          <span
+            className={`text-white font-medium ${
+              mono ? "font-mono text-xs" : ""
+            }`}
+          >
+            {truncated}
+          </span>
+        ) : (
+          <span className="text-white font-medium">{value}</span>
+        )}
+        {onCopy && (
+          <button
+            onClick={onCopy}
+            className="relative shrink-0 p-1 text-red-600 hover:text-red-500 transition-colors"
+            aria-label={`Copy ${label}`}
+          >
+            <Copy className="h-3.5 w-3.5" />
+            {copied && (
+              <span className="absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-white px-2 py-1 text-[10px] text-black">
+                Copied!
+              </span>
+            )}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -111,3 +111,46 @@ component per file):
 - `tests/unit/components/i18n/FormattedCurrency.test.tsx` covers the React
   layer (defaults, locale override, unknown-currency fallback, prop
   forwarding, render-prop children, and the `useFormatter` hook).
+
+## Receipt Route
+
+A shareable public URL for viewing transaction receipts with social preview
+cards (Open Graph / Twitter Card meta tags).
+
+**Route:** `/receipt/[txHash]`
+
+**Files:**
+- `app/receipt/[txHash]/page.tsx` — server component that fetches transaction
+  data from Horizon and sets OG meta tags via `generateMetadata`.
+- `components/ReceiptPageContent.tsx` — client component rendering the receipt
+  UI and calling `useSeo` for client-side title/description.
+
+### Behavior
+
+- Validates `txHash` as a 64-character hex string; shows an error state for
+  invalid hashes.
+- Fetches the transaction via `fetchTransactionReceipt` from Horizon.
+- If the transaction is not found, shows a "Transaction Not Found" state.
+- On success, displays the receipt: status badge, amount, transaction hash,
+  recipient, sender, date, network fee, and optional memo.
+- Share button uses the Web Share API when available; falls back to copying
+  the URL.
+- Explorer links point to stellar.expert.
+
+### Meta Tags (Social Preview)
+
+The `generateMetadata` function sets:
+
+| Tag | Value |
+|-----|-------|
+| `og:title` | `Receipt {short_hash}… | RemitWise` |
+| `og:description` | `View receipt for transaction {short_hash}… on RemitWise.` |
+| `og:type` | `website` |
+| `og:image` | Logo image from `/logo.svg` |
+| `twitter:card` | `summary_large_image` |
+| `twitter:site` | `@RemitWise` |
+
+### Tests
+
+- `tests/unit/components/ReceiptPageContent.test.tsx` covers the receipt page
+  content component for valid/invalid hashes and successful/missing transactions.

--- a/lib/config/seo.ts
+++ b/lib/config/seo.ts
@@ -2,3 +2,12 @@ export const DEFAULT_SEO = {
   title: "RemitWise - Smart Remittance & Financial Planning",
   description: "A remittance app that helps families save, plan, and protect — not just send money.",
 };
+
+export const RECEIPT_SEO = {
+  titlePrefix: "Receipt | RemitWise",
+  description: "View transaction details and confirmation on RemitWise.",
+  ogImagePath: "/logo.svg",
+  twitterHandle: "@RemitWise",
+} as const;
+
+export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://remitwise.app";

--- a/lib/remittance/horizon.ts
+++ b/lib/remittance/horizon.ts
@@ -149,6 +149,78 @@ export async function fetchTransactionHistory(
 }
 
 /**
+ * Detailed receipt data for a single transaction, assembled from Horizon.
+ */
+export interface ReceiptData {
+  hash: string;
+  amount: string;
+  currency: string;
+  recipient: string;
+  sender: string;
+  date: string;
+  fee: string;
+  status: TxStatus | "not_found" | "pending";
+  memo?: string;
+}
+
+/**
+ * Fetches detailed receipt data for a single transaction hash.
+ * Returns null if the hash is invalid or the transaction is not found.
+ */
+export async function fetchTransactionReceipt(
+  hash: string
+): Promise<ReceiptData | null> {
+  if (!isValidTxHash(hash)) return null;
+
+  const server = getHorizonServer();
+  try {
+    const tx = await server.transactions().transaction(hash).call();
+    const feeInXlm = tx.fee_charged
+      ? (Number(tx.fee_charged) / 1e7).toFixed(7)
+      : "0";
+
+    // Fetch payment operations for this transaction
+    const opsResult = await server
+      .operations()
+      .forTransaction(hash)
+      .call();
+    const paymentOp = opsResult.records.find(
+      (op): op is Horizon.ServerApi.PaymentOperationRecord =>
+        op.type === "payment"
+    );
+
+    const currency =
+      paymentOp && paymentOp.asset_type !== "native"
+        ? paymentOp.asset_code
+        : "XLM";
+
+    const amount = paymentOp ? paymentOp.amount : "0";
+
+    const recipient = paymentOp ? paymentOp.to : "";
+
+    const memo =
+      tx.memo_type === "text" && tx.memo ? tx.memo : undefined;
+
+    return {
+      hash,
+      amount,
+      currency,
+      recipient,
+      sender: tx.source_account,
+      date: tx.created_at,
+      fee: feeInXlm,
+      status: tx.successful ? "completed" : "failed",
+      memo,
+    };
+  } catch (error: any) {
+    if (error.response?.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
  * Fetches current status for a single transaction hash.
  */
 export async function fetchTransactionStatus(

--- a/tests/unit/components/ReceiptPageContent.test.tsx
+++ b/tests/unit/components/ReceiptPageContent.test.tsx
@@ -1,0 +1,129 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/hooks/useSeo", () => ({
+  useSeo: vi.fn(),
+}));
+
+vi.mock("@/lib/remittance/horizon", () => ({
+  isValidTxHash: (hash: string) => /^[0-9a-f]{64}$/i.test(hash),
+}));
+
+import ReceiptPageContent from "@/components/ReceiptPageContent";
+import type { ReceiptData } from "@/lib/remittance/horizon";
+
+afterEach(() => {
+  cleanup();
+});
+
+const VALID_HASH = "a1b2c3d4e5f60123456789abcdefa1b2c3d4e5f60123456789abcdefa1b2c3d4";
+const INVALID_HASH = "not-a-valid-hash";
+
+const completedReceipt: ReceiptData = {
+  hash: VALID_HASH,
+  amount: "100.00",
+  currency: "USDC",
+  recipient: "GABCDEF123456789012345678901234567890123456789012345678901234567",
+  sender: "G123456789012345678901234567890123456789012345678901234567890123",
+  date: "2026-06-15T14:30:00Z",
+  fee: "0.0000100",
+  status: "completed",
+};
+
+const failedReceipt: ReceiptData = {
+  ...completedReceipt,
+  status: "failed",
+};
+
+describe("ReceiptPageContent", () => {
+  it("shows invalid hash message when txHash is not a valid 64-char hex", () => {
+    render(
+      <ReceiptPageContent
+        txHash={INVALID_HASH}
+        receiptData={null}
+        notFound={false}
+      />
+    );
+    expect(screen.getByText("Invalid Transaction Hash")).toBeInTheDocument();
+  });
+
+  it("shows not-found message when receiptData is null and notFound is true", () => {
+    render(
+      <ReceiptPageContent
+        txHash={VALID_HASH}
+        receiptData={null}
+        notFound={true}
+      />
+    );
+    expect(screen.getByText("Transaction Not Found")).toBeInTheDocument();
+  });
+
+  it("renders completed receipt data", () => {
+    render(
+      <ReceiptPageContent
+        txHash={VALID_HASH}
+        receiptData={completedReceipt}
+        notFound={false}
+      />
+    );
+
+    expect(screen.getByText("Transfer Successful")).toBeInTheDocument();
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+    expect(screen.getByText("100.00")).toBeInTheDocument();
+    expect(screen.getByText("USDC")).toBeInTheDocument();
+
+    const viewOnExplorer = screen.getByText("View on Stellar Explorer");
+    expect(viewOnExplorer).toBeInTheDocument();
+    expect(viewOnExplorer.closest("a")).toHaveAttribute(
+      "href",
+      `https://stellar.expert/explorer/public/tx/${VALID_HASH}`
+    );
+  });
+
+  it("renders failed receipt status", () => {
+    render(
+      <ReceiptPageContent
+        txHash={VALID_HASH}
+        receiptData={failedReceipt}
+        notFound={false}
+      />
+    );
+
+    expect(screen.getByText("Transfer Failed")).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+
+  it("renders share and explorer action buttons", () => {
+    render(
+      <ReceiptPageContent
+        txHash={VALID_HASH}
+        receiptData={completedReceipt}
+        notFound={false}
+      />
+    );
+
+    expect(screen.getByText("Share")).toBeInTheDocument();
+    expect(screen.getByText("Return to Dashboard")).toBeInTheDocument();
+  });
+
+  it("includes a link back to dashboard", () => {
+    render(
+      <ReceiptPageContent
+        txHash={VALID_HASH}
+        receiptData={completedReceipt}
+        notFound={false}
+      />
+    );
+
+    const dashboardLink = screen.getByText("Return to Dashboard").closest("a");
+    expect(dashboardLink).toHaveAttribute("href", "/dashboard");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `/receipt/:txHash` route with Open Graph and Twitter Card meta tags so transaction receipts render social preview cards when shared (messaging apps, social media, Slack unfurls, etc.).

## Changes

### New files
- **`app/receipt/[txHash]/page.tsx`** — Server component with `generateMetadata` providing 6 social meta tags (`og:title`, `og:description`, `og:type`, `og:image`, `twitter:card`, `twitter:site`). Fetches transaction data from Horizon via `fetchTransactionReceipt` and renders the receipt client component.
- **`components/ReceiptPageContent.tsx`** — Client component displaying:
  - Status badge (Completed / Failed with semantic colors)
  - Amount hero section
  - Transaction details (hash with copy-to-clipboard, recipient, sender, date/time, network fee, optional memo)
  - Share button (Web Share API with clipboard fallback)
  - Explorer links (stellar.expert)
  - Return to Dashboard navigation
  - Error states for invalid hashes and not-found transactions
- **`tests/unit/components/ReceiptPageContent.test.tsx`** — 6 unit tests covering: invalid hash, transaction not found, completed receipt, failed receipt, action buttons, dashboard link.

### Modified files
- **`lib/remittance/horizon.ts`** — Added `ReceiptData` interface and `fetchTransactionReceipt(hash)` helper that fetches payment operations from Horizon and assembles a receipt object.
- **`lib/config/seo.ts`** — Added `RECEIPT_SEO` constants (title prefix, description, OG image path, Twitter handle) and `SITE_URL`.
- **`docs/COMPONENTS.md`** — Added Receipt Route documentation section with route, behavior, meta tag table, and test coverage.

## Verification

- [x] `npm run lint` — no errors in changed files
- [x] `npx tsc --noEmit` — no type errors in changed files
- [x] Unit tests pass — 6/6 for receipt content, no regression in existing suites
- [x] Pre-existing build/test failures (in unrelated files: `react-window`, `@tanstack/react-query`, `DensityContext`) are unchanged by this PR

## Notes

- The OG image currently uses the existing `/logo.svg` as a static placeholder. A follow-up could generate dynamic OG images per-transaction hash.
- The `fetchTransactionReceipt` helper gracefully returns `null` for 404s from Horizon and rethrows unexpected errors.
- The public `ReceiptData` type and `fetchTransactionReceipt` export are backwards-compatible — no existing consumers are affected.

# Closes #969