### PR TITLE
docs: add tracking, cookies, and telemetry opt-out guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ PII scrubbing is applied before events leave the app:
 
 Keep the auth token out of the repo and store it only in CI secrets.
 
+For more details on tracking, cookies, and telemetry configuration, see the [Tracking and Opt-Out Guide](docs/tracking-and-opt-out.md).
+
 ## Getting Started
 
 ### Environment Configuration
@@ -891,6 +893,8 @@ Sentry error monitoring is integrated for client, server, and edge runtimes.
 
 - Uploaded during build when `SENTRY_AUTH_TOKEN` and CI are present.
 - `hideSourceMaps: true` prevents browser exposure.
+
+For a comprehensive guide on what variables, cookies, and telemetry endpoints are configured—and how to opt out of them—see the [Tracking and Opt-Out Guide](docs/tracking-and-opt-out.md).
 
 ## Developer Mode & Debugging
 

--- a/docs/tracking-and-opt-out.md
+++ b/docs/tracking-and-opt-out.md
@@ -1,0 +1,91 @@
+# Tracking, Cookies, and Telemetry Configuration
+
+This document is written for **operators and deployment administrators** of the RemitWise platform. It details all cookies, local storage, session storage, and telemetry integrations used by the RemitWise frontend, why they are set, and how to disable or opt out of them.
+
+---
+
+## Browser Storage and Cookies
+
+The application stores configuration and session identifiers in the user's browser to support authentication and UI customization. 
+
+### Cookies
+
+Cookies are exchanged on HTTP requests and are used for session security and locale hydration.
+
+| Cookie Name | Scope / Access | Life-span | Purpose / Content | Operator Opt-Out / Configuration |
+|---|---|---|---|---|
+| `remitwise_session` | HTTP-Only, Lax, Secure (prod) | Configurable via `SESSION_MAX_AGE` (default: 7 days) | Encrypted JSON payload containing `{ address: string, createdAt: number, expiresAt: number }` to maintain user session. | Cannot be disabled for authenticated routes. Operators can customize session duration using `SESSION_MAX_AGE` in seconds. |
+| `remitwise_locale` | JavaScript Accessible | 1 year | The user's selected language/locale preference (e.g., `en`, `es`). Used to render server-side translations. | Managed in the UI preferences. Operators cannot disable this without disabling multi-language support. |
+
+#### Example: Session Duration Configuration
+To set a custom session expiry of 2 hours, configure the environment variable:
+```bash
+SESSION_MAX_AGE=7200
+```
+
+---
+
+### Local Storage (`localStorage`)
+
+Local storage persists data across browser sessions and tab closures. It is read-only on the client side.
+
+| Key | Life-span | Purpose | Opt-Out |
+|---|---|---|---|
+| `theme-preference` | Indefinite | Stores user visual theme choice (`dark` or `light`). | Cleared via developer tools or theme toggle in settings. |
+| `display-density` | Indefinite | Stores user layout density choice (`comfortable` or `compact`). | Cleared via developer tools or layout selector in settings. |
+| `redirect_after_auth` | Temporary | Stores the path the user visited before authentication to redirect them back after logging in. | Deleted automatically upon login redirection. |
+| `session_expiry` | Temporary | Stores session expiry timestamp for client-side warning notifications. | Deleted automatically on logout. |
+| `remitwise_whats_new_last_seen` | Indefinite | Tracks the latest seen feature announcement ID. | Managed automatically by the application. |
+| `remitwise-tutorial-<id>` | Indefinite | Tracks completed chapters within the tutorial flow. | Managed automatically, or manually cleared in developer tools. |
+
+---
+
+### Session Storage (`sessionStorage`)
+
+Session storage data persists only for the duration of the page session (as long as the browser tab is open).
+
+| Key | Life-span | Purpose | Opt-Out |
+|---|---|---|---|
+| `remitwise_dev_mode` | Tab lifetime | Toggles the floating Request-ID panel display for developer troubleshooting. | Toggled off by appending `?dev=0` to the URL. |
+| `remitwise_latest_request_id` | Tab lifetime | Holds the most recent API Response `X-Request-ID` header. | Clears automatically when the tab is closed. |
+
+---
+
+## Telemetry and Error Monitoring (Sentry)
+
+RemitWise uses Sentry to capture client, server, and edge runtime exceptions.
+
+### Privacy and PII Scrubbing
+
+To prevent sensitive information exposure, Sentry events are sanitized before being transmitted to the ingestion server:
+1. **Stellar Wallet Addresses**: Masked via regex match `G[A-Z2-7]{55}` replacing addresses with `[STELLAR_ADDRESS]`.
+2. **Transaction Amounts**: Masked via regex match `\b\d+(\.\d+)?\s*(XLM|USDC|USD)\b` replacing values with `[AMOUNT]`.
+3. **Session Tokens**: Server events redact the `iron-session` cookie signature.
+
+---
+
+### Operator Opt-Out / Configuration
+
+Operators can fully disable Sentry telemetry by unsetting or leaving the Sentry DSN environment variables empty. When telemetry is disabled, the application falls back to a safe console logger.
+
+#### Disabling Telemetry (No-Op Configuration)
+Set the environment variables in your deployment environment as follows:
+```env
+# Disable Sentry monitoring
+NEXT_PUBLIC_SENTRY_DSN=""
+SENTRY_DSN=""
+```
+
+#### Verification Code Example
+The application resolves the Sentry DSN programmatically. If none is supplied, the error reporter defaults to a no-op handler:
+
+```typescript
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN;
+
+if (!dsn) {
+  // Graceful fallback when telemetry is disabled
+  console.log("[Telemetry] Sentry DSN is empty. Sentry is disabled.");
+} else {
+  console.log("[Telemetry] Sentry initialized with DSN:", dsn);
+}
+```


### PR DESCRIPTION
# Description

This PR adds a comprehensive documentation guide detailing all cookies, local storage variables, session storage configurations, and Sentry telemetry integrations set by the RemitWise frontend. It outlines their purpose and explains how operators can disable telemetry or configure session scopes.

Closes #987


## What Changed
- Created `docs/tracking-and-opt-out.md` detailing browser storage usage and Sentry telemetry configurations.
- Linked the new guide in both Sentry monitoring sections of the root `README.md`.

## Key Design Decisions
- **Targeted Audience**: Specifically written for **operators/deployers** who manage deployments and must address compliance (GDPR/CCPA) or support queries.
- **Opt-out Guidance**: Included environment variable configuration instructions to disable telemetry by unsetting the Sentry DSN parameters.

## Verification Checklist
- [x] Change matches summary criteria (what we set, why, and how users can opt out).
- [x] New guide is cross-linked from the root `README.md`.
- [x] Examples in the document are syntactically valid and run/compile.
- [x] Clean workspace status (only `README.md` and `docs/tracking-and-opt-out.md` modified).

## Security Note
No secrets or unscrubbed credentials are added. Sentry scrubbers are documented to reassure operators that Stellar addresses and amounts are sanitized before transmission.
