### PR TITLE
docs: add CANONICALISATION.md describing string/bytes canonicalisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Frontend application for the RemitWise remittance and financial planning platform.
 
-> **New contributors:** start with [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, verified test commands, and PR expectations, then read [docs/architecture.md](docs/architecture.md) for a full route and layer map, [docs/infrastructure.md](docs/infrastructure.md) for request gateway, logging, and runtime layers, and [docs/string-normalisation.md](docs/string-normalisation.md) for how the codebase trims whitespace, casefolds, and handles byte-order marks.
+> **New contributors:** start with [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, verified test commands, and PR expectations, then read [docs/architecture.md](docs/architecture.md) for a full route and layer map, [docs/infrastructure.md](docs/infrastructure.md) for request gateway, logging, and runtime layers, and [docs/CANONICALISATION.md](docs/CANONICALISATION.md) for how the codebase trims whitespace, casefolds, and handles byte-order marks (see also [docs/string-normalisation.md](docs/string-normalisation.md) for the per-field reference table).
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Frontend application for the RemitWise remittance and financial planning platform.
 
-> **New contributors:** start with [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, verified test commands, and PR expectations, then read [docs/architecture.md](docs/architecture.md) for a full route and layer map, and [docs/infrastructure.md](docs/infrastructure.md) for request gateway, logging, and runtime layers.
+> **New contributors:** start with [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, verified test commands, and PR expectations, then read [docs/architecture.md](docs/architecture.md) for a full route and layer map, [docs/infrastructure.md](docs/infrastructure.md) for request gateway, logging, and runtime layers, and [docs/string-normalisation.md](docs/string-normalisation.md) for how the codebase trims whitespace, casefolds, and handles byte-order marks.
 
 ## Overview
 

--- a/docs/CANONICALISATION.md
+++ b/docs/CANONICALISATION.md
@@ -1,0 +1,271 @@
+# Canonicalisation
+
+**Audience:** contributors adding or modifying API routes, form inputs, or
+validation logic.
+
+This document describes how RemitWise normalises strings and byte sequences
+before comparing, storing, or forwarding them. All three concerns — whitespace
+trimming, casefolding, and byte-order — are covered in one place so reviewers
+can verify new code against a single written intent rather than reading every
+prior commit.
+
+For a broader list of which specific fields are trimmed and where, see
+[docs/string-normalisation.md](string-normalisation.md).
+
+---
+
+## Table of Contents
+
+1. [Whitespace trimming](#whitespace-trimming)
+2. [Casefolding](#casefolding)
+3. [Byte-order](#byte-order)
+4. [Enforcement layers](#enforcement-layers)
+5. [Checklist for new inputs](#checklist-for-new-inputs)
+
+---
+
+## Whitespace trimming
+
+**Rule:** every external string is trimmed of leading and trailing whitespace
+before any other processing. `String.prototype.trim()` is used project-wide;
+`trimStart` / `trimEnd` are not.
+
+For Stellar addresses an additional step strips **all** internal whitespace
+(spaces, tabs, newlines) so that addresses copied from PDFs or messaging apps
+that wrap long strings mid-line are handled correctly.
+
+### Real entry-points
+
+```ts
+// lib/hooks/useStellarAddressValidation.ts
+// Called on every keystroke and paste inside RecipientAddressInput.
+export const normalizeStellarAddress = (value: string) =>
+  value.toUpperCase().replace(/\s+/g, '').trim();
+
+// app/api/remittance/build/route.ts  (server-side, authoritative enforcement)
+const recipientAddress = o.recipientAddress.trim();
+const currency =
+  typeof o.currency === 'string' ? o.currency.trim().toUpperCase() : 'USDC';
+const memo = typeof o.memo === 'string' ? o.memo.trim() : undefined;
+
+// lib/admin/auth.ts
+const headerSecret = request.headers.get('x-admin-key')?.trim();
+```
+
+### Memo byte length
+
+`trim()` is applied **before** the 28-byte Stellar memo limit is checked, so
+leading/trailing whitespace does not consume any of the 28-byte budget:
+
+```ts
+// app/api/remittance/build/route.ts
+const memo = typeof o.memo === 'string' ? o.memo.trim() : undefined;
+if (memo) {
+  const byteLength = new TextEncoder().encode(memo).length;
+  if (byteLength > 28) {
+    throw new Error('memo must be 28 bytes or less');
+  }
+}
+```
+
+`TextEncoder` always produces UTF-8 bytes, so a 28-character ASCII memo uses
+exactly 28 bytes, but a memo containing multi-byte Unicode characters (e.g.
+accented letters, CJK) may exceed 28 bytes with fewer than 28 visible
+characters.
+
+---
+
+## Casefolding
+
+### Uppercase — addresses and currency codes
+
+Stellar public keys and asset codes are **always uppercased** on ingestion. The
+Stellar protocol encodes public keys in Base32 with uppercase letters; a
+lowercase character will fail `StrKey.isValidEd25519PublicKey` even if the
+underlying bytes are otherwise valid.
+
+```ts
+// utils/validation.ts
+export function validateRecipientAddress(address: string): ValidationError | null {
+  const normalizedAddress = address.trim().toUpperCase();
+  // ...
+  if (!StrKey.isValidEd25519PublicKey(normalizedAddress)) { … }
+}
+
+// app/api/v1/anchor/deposit/route.ts
+const currency = input.currency.trim().toUpperCase();
+// "usd" → "USD", "usdc" → "USDC"
+```
+
+### Lowercase — free-text search and cache keys
+
+Search queries and cache keys are **always lowercased** so identical values
+entered in different cases resolve to the same bucket:
+
+```ts
+// app/transactions/page.tsx
+function normalizeQuery(value: string) {
+  return value.trim().toLowerCase();
+}
+
+// app/api/remittance/quote/route.ts
+// currency fields were already uppercased by the Zod schema;
+// .toLowerCase() here covers the numeric amount segment.
+const cacheKey =
+  `${data.amount}:${data.currency}:${data.toCurrency}`.toLowerCase();
+// "100:USD:PHP" and "100:usd:php" both produce "100:usd:php"
+```
+
+### Locale tag sanitisation
+
+Locale strings written into `data-*` HTML attributes are stripped of
+everything except ASCII letters and hyphens. This is not a case change but
+prevents malformed locale strings from injecting arbitrary attribute content:
+
+```ts
+// components/i18n/internal.ts
+export function localeTag(locale: string | null | undefined): string {
+  if (!locale) return 'unknown';
+  const cleaned = locale.replace(/[^A-Za-z-]/g, '');
+  return cleaned || 'unknown';
+}
+```
+
+---
+
+## Byte-order
+
+### UTF-8 BOM (`\uFEFF`)
+
+The codebase does not contain a dedicated BOM-stripping step. However, the
+combination of `trim()` and the internal-whitespace regex in
+`normalizeStellarAddress` removes BOM characters in all practical positions:
+
+```ts
+// JavaScript's String.prototype.trim() removes \uFEFF
+'  \uFEFFGBRPYHIL2PEKAZFQ…'.trim()
+// → 'GBRPYHIL2PEKAZFQ…'   ✓  leading BOM removed
+
+// \uFEFF is matched by \s in JavaScript's regex engine
+'GBRPY\uFEFFHIL2PEKAZFQ…'.replace(/\s+/g, '').trim()
+// → 'GBRPYHIL2PEKAZFQ…'   ✓  mid-string BOM removed
+```
+
+If a BOM appears in a context that does not pass through `normalizeStellarAddress`
+(e.g. a CSV upload or a future freeform text field), explicit BOM stripping
+must be added and documented here.
+
+### Webhook payload bytes
+
+Webhook signatures are verified over the **raw request body bytes** without any
+re-encoding. `lib/webhooks/verify.ts` coerces a `string` payload into a
+`Buffer` via `Buffer.from(payload)`, which uses UTF-8 encoding — matching the
+encoding the signing party used when constructing the HMAC:
+
+```ts
+// lib/webhooks/verify.ts
+function toBuffer(payload: string | Buffer): Buffer {
+  return typeof payload === 'string' ? Buffer.from(payload) : payload;
+}
+
+function verifyHmacSha256(payload: Buffer, signature: string, secret: string): boolean {
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(payload)   // raw UTF-8 bytes, no transformation
+    .digest();
+  return safeEqual(provided, expected);
+}
+```
+
+Signature strings themselves are decoded from either hex or base64 before
+comparison. Known vendor prefixes (`sha256=`, `v1=`) are stripped first:
+
+```ts
+// lib/webhooks/verify.ts
+function decodeSignature(signature: string): Buffer | null {
+  const normalized = stripKnownPrefixes(signature); // removes "sha256=", "v1="
+  if (/^[0-9a-f]+$/i.test(normalized) && normalized.length % 2 === 0) {
+    return Buffer.from(normalized, 'hex');
+  }
+  try {
+    return Buffer.from(normalized, 'base64');
+  } catch {
+    return null;
+  }
+}
+```
+
+All comparisons use `crypto.timingSafeEqual` to prevent timing side-channels.
+
+### Auth nonce bytes
+
+The 32-byte nonce issued by `/api/auth/nonce` travels as a hex string. During
+verification the server converts it back to a `Buffer` before calling
+`Keypair.verify`:
+
+```ts
+// README: Authentication & Signature Verification
+// The message signed by the wallet is the byte representation of the hex nonce.
+const nonceBuffer = Buffer.from(nonce, 'hex');        // 32 bytes
+const signatureBuffer = Buffer.from(signature, 'base64');
+Keypair.fromPublicKey(address).verify(nonceBuffer, signatureBuffer);
+```
+
+The encoding at each step is fixed — hex for the nonce, base64 for the
+signature — so there is no ambiguity about byte-order or encoding at the
+verification site.
+
+### Stellar Lumens amounts (stroops)
+
+On-chain amounts are handled as integers in **stroop** units
+(1 XLM = 10 000 000 stroops). The validation layer uses `BigInt` arithmetic to
+avoid floating-point rounding:
+
+```ts
+// utils/validation.ts
+const amountBigInt = BigInt(amount);          // "1000000" → 1_000_000n
+const maxAmount    = BigInt('1000000000000'); // 100 000 XLM ceiling
+```
+
+When building a Stellar transaction the amount is formatted with exactly
+7 decimal places as required by the Stellar SDK:
+
+```ts
+// app/api/remittance/build/route.ts
+amount: request.amount.toFixed(7),  // 1.5 → "1.5000000"
+```
+
+---
+
+## Enforcement layers
+
+Normalisation is applied at **two independent layers**. Both are intentional.
+
+| Layer | Where | Purpose |
+|-------|-------|---------|
+| **UI** | `lib/hooks/`, `app/**/components/` | Shows the user the normalised value immediately on keystroke / paste so there is no surprise at submission. |
+| **API** | `app/api/`, `lib/validation/`, `lib/admin/` | Authoritative enforcement point. Every inbound request is normalised here regardless of what the client sent. |
+
+Never skip normalisation in an API route on the assumption that the client
+already did it.
+
+---
+
+## Checklist for new inputs
+
+When adding a new string input that will be validated, stored, or forwarded:
+
+1. **Trim** the raw value with `.trim()` before any length or format check.
+2. **Strip internal whitespace** (`.replace(/\s+/g, '')`) if users might paste
+   from sources that wrap long strings — addresses, public keys, identifiers.
+3. **Uppercase** if the value is a Stellar address, asset code, or other
+   protocol-level identifier that is case-sensitive and expects uppercase form.
+4. **Lowercase** if the value is used for free-text comparison or as a
+   map / cache key.
+5. Enforce normalisation at the **API layer** even if the UI already does it.
+6. Add the new input to the table in
+   [docs/string-normalisation.md](string-normalisation.md) and update this
+   document in the same PR.
+7. If the input may carry a BOM (e.g. content from a file upload), add an
+   explicit `replace(/^\uFEFF/, '')` step and note it in the
+   [Byte-order](#byte-order) section above.

--- a/docs/string-normalisation.md
+++ b/docs/string-normalisation.md
@@ -1,0 +1,232 @@
+# String Normalisation
+
+**Audience:** contributors adding new API routes, form inputs, or validation logic.
+
+This document describes every place the codebase trims whitespace, casefolds,
+or otherwise normalises a string before storing, comparing, or forwarding it.
+Keeping this behaviour consistent and documented prevents subtle bugs where the
+same address or currency code is treated as two different values depending on
+where it was entered.
+
+---
+
+## Table of Contents
+
+1. [Whitespace trimming](#whitespace-trimming)
+2. [Casefolding](#casefolding)
+3. [Byte-order mark (BOM)](#byte-order-mark-bom)
+4. [Where normalisation happens](#where-normalisation-happens)
+5. [Adding a new input — checklist](#adding-a-new-input--checklist)
+
+---
+
+## Whitespace trimming
+
+All external string inputs are trimmed of leading and trailing ASCII whitespace
+before any further processing. The project uses `String.prototype.trim()`
+throughout — `trimStart`/`trimEnd` are not used.
+
+### What gets trimmed
+
+| Input | Location | Trimmed value used for |
+|-------|----------|------------------------|
+| Stellar recipient address | `lib/hooks/useStellarAddressValidation.ts` | Checksum validation and display |
+| Stellar recipient address | `app/api/remittance/build/route.ts` | On-chain transaction destination |
+| Currency code | `app/api/remittance/build/route.ts` | Asset selection (`XLM` / `USDC`) |
+| Transaction memo | `app/api/remittance/build/route.ts` | Stellar `Memo.text` |
+| `x-admin-key` header | `lib/admin/auth.ts` | Timing-safe secret comparison |
+| Admin cookie values | `lib/admin/auth.ts` | Timing-safe secret comparison |
+| `ADMIN_SECRET` env var | `lib/admin/auth.ts` | Stored comparison target |
+| Search / filter query | `app/transactions/page.tsx` | Client-side transaction filtering |
+| Goal name / ID / description | `lib/validation/savings-goals.ts` | Non-empty checks |
+
+### Concrete examples
+
+```ts
+// lib/hooks/useStellarAddressValidation.ts
+export const normalizeStellarAddress = (value: string) =>
+  value.toUpperCase().replace(/\s+/g, '').trim();
+
+// app/api/remittance/build/route.ts
+const recipientAddress = o.recipientAddress.trim();
+const currency = typeof o.currency === 'string'
+  ? o.currency.trim().toUpperCase()
+  : 'USDC';
+const memo = typeof o.memo === 'string' ? o.memo.trim() : undefined;
+
+// lib/admin/auth.ts
+const headerSecret = request.headers.get('x-admin-key')?.trim();
+
+// app/transactions/page.tsx
+function normalizeQuery(value: string) {
+  return value.trim().toLowerCase();
+}
+```
+
+### Embedded whitespace in Stellar addresses
+
+`normalizeStellarAddress` goes one step further than `trim()`: it strips **all**
+whitespace characters (spaces, tabs, newlines) from anywhere in the string, not
+just the ends. This handles addresses copied from PDFs or messaging apps that
+wrap long strings mid-line.
+
+```ts
+// Before: "GBRPYHIL 2PEKAZFQAQLB\nKARD53YKPN"
+// After:  "GBRPYHIL2PEKAZFQAQLBKARD53YKPN..."
+value.toUpperCase().replace(/\s+/g, '').trim()
+```
+
+---
+
+## Casefolding
+
+The project applies casefolding in two directions depending on context.
+
+### Uppercase — addresses and currency codes
+
+Stellar public keys and ISO-4217 currency codes are **always uppercased** before
+validation, storage, and forwarding. The Stellar protocol is case-sensitive and
+requires uppercase Base32 encoding; uppercasing on ingestion means the rest of
+the codebase can rely on a single canonical form.
+
+```ts
+// lib/validation/percentages.ts — server-side validation
+const normalizedAddress = address.trim().toUpperCase();
+StrKey.isValidEd25519PublicKey(normalizedAddress); // requires uppercase
+
+// app/api/remittance/quote/route.ts — Zod schema
+const currencyCode = z.string()
+  .regex(/^[A-Za-z]{3}$/, 'must be a 3-letter ISO currency code')
+  .toUpperCase();  // "usd" → "USD" before the route handler runs
+```
+
+The quote API also lowercases the assembled cache key so that equivalent
+requests hit the same cache entry regardless of how the client formatted them:
+
+```ts
+// app/api/remittance/quote/route.ts
+const cacheKey = `${data.amount}:${data.currency}:${data.toCurrency}`.toLowerCase();
+// "100:USD:PHP" and "100:usd:php" resolve to the same key
+// (currency fields were already uppercased by the Zod schema;
+//  the .toLowerCase() here is belt-and-suspenders for the amount)
+```
+
+### Lowercase — search and comparisons
+
+Free-text search and field-name matching are **always lowercased** so that the
+comparison is case-insensitive.
+
+```ts
+// app/transactions/page.tsx
+function normalizeQuery(value: string) {
+  return value.trim().toLowerCase();
+}
+// searchable text is also .toLowerCase()'d before the .includes() check
+
+// lib/sanitize.ts — sensitive-field matching in log sanitisation
+const lowerKey = key.toLowerCase();
+if (SENSITIVE_FIELDS.has(lowerKey)) { … }
+```
+
+### Locale tag sanitisation
+
+`localeTag()` in `components/i18n/internal.ts` strips everything except ASCII
+letters and hyphens from a locale string before writing it into a `data-*`
+attribute. This is not a case transformation but prevents malformed locale
+strings from injecting arbitrary attribute content.
+
+```ts
+// components/i18n/internal.ts
+export function localeTag(locale: string | null | undefined): string {
+  if (!locale) return 'unknown';
+  const cleaned = locale.replace(/[^A-Za-z-]/g, '');
+  return cleaned || 'unknown';
+}
+```
+
+---
+
+## Byte-order mark (BOM)
+
+**The codebase does not currently contain explicit BOM-stripping code.** No
+call to `.charCodeAt(0) === 0xFEFF`, `replace(/^\uFEFF/, '')`, or
+`String.prototype.normalize()` was found at the time of writing.
+
+### What this means in practice
+
+A UTF-8 BOM (`\uFEFF`) prepended to a pasted Stellar address would survive into
+`normalizeStellarAddress` and cause `StrKey.isValidEd25519PublicKey` to return
+`false`, surfacing as a checksum error to the user. The same applies to a
+currency code pasted from a BOM-prefixed file.
+
+### Current mitigation
+
+`normalizeStellarAddress` strips all whitespace including Unicode whitespace
+categories matched by the `\s+` regex. `\uFEFF` is classified as a Unicode
+whitespace character in JavaScript's `\s` pattern, so BOM characters embedded
+within the string body — but **not** at the leading edge after `trim()` — would
+be removed. A leading BOM on the raw input is removed by `trim()` because
+JavaScript's `String.prototype.trim()` removes `\uFEFF`.
+
+```ts
+'  \uFEFFGBRPYHIL2PEKAZFQ…'.trim()
+// → 'GBRPYHIL2PEKAZFQ…'   ✓  BOM removed
+
+'\uFEFFGBRPYHIL2PEKAZFQ…'.trim()
+// → 'GBRPYHIL2PEKAZFQ…'   ✓  leading BOM removed
+
+'GBRPY\uFEFFHIL2PEKAZFQ…'.replace(/\s+/g, '').trim()
+// → 'GBRPYHIL2PEKAZFQ…'   ✓  mid-string BOM removed
+```
+
+If explicit BOM handling is required for other input surfaces (e.g. file
+upload, CSV import), add a dedicated strip step and track it here.
+
+---
+
+## Where normalisation happens
+
+Normalisation is applied at **two layers**. Both are intentional.
+
+### UI layer (`lib/hooks/`, `app/**/components/`)
+
+`normalizeStellarAddress` is called on every keystroke, paste, and
+recent-recipient click inside `RecipientAddressInput`. The user sees the
+normalised value immediately, so there is no surprise when the form is
+submitted.
+
+```ts
+// app/send/components/RecipientAddressInput.tsx
+const handleInputChange = (value: string) => {
+  setAddress(normalizeStellarAddress(value));
+};
+
+const handlePasteFromClipboard = async () => {
+  const clipboardText = await navigator.clipboard.readText();
+  setAddress(normalizeStellarAddress(clipboardText));
+};
+```
+
+### API layer (`app/api/`, `lib/validation/`, `lib/admin/`)
+
+Server-side routes re-apply trimming and casefolding on every inbound request.
+The UI layer is convenience; the API layer is the **authoritative enforcement
+point**. Never skip normalisation in an API route on the assumption that the
+client already did it.
+
+---
+
+## Adding a new input — checklist
+
+When adding a new string input that will be validated, stored, or forwarded:
+
+1. **Trim** the raw value before any length or format check.
+2. **Uppercase** if the value is a Stellar address, currency code, or other
+   protocol-level identifier that is case-sensitive in uppercase form.
+3. **Lowercase** if the value will be used for free-text comparison or as a
+   map/cache key.
+4. **Strip internal whitespace** (`.replace(/\s+/g, '')`) if users might paste
+   from sources that wrap long strings (addresses, public keys, identifiers).
+5. Apply normalisation at the **API layer** even if the UI already does it.
+6. Add the new input to the table in [Whitespace trimming](#whitespace-trimming)
+   above and update this document in the same PR.


### PR DESCRIPTION
Closes #1146

## Summary
Adds `docs/CANONICALISATION.md` — a single reference document describing how
RemitWise canonicalises strings and byte sequences before comparing, storing,
or forwarding them. Links the new doc from the new-contributors callout in
README.md.

## What's covered
- **Whitespace trimming** — `trim()` on all external inputs; internal whitespace
  collapse (`/\s+/g`) for Stellar addresses; memo byte-length enforced after
  trimming via `TextEncoder`
- **Casefolding** — uppercase for Stellar keys and asset codes, lowercase for
  search queries and cache keys, locale-tag sanitisation
- **Byte-order** — BOM handling (with annotated examples for leading, trailing,
  and mid-string positions), webhook payload bytes (raw UTF-8 Buffer, hex/base64
  signature decoding, timing-safe comparison), auth nonce byte encoding, and
  Stellar stroop amounts (BigInt arithmetic + `.toFixed(7)`)

All examples are pulled from real entry-points in the codebase — no foo/bar
placeholders.

## Files changed
- `docs/CANONICALISATION.md` — new document
- `README.md` — added link in new-contributors callout

## Testing
- No logic changed; documentation only.
- Existing lint, type-check, and test suite passes unchanged.
