### PR TITLE
fix(quote): 300 ms debounce + cancel-in-flight on new query

### DIFF
--- a/app/send/components/AmountCurrencySection.tsx
+++ b/app/send/components/AmountCurrencySection.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { ChevronDown, RefreshCw } from "lucide-react"
 import { CTA_TEST_IDS } from "@/lib/cta-testids"
 import { useExchangeRates } from "@/lib/context/RatesContext"
@@ -20,14 +20,18 @@ export default function AmountCurrencySection({ onReview, onBack }: AmountCurren
   const [quotePending, setQuotePending] = useState(false)
 
   // Debounce the raw amount so the quote API is only called after the user
-  // pauses typing, preventing one request per keystroke.
-  const debouncedAmount = useDebouncedValue(amount, 400)
+  // pauses typing for 300 ms, preventing one request per keystroke.
+  const debouncedAmount = useDebouncedValue(amount, 300)
 
   const { rates, loading, stale, error: ratesError, refresh } = useExchangeRates()
   const { t } = useClientTranslator()
 
+  // Keep a ref to the current in-flight AbortController so we can cancel it
+  // when the debounced amount or currency changes before the fetch completes.
+  const abortRef = useRef<AbortController | null>(null)
+
   // Fetch a quote whenever the debounced amount or currency changes.
-  // Using the latest debounced value ensures no stale quote is displayed.
+  // Any previous in-flight request is aborted before a new one starts (latest wins).
   useEffect(() => {
     const numValue = parseFloat(debouncedAmount)
     if (!debouncedAmount || isNaN(numValue) || numValue < 1 || numValue > 10000) {
@@ -35,26 +39,31 @@ export default function AmountCurrencySection({ onReview, onBack }: AmountCurren
       return
     }
 
-    let cancelled = false
+    // Cancel the previous in-flight request, if any.
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
     setQuotePending(true)
 
-    fetch(`/api/remittance/quote?amount=${encodeURIComponent(debouncedAmount)}&currency=${encodeURIComponent(currency)}`)
+    fetch(
+      `/api/remittance/quote?amount=${encodeURIComponent(debouncedAmount)}&currency=${encodeURIComponent(currency)}`,
+      { signal: controller.signal },
+    )
       .then((res) => (res.ok ? res.json() : null))
       .then((data: { quote?: number } | null) => {
-        if (!cancelled) {
-          setQuote(data?.quote ?? null)
-          setQuotePending(false)
-        }
+        setQuote(data?.quote ?? null)
+        setQuotePending(false)
       })
-      .catch(() => {
-        if (!cancelled) {
-          setQuote(null)
-          setQuotePending(false)
-        }
+      .catch((err: unknown) => {
+        // Ignore errors caused by intentional cancellation.
+        if (err instanceof Error && err.name === "AbortError") return
+        setQuote(null)
+        setQuotePending(false)
       })
 
     return () => {
-      cancelled = true
+      controller.abort()
     }
   }, [debouncedAmount, currency])
 

--- a/docs/REMITTANCE_FLOW.md
+++ b/docs/REMITTANCE_FLOW.md
@@ -63,7 +63,17 @@ sequenceDiagram
 
 ## 3. Quote Phase
 
-### 3a. Route — `app/api/remittance/quote/route.ts`
+### 3a. Client-side behaviour — `app/send/components/AmountCurrencySection.tsx`
+
+The amount input debounces quote fetches to reduce unnecessary API traffic:
+
+- **Debounce delay:** `300 ms` — the fetch fires only after the user stops typing for 300 ms.
+- **Cancel-in-flight:** When a new debounce cycle starts before the previous `GET /api/remittance/quote` has resolved, the outstanding request is **aborted** via `AbortController`. This is a true network-level cancellation, not merely ignoring the stale response.  
+  Sequence: `abortRef.current?.abort()` → new `AbortController` stored in `abortRef` → new fetch with `{ signal: controller.signal }`.
+- **AbortError handling:** `fetch` rejection with `err.name === "AbortError"` is silently swallowed — no error state is shown to the user.
+- **Constant location:** The 300 ms value lives in `AmountCurrencySection.tsx` directly; it matches the project-wide default in `useDebouncedValue` (`lib/hooks/useDebouncedValue.ts`).
+
+### 3b. Route — `app/api/remittance/quote/route.ts`
 
 - **Method:** `GET`
 - **Middleware:** `validatedRoute` with `quoteSchema` (Zod).
@@ -81,7 +91,7 @@ sequenceDiagram
   - Entries are evicted on read-after-expiry.
   - Response headers include `X-Cache: HIT|MISS` and `Cache-Control: max-age=…`.
 
-### 3b. Anchor integration (SEP-38)
+### 3c. Anchor integration (SEP-38)
 
 When `ANCHOR_API_BASE_URL` is set, the quote route delegates to a SEP-38-compatible
 anchor `GET /quote` endpoint:
@@ -96,7 +106,7 @@ The anchor response is remapped to the internal shape. Fields: `price`, `fee.tot
 
 Source: `app/api/remittance/quote/route.ts:100–138`
 
-### 3c. Fallback when anchor is absent
+### 3d. Fallback when anchor is absent
 
 If `ANCHOR_API_BASE_URL` is not set, `resolveQuote()` throws
 `"Unable to resolve quote"` and the route returns a `CONTRACT_ERROR` JSON error

--- a/docs/send-flow-state-inventory.md
+++ b/docs/send-flow-state-inventory.md
@@ -93,6 +93,8 @@ NOTE: Federation address support, network existence checks, and self-send preven
 Component: `app/send/components/AmountCurrencySection.tsx`  
 Validation: client-side only; min $1, max $10,000
 
+**Quote fetch:** After the user pauses typing for **300 ms** the component fires a `GET /api/remittance/quote` request. If a new debounce cycle begins before the previous fetch settles, the in-flight request is **cancelled via `AbortController`** (latest-wins). The 300 ms constant and the abort strategy are both implemented in this component.
+
 ### Amount Input
 
 | State | Description | UI Behavior | Microcopy / Error Text |

--- a/tests/unit/amount-currency-debounce.test.tsx
+++ b/tests/unit/amount-currency-debounce.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+/**
+ * Tests for the quote-fetch behaviour in AmountCurrencySection:
+ *  1. The quote API is only called after a 300 ms debounce pause.
+ *  2. Any in-flight request is cancelled (AbortError) when a new query
+ *     arrives before the previous fetch resolves.
+ *
+ * Closes #<issue>  (300 ms debounce, cancel-in-flight-on-new-query)
+ */
+
+import React, { act } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest'
+
+import AmountCurrencySection from '@/app/send/components/AmountCurrencySection'
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be at the top level of the file
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/context/RatesContext', () => ({
+  useExchangeRates: () => ({
+    rates: [],
+    loading: false,
+    stale: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}))
+
+vi.mock('@/lib/i18n/client', () => ({
+  useClientTranslator: () => ({ t: (key: string) => key }),
+  useClientLocale: () => 'en-US',
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** A resolvable promise that lets tests control exactly when a fetch settles. */
+function createControllableFetch() {
+  let resolveFn!: (value: Response) => void
+  let rejectFn!: (reason: unknown) => void
+  const promise = new Promise<Response>((resolve, reject) => {
+    resolveFn = resolve
+    rejectFn = reject
+  })
+  return { promise, resolve: resolveFn, reject: rejectFn }
+}
+
+/** Type into the amount input using synchronous fireEvent calls (compatible with fake timers). */
+function typeAmount(input: HTMLElement, value: string) {
+  act(() => {
+    fireEvent.change(input, { target: { value } })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AmountCurrencySection — debounce & cancel-in-flight', () => {
+  let fetchMock: Mock
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('does NOT call the quote API before the 300 ms debounce elapses', () => {
+    fetchMock.mockResolvedValue(new Response('{}', { status: 200 }))
+
+    render(<AmountCurrencySection />)
+    const input = screen.getByPlaceholderText('0.00')
+
+    typeAmount(input, '5')
+
+    // Only 100 ms have passed — the debounce has not fired yet.
+    act(() => { vi.advanceTimersByTime(100) })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('calls the quote API exactly once after the 300 ms debounce', () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ quote: 4.75 }), { status: 200 }),
+    )
+
+    render(<AmountCurrencySection />)
+    const input = screen.getByPlaceholderText('0.00')
+
+    typeAmount(input, '5')
+
+    // Advance past the debounce delay.
+    act(() => { vi.advanceTimersByTime(300) })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/remittance/quote'),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('aborts the previous in-flight request when a new query arrives', () => {
+    const first = createControllableFetch()
+    const second = createControllableFetch()
+
+    fetchMock
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+
+    render(<AmountCurrencySection />)
+    const input = screen.getByPlaceholderText('0.00')
+
+    // Type "5" → debounce fires → first fetch starts.
+    typeAmount(input, '5')
+    act(() => { vi.advanceTimersByTime(300) })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // The signal for the first call must not yet be aborted.
+    const firstSignal: AbortSignal = fetchMock.mock.calls[0][1].signal
+    expect(firstSignal.aborted).toBe(false)
+
+    // Type "50" → triggers a second debounce before the first fetch resolves.
+    typeAmount(input, '50')
+    act(() => { vi.advanceTimersByTime(300) })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    // The first request's signal must now be aborted (cancelled by the component).
+    expect(firstSignal.aborted).toBe(true)
+
+    // The second request's signal is still live.
+    const secondSignal: AbortSignal = fetchMock.mock.calls[1][1].signal
+    expect(secondSignal.aborted).toBe(false)
+
+    // Settle the second fetch to avoid dangling promise warnings.
+    act(() => {
+      second.resolve(
+        new Response(JSON.stringify({ quote: 47.5 }), { status: 200 }),
+      )
+    })
+  })
+
+  it('does NOT update quote state when a fetch is intentionally aborted', () => {
+    // The component should silently swallow AbortErrors and not set an error state.
+    const abortError = new DOMException('The user aborted a request.', 'AbortError')
+    fetchMock.mockRejectedValue(abortError)
+
+    render(<AmountCurrencySection />)
+    const input = screen.getByPlaceholderText('0.00')
+
+    typeAmount(input, '5')
+    act(() => { vi.advanceTimersByTime(300) })
+
+    // Even though the fetch was "aborted", no error text should appear.
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #984 

The quote fetch in AmountCurrencySection previously used a 400 ms debounce and a cancelled boolean flag that ignored stale responses but did NOT cancel the underlying network request.

Changes:
- Standardise debounce delay to 300 ms (matches useDebouncedValue default)
- Replace cancelled boolean with AbortController: each new debounce cycle calls abortRef.current?.abort() before issuing the next fetch, passing { signal: controller.signal } so the browser cancels the TCP request
- Silently swallow AbortError (err.name === 'AbortError') so no error state is shown to the user for intentional cancellations

Tests (tests/unit/amount-currency-debounce.test.tsx):
- Quote API is NOT called before 300 ms debounce elapses
- Quote API is called exactly once after 300 ms pause
- Previous in-flight AbortSignal is aborted when new query arrives
- AbortError is swallowed and does not produce an error state

Docs updated:
- docs/REMITTANCE_FLOW.md — new section 3a documents client-side debounce delay, abort sequence, and AbortError handling
- docs/send-flow-state-inventory.md — Step 2 now notes 300 ms debounce and cancel-in-flight strategy