### PR TITLE
Fix: Add a `useDialog` hook wrapping our dialog primitives (Auto-Generated)

### DIFF
--- a/lib/hooks/useDialog.ts
+++ b/lib/hooks/useDialog.ts
@@ -1,0 +1,168 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  ButtonHTMLAttributes,
+  DialogHTMLAttributes,
+  KeyboardEvent as ReactKeyboardEvent,
+  MouseEvent,
+  RefAttributes,
+  RefObject,
+} from "react";
+
+export interface UseDialogOptions {
+  initialOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+type DialogProps = DialogHTMLAttributes<HTMLDivElement> &
+  RefAttributes<HTMLDivElement> & {
+    role: "dialog";
+    "aria-modal": true;
+  };
+
+type TriggerProps = ButtonHTMLAttributes<HTMLButtonElement> &
+  RefAttributes<HTMLButtonElement> & {
+    type: "button";
+    "aria-haspopup": "dialog";
+    "aria-expanded": boolean;
+  };
+
+export interface UseDialogResult {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  dialogRef: RefObject<HTMLDivElement | null>;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+  dialogProps: DialogProps;
+  triggerProps: TriggerProps;
+  getDialogProps: (props?: DialogHTMLAttributes<HTMLDivElement>) => DialogProps;
+  getTriggerProps: (props?: ButtonHTMLAttributes<HTMLButtonElement>) => TriggerProps;
+}
+
+/**
+ * Provides the common interaction contract for dialogs.
+ *
+ * The element that has focus when `open` is called is remembered and receives
+ * focus again after `close` is called. The dialog itself receives initial
+ * focus, so consumers should attach `dialogRef` to a focusable dialog root
+ * (the returned props provide `tabIndex={-1}`).
+ */
+export function useDialog(options: UseDialogOptions = {}): UseDialogResult {
+  const { initialOpen = false, onOpenChange } = options;
+  const [isOpen, setIsOpen] = useState(initialOpen);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+  const wasOpenRef = useRef(initialOpen);
+
+  const open = useCallback(() => {
+    if (isOpen) return;
+
+    const activeElement = document.activeElement;
+    previouslyFocusedRef.current =
+      activeElement instanceof HTMLElement ? activeElement : null;
+    wasOpenRef.current = true;
+    setIsOpen(true);
+    onOpenChange?.(true);
+  }, [isOpen, onOpenChange]);
+
+  const close = useCallback(() => {
+    if (!isOpen) return;
+
+    setIsOpen(false);
+    onOpenChange?.(false);
+  }, [isOpen, onOpenChange]);
+
+  const toggle = useCallback(() => {
+    if (isOpen) {
+      close();
+    } else {
+      open();
+    }
+  }, [close, isOpen, open]);
+
+  useEffect(() => {
+    if (isOpen) {
+      dialogRef.current?.focus({ preventScroll: true });
+      return;
+    }
+
+    if (!wasOpenRef.current) return;
+
+    wasOpenRef.current = false;
+    const elementToRestore = previouslyFocusedRef.current;
+    previouslyFocusedRef.current = null;
+
+    if (elementToRestore && elementToRestore.isConnected) {
+      elementToRestore.focus({ preventScroll: true });
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !event.defaultPrevented) {
+        event.preventDefault();
+        close();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [close, isOpen]);
+
+  const getDialogProps = useCallback(
+    (props: DialogHTMLAttributes<HTMLDivElement> = {}): DialogProps => {
+      const { onKeyDown, ...rest } = props;
+
+      return {
+        ...rest,
+        ref: dialogRef,
+        role: "dialog",
+        "aria-modal": true,
+        tabIndex: props.tabIndex ?? -1,
+        onKeyDown: (event: ReactKeyboardEvent<HTMLDivElement>) => {
+          onKeyDown?.(event);
+        },
+      };
+    },
+    []
+  );
+
+  const getTriggerProps = useCallback(
+    (props: ButtonHTMLAttributes<HTMLButtonElement> = {}): TriggerProps => {
+      const { onClick, ...rest } = props;
+
+      return {
+        ...rest,
+        ref: triggerRef,
+        type: "button",
+        "aria-haspopup": "dialog",
+        "aria-expanded": isOpen,
+        onClick: (event: MouseEvent<HTMLButtonElement>) => {
+          onClick?.(event);
+          if (!event.defaultPrevented) open();
+        },
+      };
+    },
+    [isOpen, open]
+  );
+
+  return {
+    isOpen,
+    open,
+    close,
+    toggle,
+    dialogRef,
+    triggerRef,
+    dialogProps: getDialogProps(),
+    triggerProps: getTriggerProps(),
+    getDialogProps,
+    getTriggerProps,
+  };
+}
+
+export default useDialog;

--- a/tests/unit/hooks/useDialog.test.tsx
+++ b/tests/unit/hooks/useDialog.test.tsx
@@ -1,0 +1,63 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useDialog } from "@/lib/hooks/useDialog";
+
+function TestDialog({ onOpenChange }: { onOpenChange?: (open: boolean) => void }) {
+  const { isOpen, open, close, dialogProps } = useDialog({ onOpenChange });
+
+  return (
+    <>
+      <button type="button" onClick={open}>
+        Open dialog
+      </button>
+      {isOpen && (
+        <div {...dialogProps} aria-labelledby="dialog-title">
+          <h2 id="dialog-title">Dialog title</h2>
+          <button type="button" onClick={close}>
+            Close dialog
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
+describe("useDialog", () => {
+  it("opens the dialog and moves focus into it", () => {
+    render(<TestDialog />);
+
+    const openButton = screen.getByRole("button", { name: "Open dialog" });
+    act(() => openButton.focus());
+    fireEvent.click(openButton);
+
+    const dialog = screen.getByRole("dialog", { name: "Dialog title" });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(document.activeElement).toBe(dialog);
+  });
+
+  it("closes on Escape and restores focus to the opener", () => {
+    const onOpenChange = vi.fn();
+    render(<TestDialog onOpenChange={onOpenChange} />);
+
+    const openButton = screen.getByRole("button", { name: "Open dialog" });
+    fireEvent.click(openButton);
+    expect(screen.getByRole("dialog", { name: "Dialog title" })).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(openButton);
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
+    expect(onOpenChange).toHaveBeenNthCalledWith(1, true);
+    expect(onOpenChange).toHaveBeenNthCalledWith(2, false);
+  });
+
+  it("does not close for other keys", () => {
+    render(<TestDialog />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open dialog" }));
+    fireEvent.keyDown(document, { key: "Enter" });
+
+    expect(screen.getByRole("dialog", { name: "Dialog title" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #1111

This PR was generated by the DripTide AI coder and scoped strictly to issue #1111.

### Changes
Adds a client-side useDialog hook providing centralized open, close, toggle, Escape-key dismissal, initial dialog focus, focus restoration, trigger props, dialog props, and open-state callbacks. Adds unit tests covering opening, focus management, Escape dismissal, callback notifications, and ignoring unrelated keys.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #1111` so the Drips Wave bot resolves the issue on merge._