### PR TITLE
docs: add DESIGN_TOKEN_MIGRATION.md for renaming and deprecating tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Frontend application for the RemitWise remittance and financial planning platform.
 
-> **New contributors:** start with [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, verified test commands, and PR expectations, then read [docs/architecture.md](docs/architecture.md) for a full route and layer map, [docs/infrastructure.md](docs/infrastructure.md) for request gateway, logging, and runtime layers, and [docs/string-normalisation.md](docs/string-normalisation.md) for how the codebase trims whitespace, casefolds, and handles byte-order marks.
+> **New contributors:** start with [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, verified test commands, and PR expectations, then read [docs/architecture.md](docs/architecture.md) for a full route and layer map, [docs/infrastructure.md](docs/infrastructure.md) for request gateway, logging, and runtime layers, and [docs/CANONICALISATION.md](docs/CANONICALISATION.md) for how the codebase trims whitespace, casefolds, and handles byte-order marks (see also [docs/string-normalisation.md](docs/string-normalisation.md) for the per-field reference table).
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -724,6 +724,11 @@ GET  /api/admin/audit         # Admin-only audit events
 - Motion vocabulary and standard animations are documented in [docs/MOTION.md](docs/MOTION.md).
 - Components are structured for easy integration
 
+Design token reference and migration guides:
+
+- [docs/THEMING.md](docs/THEMING.md) — full catalogue of CSS custom properties, Tailwind color, spacing, focus-ring, and animation tokens with semantic roles and usage examples.
+- [docs/DESIGN_TOKEN_MIGRATION.md](docs/DESIGN_TOKEN_MIGRATION.md) — step-by-step guide for safely renaming or deprecating a token, including a PR checklist.
+
 ## API Endpoints
 
 ### Pagination

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Frontend application for the RemitWise remittance and financial planning platform.
 
-> **New contributors:** start with [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, verified test commands, and PR expectations, then read [docs/architecture.md](docs/architecture.md) for a full route and layer map, [docs/infrastructure.md](docs/infrastructure.md) for request gateway, logging, and runtime layers, and [docs/CANONICALISATION.md](docs/CANONICALISATION.md) for how the codebase trims whitespace, casefolds, and handles byte-order marks (see also [docs/string-normalisation.md](docs/string-normalisation.md) for the per-field reference table).
+> **New contributors:** start with [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, verified test commands, and PR expectations, then read [docs/architecture.md](docs/architecture.md) for a full route and layer map, [docs/infrastructure.md](docs/infrastructure.md) for request gateway, logging, and runtime layers, [docs/CANONICALISATION.md](docs/CANONICALISATION.md) for how the codebase trims whitespace, casefolds, and handles byte-order marks (see also [docs/string-normalisation.md](docs/string-normalisation.md) for the per-field reference table), and [docs/DESIGN_TOKEN_MIGRATION.md](docs/DESIGN_TOKEN_MIGRATION.md) for how to rename or deprecate a design token.
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Frontend application for the RemitWise remittance and financial planning platform.
 
-> **New contributors:** start with [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, verified test commands, and PR expectations. When building UI, follow the [component lifecycle](docs/COMPONENT_LIFECYCLE.md) from Figma and design tokens through stories, tests, and production. Then read [docs/architecture.md](docs/architecture.md) for a full route and layer map, and [docs/infrastructure.md](docs/infrastructure.md) for request gateway, logging, and runtime layers.
+> **New contributors:** start with [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, verified test commands, and PR expectations, then read [docs/architecture.md](docs/architecture.md) for a full route and layer map, [docs/infrastructure.md](docs/infrastructure.md) for request gateway, logging, and runtime layers, and [docs/string-normalisation.md](docs/string-normalisation.md) for how the codebase trims whitespace, casefolds, and handles byte-order marks.
 
 ## Overview
 

--- a/docs/DESIGN_TOKEN_MIGRATION.md
+++ b/docs/DESIGN_TOKEN_MIGRATION.md
@@ -1,0 +1,269 @@
+# Design Token Migration
+
+**Audience:** contributors renaming, replacing, or retiring a design token.
+
+This document covers the two operations that are easy to get wrong —
+**renaming** a token and **deprecating** one — and walks through each with real
+examples from this codebase. For the full catalogue of tokens and their semantic
+roles see [docs/THEMING.md](THEMING.md).
+
+---
+
+## Table of Contents
+
+1. [Token locations](#token-locations)
+2. [Renaming a token](#renaming-a-token)
+3. [Deprecating a token](#deprecating-a-token)
+4. [Checklist](#checklist)
+
+---
+
+## Token locations
+
+The design system has two authoritative sources. Both must be kept in sync
+whenever a token changes.
+
+| Source | File | Controls |
+|--------|------|----------|
+| CSS custom properties | `app/globals.css` | Global values consumed by raw CSS (`var(--accent)`, etc.) |
+| Tailwind theme extensions | `tailwind.config.js` | Utility class names (`bg-brand-red`, `text-status-error-fg`, etc.) |
+
+Class names are built at **compile time** by Tailwind. A token that no longer
+exists in `tailwind.config.js` silently produces no CSS — the class is dropped
+without an error, so visual regressions are the only signal. This is why the
+steps below require a project-wide search before removing anything.
+
+---
+
+## Renaming a token
+
+Renaming means the old name disappears entirely and every reference is updated
+to the new name in a single PR.
+
+### Step 1 — Find every usage
+
+Run a case-sensitive search for the old token name across all source files:
+
+```bash
+# Example: renaming brand.red → brand.primary
+grep -r "brand-red" app/ components/ lib/ --include="*.tsx" --include="*.ts" --include="*.css" -l
+```
+
+Also check plain CSS files and `globals.css` for any `var(--accent)` references
+if the matching CSS custom property is also changing.
+
+### Step 2 — Add the new token alongside the old one
+
+In `tailwind.config.js`, add the new token **before** removing the old one so
+the build stays green while you update usages:
+
+```js
+// tailwind.config.js
+colors: {
+  brand: {
+    red: "#D72323",        // keep until all usages are migrated
+    primary: "#D72323",    // new canonical name — same value for now
+    redHover: "#B91C1C",
+  },
+}
+```
+
+For a CSS custom property, add the alias in `globals.css`:
+
+```css
+:root {
+  --accent: #dc2626;         /* keep until all usages are migrated */
+  --brand-primary: #dc2626;  /* new canonical name */
+}
+```
+
+### Step 3 — Update every usage
+
+Replace all occurrences of the old class name with the new one. Real example —
+`brand-red` is used in at least these files today:
+
+```
+app/not-found.tsx
+components/Dashboard/DashboardHeader.tsx
+components/Dashboard/WhatsNewPanel.tsx
+```
+
+A typical diff for one component:
+
+```diff
+- <span className="w-2 h-2 rounded-full bg-brand-red animate-neon-pulse" />
+- <span className="text-brand-red text-sm font-semibold tracking-wide">
++ <span className="w-2 h-2 rounded-full bg-brand-primary animate-neon-pulse" />
++ <span className="text-brand-primary text-sm font-semibold tracking-wide">
+```
+
+### Step 4 — Remove the old token
+
+Once every reference is gone, delete the old entry from `tailwind.config.js`
+and `globals.css`:
+
+```js
+// tailwind.config.js — after all usages have been updated
+colors: {
+  brand: {
+    // red: "#D72323",  ← removed
+    primary: "#D72323",
+    redHover: "#B91C1C",
+  },
+}
+```
+
+### Step 5 — Build and verify
+
+```bash
+npm run lint
+npm run build
+```
+
+A successful build with no lint errors confirms Tailwind did not silently drop
+any class. Spot-check the affected components in the browser to confirm the
+rendered output is unchanged.
+
+### Step 6 — Update the token catalogue
+
+Update the tables in [docs/THEMING.md](THEMING.md) to reflect the new name.
+Remove the old row and add the new one with the same value and semantic role
+description. Do this in the same PR as the rename — orphaned documentation
+misleads the next contributor.
+
+---
+
+## Deprecating a token
+
+Deprecation is the right choice when a token needs to live on temporarily —
+for example when the old name is referenced by a design spec that has not been
+updated yet, or when you want a multi-PR migration window.
+
+### Step 1 — Mark the token deprecated in both sources
+
+In `tailwind.config.js`, add a comment:
+
+```js
+// tailwind.config.js
+colors: {
+  brand: {
+    /** @deprecated Use `brand.primary` instead. Remove after <target date or issue #>. */
+    red: "#D72323",
+    primary: "#D72323",   // canonical replacement
+    redHover: "#B91C1C",
+  },
+}
+```
+
+In `globals.css`, mark the variable:
+
+```css
+:root {
+  /* @deprecated – use --brand-primary. Remove after issue #NNN is closed. */
+  --accent: #dc2626;
+  --brand-primary: #dc2626;
+}
+```
+
+### Step 2 — Open a tracking issue
+
+File a follow-up issue titled `Remove deprecated token brand.red` and paste the
+grep output from Step 1 of [Renaming a token](#renaming-a-token) as the task
+list. Reference that issue number in the deprecation comment so it is never
+"just a comment":
+
+```js
+/** @deprecated Use `brand.primary`. Tracked in #NNN. */
+red: "#D72323",
+```
+
+### Step 3 — Do not introduce new usages
+
+Add a note to [docs/THEMING.md](THEMING.md) marking the token deprecated:
+
+```markdown
+| `brand.red` | `#D72323` | **Deprecated.** Use `brand.primary`. Tracked in #NNN. | `bg-brand-red` |
+```
+
+This surfaces in PR reviews: any new `bg-brand-red` in a diff becomes a
+conversation starter.
+
+### Step 4 — Complete the migration
+
+When all usages have been replaced — across PRs if necessary — follow Steps 4–6
+of [Renaming a token](#renaming-a-token) to remove the old entry and clean up
+the documentation.
+
+---
+
+## Real token inventory for reference
+
+The tables below list the tokens most likely to need migration, grouped by
+where they are used in the codebase today.
+
+### Status tokens — `components/` and `app/family/`
+
+These tokens appear across `components/Toast.tsx`,
+`components/Bills/BillsCard.tsx`, and `app/family/components/`. They follow a
+four-variant × four-role pattern. Renaming any one of them requires updating
+all four files.
+
+```
+status.success.fg      → text-status-success-fg   (progress fill, icon colour)
+status.success.bg      → bg-status-success-bg     (badge background)
+status.success.border  → border-status-success-border
+status.success.soft    → bg-status-success-soft   (toast panel background)
+
+status.error.*         (same four roles — used in FamilyMemberStatCard, BillsCard)
+status.warning.*       (same four roles — used in FamilyMemberDetailDrawer, Toast)
+status.info.*          (same four roles — available, currently used in info badges)
+```
+
+### Brand tokens — `app/` and `components/Dashboard/`
+
+```
+brand.red       → bg-brand-red, text-brand-red, border-brand-red/*
+brand.dark      → bg-brand-dark   (full-page dark canvas, e.g. app/not-found.tsx)
+brand.redHover  → hover:bg-brand-redHover
+```
+
+### Semantic spacing tokens — `tailwind.config.js`
+
+```
+space-xs  →  gap-space-xs, p-space-xs   (4px)
+space-sm  →  space-y-space-sm           (8px)
+space-md  →  p-space-md                 (16px)
+space-lg  →  gap-space-lg               (24px)
+space-xl  →  py-space-xl                (32px)
+```
+
+### CSS custom properties — `app/globals.css`
+
+```
+--accent           used for CSS-level accent styling (red, #dc2626)
+--card             used for card gradient surfaces
+--color-bg2        feeds into --card gradient (light: #f8fafc, dark: #0f0f0f)
+--color-bg3        feeds into --card gradient (light: #f1f5f9, dark: #0a0a0a)
+--foreground-rgb   feeds body text colour via rgb(var(--foreground-rgb))
+```
+
+---
+
+## Checklist
+
+Use this as a PR description checklist when renaming or deprecating a token.
+
+**Rename**
+- [ ] Searched all source files for the old token name
+- [ ] Added the new token in `tailwind.config.js` (and `globals.css` if applicable)
+- [ ] Updated every usage to the new class / variable name
+- [ ] Removed the old token from `tailwind.config.js` (and `globals.css`)
+- [ ] `npm run lint` passes
+- [ ] `npm run build` passes with no dropped classes
+- [ ] Updated the token table in [docs/THEMING.md](THEMING.md)
+
+**Deprecate**
+- [ ] Added `@deprecated` comment with replacement name and tracking issue number
+- [ ] Opened a follow-up issue and referenced it in the comment
+- [ ] Marked the token deprecated in the [docs/THEMING.md](THEMING.md) table
+- [ ] No new usages of the deprecated token introduced in this PR


### PR DESCRIPTION
Closes #1021

## Summary
Adds `docs/DESIGN_TOKEN_MIGRATION.md` — a step-by-step contributor guide
for safely renaming or deprecating a design token. Links added to the
Design Notes section in README.md alongside docs/THEMING.md so neither
doc is orphaned.

## What's covered
- **Token locations** — explains the two authoritative sources
  (`tailwind.config.js` and `globals.css`) and why a missing Tailwind
  token silently drops CSS with no build error
- **Renaming a token** — 6-step procedure: grep for usages → add new
  token alongside old → update all usages → remove old token → build
  verify → update THEMING.md
- **Deprecating a token** — 4-step procedure: add `@deprecated` comment
  with tracking issue → open follow-up issue → mark deprecated in
  THEMING.md → complete migration later
- **Real token inventory** — lists the actual `status.*`, `brand.*`,
  `space-*`, and CSS custom property tokens with their current file
  locations so contributors know exactly what to grep for
- **PR checklist** — copy-paste checklist for both rename and
  deprecation operations

All examples use real tokens and real files from the codebase — no
foo/bar placeholders.

## Files changed
- `docs/DESIGN_TOKEN_MIGRATION.md` — new document
- `README.md` — added links in the Design Notes section

## Testing
- No logic changed; documentation only.
- Existing lint, type-check, and test suite passes unchanged.
