### PR TITLE
feat: add fetchWithTimeout wrapper with per-endpoint policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ Every route handler under `app/api/` is composed from a small set of reusable de
 
 For authenticated browser-side requests, use the shared client API layer documented in [docs/client-api.md](docs/client-api.md). That guide covers when to use `apiClient` instead of raw `fetch`, the `401 -> refresh -> retry once` flow, session-expiry UI surfacing, and logout behavior.
 
+For server-side and third-party requests that need automatic abort on deadline, use the `fetchWithTimeout` wrapper documented in [docs/fetch-timeout.md](docs/fetch-timeout.md). Each endpoint declares its timeout in `lib/config/fetch-timeouts.ts`; the wrapper aborts and throws a `TimeoutError` if the deadline is exceeded. `apiClient` uses the same design for browser requests.
+
 ### Transaction Export
 
 Both the standalone **Transactions** page (`/transactions`) and the dashboard

--- a/docs/fetch-timeout.md
+++ b/docs/fetch-timeout.md
@@ -1,0 +1,148 @@
+# Fetch Timeout Wrapper
+
+`lib/fetch-timeout.ts` provides a drop-in `fetch` replacement that automatically
+aborts requests exceeding a configurable deadline.  The deadline for every
+endpoint is declared once in `lib/config/fetch-timeouts.ts` and re-used across
+the codebase — no more inline magic numbers.
+
+## Quick Start
+
+```ts
+import { fetchWithTimeout } from '@/lib/fetch-timeout';
+
+// Timeout resolved automatically from the per-endpoint policy table.
+const response = await fetchWithTimeout('/api/anchor/rates');
+
+// Override the timeout explicitly for a one-off call.
+const response = await fetchWithTimeout('/api/send', { method: 'POST', body }, 20_000);
+
+// Works with a caller AbortController — both signals are merged.
+const controller = new AbortController();
+const response = await fetchWithTimeout('/api/goals', { signal: controller.signal });
+```
+
+## API Reference
+
+### `fetchWithTimeout(url, options?, timeoutMs?)`
+
+| Parameter   | Type                     | Default                              | Description                                                                                                   |
+| ----------- | ------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `url`       | `string`                 | —                                    | The resource URL, passed straight through to `fetch`.                                                         |
+| `options`   | `RequestInit`            | `{}`                                 | Standard Fetch API options.  A caller-supplied `signal` is respected and composed with the timeout signal.    |
+| `timeoutMs` | `number` or `undefined`  | `getTimeoutForUrl(url)`              | Timeout in milliseconds.  When omitted the value comes from the per-endpoint policy table.  `0` disables it.  |
+
+**Returns** `Promise<Response>` — resolves with the `Response`, or rejects with:
+
+| Scenario                            | Error name       | Description                                               |
+| ----------------------------------- | ---------------- | --------------------------------------------------------- |
+| Deadline exceeded                   | `TimeoutError`   | `DOMException` with `name === 'TimeoutError'`.            |
+| Caller `AbortController` fires      | `AbortError`     | Re-thrown as-is from the underlying `fetch`.              |
+| Any other network/transport failure | varies           | Re-thrown unchanged.                                      |
+
+### Distinguishing a timeout from a deliberate abort
+
+```ts
+try {
+  const res = await fetchWithTimeout('/api/slow', {}, 3_000);
+} catch (err) {
+  if (err instanceof DOMException && err.name === 'TimeoutError') {
+    // deadline exceeded
+  } else if (err instanceof DOMException && err.name === 'AbortError') {
+    // caller aborted intentionally
+  } else {
+    // network error
+  }
+}
+```
+
+## Per-Endpoint Policy
+
+All timeout values live in `lib/config/fetch-timeouts.ts`.  **Do not
+hard-code timeouts at call sites** — add or update an entry in that file so the
+policy stays auditable and consistent.
+
+### Policy table
+
+| Pattern                   | Constant                       | Value  | Rationale                                                  |
+| ------------------------- | ------------------------------ | ------ | ---------------------------------------------------------- |
+| `/api/auth/nonce`         | `AUTH_NONCE_TIMEOUT_MS`        | 5 s    | Lightweight; fail fast.                                    |
+| `/api/auth/login`         | `AUTH_LOGIN_TIMEOUT_MS`        | 8 s    | Crypto verification on the server.                         |
+| `/api/auth/refresh`       | `AUTH_REFRESH_TIMEOUT_MS`      | 5 s    | Token refresh must be fast so it doesn't block requests.   |
+| `/api/anchor/deposit`     | `ANCHOR_DEPOSIT_TIMEOUT_MS`    | 15 s   | Provision interactive anchor session.                      |
+| `/api/anchor/withdraw`    | `ANCHOR_WITHDRAW_TIMEOUT_MS`   | 15 s   | Provision interactive anchor session.                      |
+| `/api/anchor/rates`       | `ANCHOR_RATES_TIMEOUT_MS`      | 5 s    | Cached CDN read; tight deadline.                           |
+| `/api/anchor` (generic)   | `ANCHOR_DEFAULT_TIMEOUT_MS`    | 5 s    | Catch-all for other anchor routes.                         |
+| `/api/send`               | `SEND_TIMEOUT_MS`              | 20 s   | Signs + propagates a Stellar transaction.                  |
+| `/api/health`             | `HEALTH_TIMEOUT_MS`            | 3 s    | Uptime monitors; must be fast.                             |
+| `/api/metrics`            | `METRICS_TIMEOUT_MS`           | 3 s    | Best-effort telemetry.                                     |
+| `/api/contracts`          | `CONTRACT_READ_TIMEOUT_MS`     | 12 s   | Soroban RPC round-trip.                                    |
+| `/api/goals`              | `CONTRACT_READ_TIMEOUT_MS`     | 12 s   | Soroban RPC round-trip.                                    |
+| `/api/bills`              | `CONTRACT_READ_TIMEOUT_MS`     | 12 s   | Soroban RPC round-trip.                                    |
+| `/api/insurance`          | `CONTRACT_READ_TIMEOUT_MS`     | 12 s   | Soroban RPC round-trip.                                    |
+| `/api/split`              | `CONTRACT_READ_TIMEOUT_MS`     | 12 s   | Soroban RPC round-trip.                                    |
+| `/api/family`             | `CONTRACT_READ_TIMEOUT_MS`     | 12 s   | Soroban RPC round-trip.                                    |
+| _(anything else)_         | `DEFAULT_FETCH_TIMEOUT_MS`     | 10 s   | Safe default for unknown routes.                           |
+
+### Matching algorithm
+
+`getTimeoutForUrl(url)` iterates `ENDPOINT_TIMEOUTS` in declaration order and
+returns the timeout for the **first** entry whose key appears anywhere in `url`
+(`url.includes(key)`).  More-specific patterns must therefore appear **before**
+more-general ones in the array.
+
+```ts
+import { getTimeoutForUrl } from '@/lib/config/fetch-timeouts';
+
+getTimeoutForUrl('/api/anchor/rates');   // → 5_000  (ANCHOR_RATES_TIMEOUT_MS)
+getTimeoutForUrl('/api/anchor/deposit'); // → 15_000 (ANCHOR_DEPOSIT_TIMEOUT_MS)
+getTimeoutForUrl('/api/unknown');        // → 10_000 (DEFAULT_FETCH_TIMEOUT_MS)
+```
+
+### Adding a new endpoint timeout
+
+1. Open `lib/config/fetch-timeouts.ts`.
+2. Add a named constant: `export const MY_ROUTE_TIMEOUT_MS = 7_000;`
+3. Add an entry to `ENDPOINT_TIMEOUTS` in the right position (more specific → less specific):
+   ```ts
+   ['/api/my-route', MY_ROUTE_TIMEOUT_MS],
+   ```
+4. Update this table in `docs/fetch-timeout.md`.
+
+## Signal Composition
+
+When `options.signal` is provided the wrapper merges both signals so the request
+is cancelled when **either** the caller aborts **or** the deadline fires.  This
+means you can pass a component-lifecycle controller and still get an automatic
+timeout — the two do not interfere.
+
+```ts
+const controller = new AbortController();
+useEffect(() => {
+  fetchWithTimeout('/api/goals', { signal: controller.signal });
+  return () => controller.abort(); // cancels on unmount, not a TimeoutError
+}, []);
+```
+
+## Relationship to `apiClient`
+
+`apiClient` (`lib/client/apiClient.ts`) has its own per-request timeout built
+in (default 10 s, configurable via `timeout: number`).  Use it for
+**authenticated browser requests** to RemitWise's own API routes because it also
+handles session refresh and the `401 → refresh → retry once` flow.
+
+Use `fetchWithTimeout` directly when:
+
+- Code runs on the **server** (route handlers, server actions).
+- You are calling a **third-party service** (e.g. the Anchor platform).
+- You want the per-endpoint policy without the browser session machinery.
+
+## Tests
+
+Unit tests live at `tests/unit/fetch-timeout.test.ts` and cover:
+
+- Happy path (successful response, options pass-through).
+- Timeout fires → `TimeoutError` (fake timers).
+- Caller abort → original error re-thrown.
+- Signal composition (merged signal passed to `fetch`).
+- Per-endpoint policy lookup (`getTimeoutForUrl` exhaustive).
+- `ENDPOINT_TIMEOUTS` table sanity (no duplicate keys, positive integers).

--- a/lib/anchor/client.ts
+++ b/lib/anchor/client.ts
@@ -36,7 +36,17 @@ export interface AnchorFlowResponse {
     [key: string]: unknown;
 }
 
-export const DEFAULT_TIMEOUT_MS = 5000;
+import { fetchWithTimeout } from '../fetch-timeout';
+import {
+  ANCHOR_DEFAULT_TIMEOUT_MS,
+} from '../config/fetch-timeouts';
+
+/**
+ * @deprecated Import {@link ANCHOR_DEFAULT_TIMEOUT_MS} from
+ *   `lib/config/fetch-timeouts` instead. This re-export is kept for backwards
+ *   compatibility only and will be removed in a future release.
+ */
+export const DEFAULT_TIMEOUT_MS = ANCHOR_DEFAULT_TIMEOUT_MS;
 export const MAX_RETRY_ATTEMPTS = 3;
 export const RETRY_BASE_DELAY_MS = 200;
 
@@ -66,24 +76,13 @@ export class AnchorClient {
         return Boolean(this.baseUrl);
     }
 
-    private async fetchWithTimeout(url: string, options: RequestInit = {}, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<Response> {
-        const controller = new AbortController();
-        const id = setTimeout(() => controller.abort(), timeoutMs);
-
-        try {
-            const response = await fetch(url, {
-                ...options,
-                signal: controller.signal,
-            });
-            clearTimeout(id);
-            return response;
-        } catch (error: unknown) {
-            clearTimeout(id);
-            if (error instanceof Error && error.name === 'AbortError') {
-                throw new Error(`Request timed out after ${timeoutMs}ms`);
-            }
-            throw error;
-        }
+    /**
+     * Delegates to the shared {@link fetchWithTimeout} wrapper from
+     * `lib/fetch-timeout.ts`, which resolves the timeout from the
+     * per-endpoint policy table when none is supplied explicitly.
+     */
+    private async fetchWithTimeout(url: string, options: RequestInit = {}, timeoutMs?: number): Promise<Response> {
+        return fetchWithTimeout(url, options, timeoutMs);
     }
 
     private async sleep(ms: number): Promise<void> {

--- a/lib/config/fetch-timeouts.ts
+++ b/lib/config/fetch-timeouts.ts
@@ -1,0 +1,150 @@
+/**
+ * Per-endpoint fetch timeout policy.
+ *
+ * Every entry declares the maximum number of milliseconds the caller will wait
+ * before the request is aborted. Route patterns are matched with
+ * {@link getTimeoutForUrl} using a prefix/contains check, falling back to
+ * {@link DEFAULT_FETCH_TIMEOUT_MS} when no rule matches.
+ *
+ * ## Conventions
+ * - Keep all values in this file. Do **not** hard-code timeouts inline at call
+ *   sites — reference these constants so they remain auditable and consistent.
+ * - Use snake_case for the constant name and mirror the route path as closely as
+ *   possible so the mapping is obvious at a glance.
+ * - When a rule covers a whole namespace (e.g. `/api/anchor`) all routes under
+ *   that namespace inherit the same limit unless overridden with a more specific
+ *   key.
+ *
+ * See {@link getTimeoutForUrl} for the matching algorithm.
+ */
+
+// ── Base default ─────────────────────────────────────────────────────────────
+
+/**
+ * Fallback timeout applied to any URL that has no specific policy entry.
+ * Matches the `apiClient` default of 10 s.
+ */
+export const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
+
+// ── Anchor platform routes ────────────────────────────────────────────────────
+
+/**
+ * Exchange-rate lookups are read-only and served from a CDN cache, so a tight
+ * deadline is appropriate.
+ */
+export const ANCHOR_RATES_TIMEOUT_MS = 5_000;
+
+/**
+ * Interactive deposit/withdraw flows hit the anchor's backend and may need to
+ * provision a session. Allow a bit more room than a cached read.
+ */
+export const ANCHOR_DEPOSIT_TIMEOUT_MS = 15_000;
+
+/** Same reasoning as {@link ANCHOR_DEPOSIT_TIMEOUT_MS}. */
+export const ANCHOR_WITHDRAW_TIMEOUT_MS = 15_000;
+
+/**
+ * Generic anchor timeout used for any anchor route that does not have a more
+ * specific entry.
+ */
+export const ANCHOR_DEFAULT_TIMEOUT_MS = 5_000;
+
+// ── Auth routes ───────────────────────────────────────────────────────────────
+
+/** Nonce generation is lightweight; fail fast. */
+export const AUTH_NONCE_TIMEOUT_MS = 5_000;
+
+/** Signature verification involves a crypto operation server-side. */
+export const AUTH_LOGIN_TIMEOUT_MS = 8_000;
+
+/** Token refresh should be fast to avoid blocking subsequent requests. */
+export const AUTH_REFRESH_TIMEOUT_MS = 5_000;
+
+// ── Contract/RPC routes ───────────────────────────────────────────────────────
+
+/**
+ * Contract reads go through the Soroban RPC node and may take longer under
+ * network congestion.
+ */
+export const CONTRACT_READ_TIMEOUT_MS = 12_000;
+
+/**
+ * Sending a transaction involves signing and network propagation, so allow a
+ * generous window.
+ */
+export const SEND_TIMEOUT_MS = 20_000;
+
+// ── Health / telemetry ────────────────────────────────────────────────────────
+
+/** Health checks must be fast; they are used by uptime monitors. */
+export const HEALTH_TIMEOUT_MS = 3_000;
+
+/** Metrics collection is best-effort; do not block on it. */
+export const METRICS_TIMEOUT_MS = 3_000;
+
+// ── Policy map ────────────────────────────────────────────────────────────────
+
+/**
+ * A map from URL fragment (prefix or substring) to timeout in milliseconds.
+ *
+ * The map is evaluated in declaration order by {@link getTimeoutForUrl}; the
+ * first matching key wins. More-specific patterns should therefore appear before
+ * more-general ones.
+ */
+export const ENDPOINT_TIMEOUTS: ReadonlyArray<readonly [string, number]> = [
+  // Auth
+  ['/api/auth/nonce', AUTH_NONCE_TIMEOUT_MS],
+  ['/api/auth/login', AUTH_LOGIN_TIMEOUT_MS],
+  ['/api/auth/refresh', AUTH_REFRESH_TIMEOUT_MS],
+
+  // Anchor — specific routes first, generic last
+  ['/api/anchor/deposit', ANCHOR_DEPOSIT_TIMEOUT_MS],
+  ['/api/anchor/withdraw', ANCHOR_WITHDRAW_TIMEOUT_MS],
+  ['/api/anchor/rates', ANCHOR_RATES_TIMEOUT_MS],
+  ['/api/anchor', ANCHOR_DEFAULT_TIMEOUT_MS],
+
+  // Send / remittance
+  ['/api/send', SEND_TIMEOUT_MS],
+
+  // Health + metrics
+  ['/api/health', HEALTH_TIMEOUT_MS],
+  ['/api/metrics', METRICS_TIMEOUT_MS],
+
+  // Contract interactions
+  ['/api/contracts', CONTRACT_READ_TIMEOUT_MS],
+  ['/api/goals', CONTRACT_READ_TIMEOUT_MS],
+  ['/api/bills', CONTRACT_READ_TIMEOUT_MS],
+  ['/api/insurance', CONTRACT_READ_TIMEOUT_MS],
+  ['/api/split', CONTRACT_READ_TIMEOUT_MS],
+  ['/api/family', CONTRACT_READ_TIMEOUT_MS],
+] as const;
+
+// ── Lookup helper ─────────────────────────────────────────────────────────────
+
+/**
+ * Returns the configured timeout in milliseconds for the given URL.
+ *
+ * Matching algorithm:
+ * 1. Iterate {@link ENDPOINT_TIMEOUTS} in declaration order.
+ * 2. Return the timeout for the first entry whose key appears anywhere in
+ *    `url` (i.e. `url.includes(key)`).
+ * 3. Fall back to {@link DEFAULT_FETCH_TIMEOUT_MS} when nothing matches.
+ *
+ * @param url - The full URL (or path) of the request.
+ * @returns Timeout in milliseconds.
+ *
+ * @example
+ * ```ts
+ * getTimeoutForUrl('/api/anchor/rates');  // → 5_000
+ * getTimeoutForUrl('/api/anchor/deposit'); // → 15_000
+ * getTimeoutForUrl('/api/unknown');        // → 10_000 (default)
+ * ```
+ */
+export function getTimeoutForUrl(url: string): number {
+  for (const [pattern, timeout] of ENDPOINT_TIMEOUTS) {
+    if (url.includes(pattern)) {
+      return timeout;
+    }
+  }
+  return DEFAULT_FETCH_TIMEOUT_MS;
+}

--- a/lib/fetch-timeout.ts
+++ b/lib/fetch-timeout.ts
@@ -1,0 +1,184 @@
+/**
+ * `fetchWithTimeout` — a lightweight `fetch` wrapper that aborts the request
+ * after a configurable deadline.
+ *
+ * ## Quick start
+ *
+ * ```ts
+ * import { fetchWithTimeout } from '@/lib/fetch-timeout';
+ *
+ * // Uses the per-endpoint policy from lib/config/fetch-timeouts automatically.
+ * const response = await fetchWithTimeout('/api/anchor/rates');
+ *
+ * // Override the timeout for a one-off call.
+ * const response = await fetchWithTimeout('/api/send', { method: 'POST', body }, 20_000);
+ * ```
+ *
+ * ## Per-endpoint policy
+ *
+ * When no explicit `timeoutMs` is passed the timeout is resolved by calling
+ * {@link getTimeoutForUrl} from `lib/config/fetch-timeouts.ts`. That function
+ * walks the {@link ENDPOINT_TIMEOUTS} table in declaration order and returns
+ * the timeout for the first matching pattern. Unknown routes fall back to
+ * {@link DEFAULT_FETCH_TIMEOUT_MS} (10 s).
+ *
+ * ## AbortController composition
+ *
+ * If `options.signal` is already set the module **merges** both signals, so the
+ * request is cancelled when _either_ the caller's own controller fires _or_ the
+ * deadline fires — whichever comes first. The original signal is never replaced.
+ *
+ * ## Error surface
+ *
+ * | Scenario                              | Thrown error                                      |
+ * |---------------------------------------|---------------------------------------------------|
+ * | Deadline fires before response        | `DOMException` with `name === 'TimeoutError'`     |
+ * | Caller signal fires before response   | Re-throws as-is (typically `AbortError`)          |
+ * | Any other network / fetch error       | Re-thrown unchanged                               |
+ *
+ * @module
+ */
+
+import { getTimeoutForUrl } from './config/fetch-timeouts';
+
+export type { FetchWithTimeoutOptions };
+
+/** Options accepted by {@link fetchWithTimeout} in addition to `RequestInit`. */
+interface FetchWithTimeoutOptions extends RequestInit {
+  /**
+   * Optional `AbortSignal` from the caller.  When provided it is combined with
+   * the internal timeout signal — aborting either one cancels the request.
+   */
+  signal?: AbortSignal | null;
+}
+
+/**
+ * Performs a `fetch` request that is automatically aborted after `timeoutMs`
+ * milliseconds.
+ *
+ * @param url      - The resource URL (passed straight through to `fetch`).
+ * @param options  - Standard `RequestInit` options.  A caller-supplied `signal`
+ *                   is respected and composed with the timeout signal.
+ * @param timeoutMs - Timeout in milliseconds.  When omitted the value is
+ *                   resolved from the per-endpoint policy table via
+ *                   {@link getTimeoutForUrl}.  Pass `0` to disable the timeout.
+ * @returns A `Promise` that resolves with the `Response` or rejects with a
+ *          `DOMException` (`name === 'TimeoutError'`) when the deadline fires.
+ *
+ * @example Default per-endpoint policy
+ * ```ts
+ * const res = await fetchWithTimeout('/api/anchor/rates');
+ * ```
+ *
+ * @example Explicit timeout override
+ * ```ts
+ * const res = await fetchWithTimeout('/api/send', { method: 'POST', body }, 20_000);
+ * ```
+ *
+ * @example Combined with a caller signal
+ * ```ts
+ * const controller = new AbortController();
+ * const res = await fetchWithTimeout('/api/goals', { signal: controller.signal });
+ * // controller.abort() still works even though a timeout signal is also active.
+ * ```
+ */
+export async function fetchWithTimeout(
+  url: string,
+  options: FetchWithTimeoutOptions = {},
+  timeoutMs?: number
+): Promise<Response> {
+  const resolvedTimeout = timeoutMs ?? getTimeoutForUrl(url);
+  const { signal: callerSignal, ...rest } = options;
+
+  // Disabled timeout: fall back to a plain fetch, preserving the caller signal.
+  if (resolvedTimeout <= 0) {
+    return fetch(url, callerSignal != null ? { ...rest, signal: callerSignal } : rest);
+  }
+
+  const timeoutController = new AbortController();
+  const timerId = setTimeout(() => {
+    timeoutController.abort(
+      new DOMException(
+        `Request to ${url} timed out after ${resolvedTimeout}ms`,
+        'TimeoutError'
+      )
+    );
+  }, resolvedTimeout);
+
+  // Build the effective signal by merging caller + timeout.
+  const effectiveSignal = mergeSignals(
+    callerSignal ?? null,
+    timeoutController.signal
+  );
+
+  try {
+    return await fetch(url, { ...rest, signal: effectiveSignal });
+  } catch (error: unknown) {
+    // If the timeout fired, surface a clean TimeoutError to the caller so it
+    // can be distinguished from a deliberate abort.
+    if (timeoutController.signal.aborted) {
+      const reason = timeoutController.signal.reason;
+      // reason is already the DOMException we created above.
+      throw reason instanceof Error
+        ? reason
+        : new DOMException(
+            `Request to ${url} timed out after ${resolvedTimeout}ms`,
+            'TimeoutError'
+          );
+    }
+
+    // The caller's own signal fired — re-throw as-is so callers can inspect the
+    // original abort reason.
+    throw error;
+  } finally {
+    clearTimeout(timerId);
+  }
+}
+
+/**
+ * Merges two `AbortSignal`s into a single combined signal that fires when
+ * **either** source fires.  Returns the `timeoutSignal` directly when
+ * `callerSignal` is `null` to avoid creating unnecessary controllers.
+ *
+ * @internal
+ */
+function mergeSignals(
+  callerSignal: AbortSignal | null,
+  timeoutSignal: AbortSignal
+): AbortSignal {
+  if (callerSignal === null) {
+    return timeoutSignal;
+  }
+
+  // If either is already aborted, create a pre-aborted controller.
+  if (callerSignal.aborted) {
+    const c = new AbortController();
+    c.abort(callerSignal.reason);
+    return c.signal;
+  }
+  if (timeoutSignal.aborted) {
+    const c = new AbortController();
+    c.abort(timeoutSignal.reason);
+    return c.signal;
+  }
+
+  const merged = new AbortController();
+
+  const onCallerAbort = () => merged.abort(callerSignal.reason);
+  const onTimeoutAbort = () => merged.abort(timeoutSignal.reason);
+
+  callerSignal.addEventListener('abort', onCallerAbort, { once: true });
+  timeoutSignal.addEventListener('abort', onTimeoutAbort, { once: true });
+
+  // Clean up listeners when the merged signal fires to prevent memory leaks.
+  merged.signal.addEventListener(
+    'abort',
+    () => {
+      callerSignal.removeEventListener('abort', onCallerAbort);
+      timeoutSignal.removeEventListener('abort', onTimeoutAbort);
+    },
+    { once: true }
+  );
+
+  return merged.signal;
+}

--- a/tests/unit/fetch-timeout.test.ts
+++ b/tests/unit/fetch-timeout.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Unit tests for:
+ *   - lib/fetch-timeout.ts  (fetchWithTimeout)
+ *   - lib/config/fetch-timeouts.ts  (getTimeoutForUrl, ENDPOINT_TIMEOUTS)
+ */
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { fetchWithTimeout } from '../../lib/fetch-timeout';
+import {
+  getTimeoutForUrl,
+  ENDPOINT_TIMEOUTS,
+  DEFAULT_FETCH_TIMEOUT_MS,
+  ANCHOR_RATES_TIMEOUT_MS,
+  ANCHOR_DEPOSIT_TIMEOUT_MS,
+  ANCHOR_WITHDRAW_TIMEOUT_MS,
+  ANCHOR_DEFAULT_TIMEOUT_MS,
+  AUTH_NONCE_TIMEOUT_MS,
+  AUTH_LOGIN_TIMEOUT_MS,
+  AUTH_REFRESH_TIMEOUT_MS,
+  HEALTH_TIMEOUT_MS,
+  METRICS_TIMEOUT_MS,
+  SEND_TIMEOUT_MS,
+  CONTRACT_READ_TIMEOUT_MS,
+} from '../../lib/config/fetch-timeouts';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a `fetch` mock whose requests hang until the supplied `AbortSignal`
+ * fires, then reject with the abort reason.
+ */
+function hangingFetch() {
+  return vi.fn(
+    (_url: string, opts: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        const signal = opts.signal as AbortSignal;
+        if (signal?.aborted) {
+          reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+          return;
+        }
+        signal?.addEventListener('abort', () =>
+          reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
+        );
+      })
+  );
+}
+
+/** Returns a `fetch` mock that resolves immediately with a 200 response. */
+function okFetch() {
+  return vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+}
+
+// ── getTimeoutForUrl ──────────────────────────────────────────────────────────
+
+describe('getTimeoutForUrl', () => {
+  it('returns DEFAULT_FETCH_TIMEOUT_MS for an unknown route', () => {
+    expect(getTimeoutForUrl('/api/unknown/route')).toBe(DEFAULT_FETCH_TIMEOUT_MS);
+  });
+
+  it('returns DEFAULT_FETCH_TIMEOUT_MS for an empty string', () => {
+    expect(getTimeoutForUrl('')).toBe(DEFAULT_FETCH_TIMEOUT_MS);
+  });
+
+  it('returns ANCHOR_RATES_TIMEOUT_MS for /api/anchor/rates', () => {
+    expect(getTimeoutForUrl('/api/anchor/rates')).toBe(ANCHOR_RATES_TIMEOUT_MS);
+  });
+
+  it('returns ANCHOR_DEPOSIT_TIMEOUT_MS for /api/anchor/deposit', () => {
+    expect(getTimeoutForUrl('/api/anchor/deposit')).toBe(ANCHOR_DEPOSIT_TIMEOUT_MS);
+  });
+
+  it('returns ANCHOR_WITHDRAW_TIMEOUT_MS for /api/anchor/withdraw', () => {
+    expect(getTimeoutForUrl('/api/anchor/withdraw')).toBe(ANCHOR_WITHDRAW_TIMEOUT_MS);
+  });
+
+  it('returns ANCHOR_DEFAULT_TIMEOUT_MS for a generic /api/anchor route', () => {
+    expect(getTimeoutForUrl('/api/anchor/something-else')).toBe(ANCHOR_DEFAULT_TIMEOUT_MS);
+  });
+
+  it('returns AUTH_NONCE_TIMEOUT_MS for /api/auth/nonce', () => {
+    expect(getTimeoutForUrl('/api/auth/nonce')).toBe(AUTH_NONCE_TIMEOUT_MS);
+  });
+
+  it('returns AUTH_LOGIN_TIMEOUT_MS for /api/auth/login', () => {
+    expect(getTimeoutForUrl('/api/auth/login')).toBe(AUTH_LOGIN_TIMEOUT_MS);
+  });
+
+  it('returns AUTH_REFRESH_TIMEOUT_MS for /api/auth/refresh', () => {
+    expect(getTimeoutForUrl('/api/auth/refresh')).toBe(AUTH_REFRESH_TIMEOUT_MS);
+  });
+
+  it('returns HEALTH_TIMEOUT_MS for /api/health', () => {
+    expect(getTimeoutForUrl('/api/health')).toBe(HEALTH_TIMEOUT_MS);
+  });
+
+  it('returns METRICS_TIMEOUT_MS for /api/metrics', () => {
+    expect(getTimeoutForUrl('/api/metrics')).toBe(METRICS_TIMEOUT_MS);
+  });
+
+  it('returns SEND_TIMEOUT_MS for /api/send', () => {
+    expect(getTimeoutForUrl('/api/send')).toBe(SEND_TIMEOUT_MS);
+  });
+
+  it('returns CONTRACT_READ_TIMEOUT_MS for /api/goals', () => {
+    expect(getTimeoutForUrl('/api/goals')).toBe(CONTRACT_READ_TIMEOUT_MS);
+  });
+
+  it('returns CONTRACT_READ_TIMEOUT_MS for /api/bills', () => {
+    expect(getTimeoutForUrl('/api/bills')).toBe(CONTRACT_READ_TIMEOUT_MS);
+  });
+
+  it('returns CONTRACT_READ_TIMEOUT_MS for /api/insurance', () => {
+    expect(getTimeoutForUrl('/api/insurance')).toBe(CONTRACT_READ_TIMEOUT_MS);
+  });
+
+  it('returns CONTRACT_READ_TIMEOUT_MS for /api/split', () => {
+    expect(getTimeoutForUrl('/api/split')).toBe(CONTRACT_READ_TIMEOUT_MS);
+  });
+
+  it('returns CONTRACT_READ_TIMEOUT_MS for /api/family', () => {
+    expect(getTimeoutForUrl('/api/family')).toBe(CONTRACT_READ_TIMEOUT_MS);
+  });
+
+  it('matches by substring — absolute URL still resolves', () => {
+    expect(getTimeoutForUrl('https://example.com/api/anchor/rates?v=1')).toBe(
+      ANCHOR_RATES_TIMEOUT_MS
+    );
+  });
+
+  it('more-specific anchor routes win over the generic /api/anchor rule', () => {
+    // /api/anchor/deposit and /api/anchor/withdraw both contain /api/anchor, but
+    // the more-specific keys appear earlier in ENDPOINT_TIMEOUTS, so they win.
+    const depositIdx = ENDPOINT_TIMEOUTS.findIndex(([k]) => k === '/api/anchor/deposit');
+    const genericIdx = ENDPOINT_TIMEOUTS.findIndex(([k]) => k === '/api/anchor');
+    expect(depositIdx).toBeLessThan(genericIdx);
+  });
+});
+
+// ── ENDPOINT_TIMEOUTS sanity ─────────────────────────────────────────────────
+
+describe('ENDPOINT_TIMEOUTS table', () => {
+  it('has no duplicate keys', () => {
+    const keys = ENDPOINT_TIMEOUTS.map(([k]) => k);
+    const unique = new Set(keys);
+    expect(unique.size).toBe(keys.length);
+  });
+
+  it('every timeout value is a positive integer', () => {
+    for (const [key, ms] of ENDPOINT_TIMEOUTS) {
+      expect(ms, `timeout for "${key}" should be > 0`).toBeGreaterThan(0);
+      expect(Number.isInteger(ms), `timeout for "${key}" should be an integer`).toBe(true);
+    }
+  });
+
+  it('DEFAULT_FETCH_TIMEOUT_MS is a positive integer', () => {
+    expect(DEFAULT_FETCH_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(Number.isInteger(DEFAULT_FETCH_TIMEOUT_MS)).toBe(true);
+  });
+});
+
+// ── fetchWithTimeout — happy path ─────────────────────────────────────────────
+
+describe('fetchWithTimeout — successful requests', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', okFetch());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the response on success', async () => {
+    const response = await fetchWithTimeout('/api/health');
+    expect(response.status).toBe(200);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the URL and options through to fetch', async () => {
+    await fetchWithTimeout('/api/anchor/rates', { headers: { 'X-Custom': 'yes' } });
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/anchor/rates',
+      expect.objectContaining({ headers: { 'X-Custom': 'yes' } })
+    );
+  });
+
+  it('resolves the timeout from the policy table when none is specified', async () => {
+    await fetchWithTimeout('/api/anchor/rates');
+    // The signal passed to fetch should be an AbortSignal (not null/undefined).
+    const callArgs = (fetch as any).mock.calls[0][1];
+    expect(callArgs.signal).toBeDefined();
+    expect(typeof callArgs.signal.aborted).toBe('boolean');
+  });
+
+  it('uses an explicit timeout override instead of the policy table', async () => {
+    // Should not throw — just verify fetch is called.
+    const response = await fetchWithTimeout('/api/health', {}, 999_999);
+    expect(response.status).toBe(200);
+  });
+
+  it('makes a plain fetch when timeout is 0 (disabled)', async () => {
+    await fetchWithTimeout('/api/health', {}, 0);
+    // With timeout=0, fetch is called without a timeout signal.
+    const callArgs = (fetch as any).mock.calls[0][1];
+    // No AbortSignal means the signal field should be absent or undefined.
+    expect(callArgs.signal).toBeUndefined();
+  });
+});
+
+// ── fetchWithTimeout — timeout fires ─────────────────────────────────────────
+
+describe('fetchWithTimeout — timeout fires', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects with a TimeoutError DOMException when the deadline fires', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', hangingFetch());
+
+    const assertionPromise = expect(
+      fetchWithTimeout('/api/slow', {}, 50)
+    ).rejects.toMatchObject({ name: 'TimeoutError' });
+
+    await vi.advanceTimersByTimeAsync(50);
+    await assertionPromise;
+  });
+
+  it('error message includes the URL and timeout', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', hangingFetch());
+
+    const assertionPromise = expect(
+      fetchWithTimeout('/api/slow-endpoint', {}, 100)
+    ).rejects.toMatchObject({ message: expect.stringContaining('/api/slow-endpoint') });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await assertionPromise;
+  });
+
+  it('does not call fetch more than once — no implicit retry', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', hangingFetch());
+
+    const promise = fetchWithTimeout('/api/slow', {}, 50);
+    // Attach catch before advancing timers so the rejection is handled.
+    promise.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(50);
+    await promise.catch(() => {});
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the policy-table timeout for the relevant endpoint', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', hangingFetch());
+
+    // HEALTH_TIMEOUT_MS is 3_000.
+    const assertionPromise = expect(
+      fetchWithTimeout('/api/health')
+    ).rejects.toMatchObject({ name: 'TimeoutError' });
+
+    await vi.advanceTimersByTimeAsync(HEALTH_TIMEOUT_MS);
+    await assertionPromise;
+  });
+});
+
+// ── fetchWithTimeout — caller abort ──────────────────────────────────────────
+
+describe('fetchWithTimeout — caller abort', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', hangingFetch());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects immediately when the caller aborts a hanging request', async () => {
+    const controller = new AbortController();
+
+    const promise = fetchWithTimeout('/api/goals', { signal: controller.signal }, 30_000);
+    controller.abort();
+
+    await expect(promise).rejects.toBeDefined();
+  });
+
+  it('rejects immediately when the signal is already aborted before the call', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(fetchWithTimeout('/api/goals', { signal: controller.signal }, 30_000)).rejects.toBeDefined();
+  });
+
+  it('does not fire a timeout error when the caller aborts first', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+
+    const promise = fetchWithTimeout('/api/goals', { signal: controller.signal }, 100);
+    controller.abort(new DOMException('user cancelled', 'AbortError'));
+
+    let caught: unknown;
+    try {
+      await promise;
+    } catch (e) {
+      caught = e;
+    }
+
+    // Should be the caller's abort, not a TimeoutError.
+    expect((caught as DOMException).name).not.toBe('TimeoutError');
+
+    vi.useRealTimers();
+  });
+});
+
+// ── fetchWithTimeout — signal composition ────────────────────────────────────
+
+describe('fetchWithTimeout — signal composition', () => {
+  it('passes a signal to fetch even when no caller signal is provided', async () => {
+    vi.stubGlobal('fetch', okFetch());
+    await fetchWithTimeout('/api/health', {}, 5_000);
+
+    const callArgs = (fetch as any).mock.calls[0][1];
+    expect(callArgs).toHaveProperty('signal');
+    vi.unstubAllGlobals();
+  });
+
+  it('merges the caller signal and the timeout signal', async () => {
+    vi.stubGlobal('fetch', okFetch());
+    const callerController = new AbortController();
+
+    await fetchWithTimeout('/api/health', { signal: callerController.signal }, 5_000);
+
+    // The signal passed to fetch is a combined signal (not the raw caller one).
+    const callArgs = (fetch as any).mock.calls[0][1];
+    expect(callArgs.signal).toBeDefined();
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a shared `fetchWithTimeout` wrapper with a per-endpoint timeout policy table, satisfying the requirement that each endpoint declares its own timeout and the wrapper aborts with a `TimeoutError` if the deadline is exceeded.

## Changes

| File | What changed |
|------|-------------|
| `lib/config/fetch-timeouts.ts` | Single source of truth for all endpoint timeouts — named constants, `ENDPOINT_TIMEOUTS` lookup table, `getTimeoutForUrl()` helper |
| `lib/fetch-timeout.ts` | Generic `fetchWithTimeout` wrapper — resolves timeout from policy table, composes caller + timeout `AbortSignal`s, throws `TimeoutError` DOMException on deadline |
| `lib/anchor/client.ts` | Replaces inline private `fetchWithTimeout` with a delegation to the shared wrapper; re-exports `DEFAULT_TIMEOUT_MS` as a deprecated alias for backwards compat |
| `tests/unit/fetch-timeout.test.ts` | 36 new tests — happy path, timeout fires, caller abort, signal composition, `getTimeoutForUrl` exhaustive, `ENDPOINT_TIMEOUTS` table sanity |
| `docs/fetch-timeout.md` | Full API reference, per-endpoint policy table, matching algorithm, usage examples, relationship to `apiClient` |
| `README.md` | Link to `docs/fetch-timeout.md` under the API section |

## Testing

- **36 new tests** — all pass, zero unhandled errors
- Pre-existing failures in `middleware-gateway.test.ts` are unrelated (present on `main` before this change, verified by stash test)
- Lint: zero warnings
- TypeScript: zero errors

## Backwards Compatibility

- Public API of `lib/anchor/client.ts` is unchanged — `DEFAULT_TIMEOUT_MS` is kept as a deprecated re-export
- `fetchWithTimeout` in `lib/fetch-timeout.ts` is additive; no existing call sites are removed

Closes #1014