### PR TITLE
docs: Add responsive testing guide and update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Frontend application for the RemitWise remittance and financial planning platform.
 
-> **New contributors:** start with [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, verified test commands, and PR expectations. When building UI, follow the [component lifecycle](docs/COMPONENT_LIFECYCLE.md) from Figma and design tokens through stories, tests, and production, check the [design system roadmap](docs/DESIGN_SYSTEM_ROADMAP.md) for planned components and active deprecations, and refer to [docs/RESPONSIVE_TESTING.md](docs/RESPONSIVE_TESTING.md) to verify layout behavior across breakpoints. For conventions around route naming, layouts, and nested routes, see [docs/ROUTING_PATTERNS.md](docs/ROUTING_PATTERNS.md). Then read [docs/architecture.md](docs/architecture.md) for a full route and layer map, and [docs/infrastructure.md](docs/infrastructure.md) for request gateway, logging, and runtime layers.
+> **New contributors:** start with [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, verified test commands, and PR expectations. When building UI, follow the [component lifecycle](docs/COMPONENT_LIFECYCLE.md) from Figma and design tokens through stories, tests, and production, and refer to [docs/RESPONSIVE_TESTING.md](docs/RESPONSIVE_TESTING.md) to verify layout behavior across breakpoints. For conventions around route naming, layouts, and nested routes, see [docs/ROUTING_PATTERNS.md](docs/ROUTING_PATTERNS.md). Then read [docs/architecture.md](docs/architecture.md) for a full route and layer map, and [docs/infrastructure.md](docs/infrastructure.md) for request gateway, logging, and runtime layers.
 
 ## Overview
 


### PR DESCRIPTION
Closes #1106 
This PR resolves the issue by creating a comprehensive reference guide for verifying responsive breakpoints and layouts on the RemitWise Frontend platform.

The guide is written specifically for frontend contributors and covers both automated (Playwright E2E) and manual (browser Developer Tools) verification methods, complete with code snippets, device test tables, and typical layout fixes.

Key Changes
New Guide: Created 
docs/RESPONSIVE_TESTING.md
 detailing standards, criteria (no horizontal overflow, minimum font size, touch target guarantees, safe areas), and step-by-step verification methods.
Introductory Discovery: Linked the new testing guide in the main 
README.md
 file (within the overview, project structure, and E2E testing sections).
Cross-linking:
Linked under the Playwright E2E browser tests section in 
docs/testing.md
.
Linked under the resources section in the 
docs/RESPONSIVE_BREAKPOINT_GUIDE.md
.