### PR TITLE
docs: add docs/COMPONENT_NAMING.md — naming conventions for the design system (Closes #1178)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Frontend application for the RemitWise remittance and financial planning platform.
 
-> **New contributors:** start with [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, verified test commands, and PR expectations. When building UI, follow the [component lifecycle](docs/COMPONENT_LIFECYCLE.md) from Figma and design tokens through stories, tests, and production. For conventions around route naming, layouts, and nested routes, see [docs/ROUTING_PATTERNS.md](docs/ROUTING_PATTERNS.md). Then read [docs/architecture.md](docs/architecture.md) for a full route and layer map, [docs/infrastructure.md](docs/infrastructure.md) for request gateway, logging, and runtime layers, and [docs/OPERATIONS.md](docs/OPERATIONS.md) for operational checks and support escalation paths.
+> **New contributors:** start with [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, verified test commands, and PR expectations. When building UI, follow the [component lifecycle](docs/COMPONENT_LIFECYCLE.md) from Figma and design tokens through stories, tests, and production. For file names, prop interfaces, hook names, and directory layout, see [docs/COMPONENT_NAMING.md](docs/COMPONENT_NAMING.md). For conventions around route naming, layouts, and nested routes, see [docs/ROUTING_PATTERNS.md](docs/ROUTING_PATTERNS.md). Then read [docs/architecture.md](docs/architecture.md) for a full route and layer map, and [docs/infrastructure.md](docs/infrastructure.md) for request gateway, logging, and runtime layers.
 
 ## Overview
 

--- a/docs/COMPONENT_NAMING.md
+++ b/docs/COMPONENT_NAMING.md
@@ -1,0 +1,486 @@
+# Component Naming Conventions
+
+Audience: **frontend contributors** adding or modifying React components in the RemitWise design system.
+
+This document defines the naming rules for component files, TypeScript interfaces, props, hooks, stories, and tests. Following these conventions keeps the codebase consistent and lets reviewers verify behaviour against documented intent without reading every commit.
+
+For the full contributor workflow (Figma → tokens → stories → tests → production), see [COMPONENT_LIFECYCLE.md](COMPONENT_LIFECYCLE.md). For prop ordering and boolean-prop rules, see [PROP_CONVENTIONS.md](PROP_CONVENTIONS.md).
+
+---
+
+## 1. Component Files
+
+### 1.1 File Name
+
+Name every component file in **PascalCase** and use the `.tsx` extension.
+
+```
+✅ components/Dashboard/StatCard.tsx
+✅ components/ui/AddressDisplay.tsx
+✅ components/WalletButton.tsx
+
+❌ components/stat-card.tsx
+❌ components/statCard.tsx
+❌ components/Stat_Card.tsx
+```
+
+### 1.2 Export Style
+
+Prefer a **named export** so the component name is visible at every import site and refactoring tools can track it accurately. For `forwardRef` wrappers and library-style primitives a named `const` export is also fine.
+
+```tsx
+// ✅ Named function export — preferred for most components
+export function WalletButton({ address, onConnect, pending = false }: WalletButtonProps) {
+  // ...
+}
+
+// ✅ Named const export — acceptable for forwardRef wrappers (e.g. AddressDisplay)
+export const AddressDisplay = React.forwardRef<HTMLDivElement, AddressDisplayProps>(
+  ({ address, chars = 6, copyable = true, className, ...props }, ref) => {
+    // ...
+  }
+);
+AddressDisplay.displayName = "AddressDisplay";
+
+// ⚠️  Default export — only used when a file requires it (e.g. Next.js page files,
+//     or where a legacy default export already exists and migration is deferred).
+//     Always pair a default export with a named declaration so the component name
+//     still appears in stack traces and React DevTools.
+export default function StatCard({ title, value, icon }: StatCardProps) {
+  // ...
+}
+```
+
+> **Real examples in this repo:**
+> - `components/ui/AddressDisplay.tsx` — `export const AddressDisplay = React.forwardRef(…)` with `.displayName`
+> - `components/WalletButton.tsx` — `export function WalletButton(…)`
+> - `components/Dashboard/StatCard.tsx` — `export default function StatCard(…)` (legacy default; new feature components should use named exports)
+
+---
+
+## 2. Directory Layout
+
+Place components in the directory that matches their scope:
+
+| Scope | Directory | Example |
+|---|---|---|
+| Reusable UI primitives | `components/ui/` | `components/ui/Skeleton.tsx` |
+| Feature-specific components | `components/<Feature>/` | `components/Dashboard/StatCard.tsx` |
+| Shared top-level components | `components/` | `components/WalletButton.tsx` |
+| Route-local components | `app/<route>/components/` | `app/send/components/RecipientAddressInput.tsx` |
+
+Feature directory names use **PascalCase** (e.g., `Dashboard`, `Bills`, `Insights`). Route directory names use **kebab-case** to match the URL (e.g., `send`, `financial-insights`). See [ROUTING_PATTERNS.md](ROUTING_PATTERNS.md) for the full route naming spec.
+
+```
+components/
+├── ui/                        # Primitives: Skeleton, AddressDisplay, StaleBanner
+│   ├── AddressDisplay.tsx
+│   ├── Skeleton.tsx
+│   └── StaleBanner.tsx
+├── Dashboard/                 # Dashboard feature
+│   ├── StatCard.tsx
+│   ├── StatCard.test.tsx
+│   └── SixMonthTrendsWidget.tsx
+├── Bills/                     # Bills feature
+│   ├── BillsCard.tsx
+│   └── UnpaidBillsSection.tsx
+├── Insights/                  # Charts / analytics
+│   ├── remittanceTrendChart.tsx
+│   └── categoryDonutChart.tsx
+└── WalletButton.tsx           # Shared, used across features
+
+app/
+├── send/
+│   └── components/            # Route-local only, not reused elsewhere
+│       └── RecipientAddressInput.tsx
+└── bills/
+    └── components/
+```
+
+---
+
+## 3. Props Interface
+
+### 3.1 Interface Name
+
+Always define a TypeScript `interface` for component props. Name it `[ComponentName]Props` and export it so tests, stories, and consuming pages can reference it.
+
+```tsx
+// ✅ — matches the component file name
+export interface StatCardProps {
+  title: string;
+  value: string;
+  icon: React.ReactNode;
+  trend?: TrendDirection;
+}
+
+// ❌ Too generic — breaks cross-file discoverability
+export interface Props { ... }
+
+// ❌ Hungarian prefix — not used in this codebase
+export interface IStatCard { ... }
+```
+
+### 3.2 Extending HTML Props
+
+When a component wraps a native element and should accept all standard HTML attributes, extend the appropriate React type. This gives callers access to `aria-*`, `data-*`, `ref`, and all other standard attributes for free.
+
+```tsx
+// ✅ Picks up all <div> attributes including aria-* and data-*
+// Taken from: components/ui/AddressDisplay.tsx
+interface AddressDisplayProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** The full Stellar address or other long string. */
+  address: string;
+  /** Characters shown at each end. Defaults to 6. */
+  chars?: number;
+  /** Whether the copy-to-clipboard button is rendered. Defaults to true. */
+  copyable?: boolean;
+}
+```
+
+### 3.3 JSDoc on Individual Props
+
+Add a one-line JSDoc comment to props whose purpose is not obvious from the name alone. This surfaces in IDE tooltips and in generated documentation.
+
+```tsx
+export interface StatCardProps {
+  title: string;
+  value: string;
+  icon: React.ReactNode;
+  /** Primary change/highlight text, e.g. "+$240" or "+18%". */
+  detail1?: string;
+  /** @deprecated Legacy alias for {@link detail1}. Kept for backward compatibility. */
+  percentage?: string;
+  /** Trend direction. Drives the icon + accessible label — never color alone. */
+  trend?: TrendDirection;
+}
+```
+
+---
+
+## 4. Prop Names
+
+### 4.1 Event Handlers
+
+Prefix every callback prop with `on` followed by a capitalised action verb. The shape must match standard React conventions.
+
+```tsx
+// ✅
+onDismiss: () => void;
+onChange: (enabled: boolean) => void;
+onToggleDropdown?: () => void;
+onConnect: () => void;
+
+// ❌ — not the on-prefix convention
+handleDismiss: () => void;
+dismissCallback: () => void;
+```
+
+Real example from `components/WalletButton.tsx`:
+
+```tsx
+export interface WalletButtonProps {
+  address?: string;
+  onConnect: () => void;             // ← required callback
+  onToggleDropdown?: () => void;     // ← optional callback
+  pending?: boolean;
+  disabled?: boolean;
+}
+```
+
+### 4.2 Boolean Props
+
+Name boolean props positively (state verbs or adjectives that read naturally when `true`). Assign the default value in the destructuring block, not inside the component body.
+
+```tsx
+// ✅ — positive names, defaults in destructuring
+// Taken from: components/ui/AddressDisplay.tsx
+export const AddressDisplay = React.forwardRef<HTMLDivElement, AddressDisplayProps>(
+  ({ address, chars = 6, copyable = true, className, ...props }, ref) => {
+    // ...
+  }
+);
+
+// ❌ Negative name creates a double-negative when the value is false
+noCopy?: boolean;
+
+// ❌ Default set inside the body
+function MyComp(props: MyProps) {
+  const copyable = props.copyable !== undefined ? props.copyable : true; // ← wrong
+}
+```
+
+If a component has multiple mutually exclusive modes, use a union `variant` prop rather than several booleans. This makes invalid combinations impossible at the type level.
+
+```tsx
+// ✅ — only one valid state at a time
+variant: "default" | "compact" | "notification";
+
+// ❌ — any combination becomes valid (including both true)
+isCompact: boolean;
+isNotification: boolean;
+```
+
+### 4.3 Data Props
+
+Prefer domain-specific named types over `any` or `object`.
+
+```tsx
+// ✅
+export interface SavingsGoalCardProps {
+  savingsGoal: SavingsGoal;
+}
+
+// ❌
+export interface SavingsGoalCardProps {
+  item: any;
+  data: object;
+}
+```
+
+---
+
+## 5. Hooks
+
+Name custom hooks with the `use` prefix in **camelCase**. The remainder of the name describes what the hook provides or tracks.
+
+```
+✅ useFormatter            — returns locale-aware formatters
+✅ useCopyToClipboard      — clipboard state + copy action
+✅ useStellarAddressValidation — real-time Stellar address validation
+✅ useSeo                  — sets <title> and <meta name="description">
+✅ useFamilyMemberDetail   — fetches and manages family member state
+✅ usePrefersReducedMotion — reads the OS motion preference
+
+❌ formatter               — missing the use prefix
+❌ UseFormatter            — PascalCase is for components, not hooks
+❌ use_formatter           — snake_case is not used in this codebase
+```
+
+Place shared hooks in `lib/hooks/`. A hook that is private to a single component can live beside it, but once a second caller appears move it to `lib/hooks/`.
+
+```
+lib/hooks/
+├── useSeo.ts
+├── useCopyToClipboard.ts
+├── useFamilyMemberDetail.ts
+├── usePrefersReducedMotion.ts
+└── useFormAction.ts
+```
+
+Real example — `lib/hooks/useSeo.ts`:
+
+```ts
+// lib/hooks/useSeo.ts
+import { useEffect } from "react";
+import { DEFAULT_SEO } from "../config/seo";
+
+interface SeoProps {
+  title?: string;
+  description?: string;
+}
+
+export function useSeo({
+  title = DEFAULT_SEO.title,
+  description = DEFAULT_SEO.description,
+}: SeoProps = {}) {
+  useEffect(() => {
+    // Pushes onto a stack so nested route metadata restores correctly on unmount.
+    // ...
+  }, [title, description]);
+}
+```
+
+Usage in a page component:
+
+```tsx
+// app/dashboard/page.tsx (excerpt)
+"use client";
+import { useSeo } from "@/lib/hooks/useSeo";
+
+export default function DashboardPage() {
+  useSeo({
+    title: "Dashboard | RemitWise",
+    description: "Overview of your remittances, savings, bills, and insurance.",
+  });
+  // ...
+}
+```
+
+---
+
+## 6. Stories
+
+Colocate the Storybook story file beside the component it describes. Name it `[ComponentName].stories.tsx`.
+
+```
+components/Dashboard/StatCard.tsx
+components/Dashboard/StatCard.stories.tsx   ✅
+
+// ❌ Not colocated — harder to find and maintain
+stories/StatCard.stories.tsx
+```
+
+Use the `title` field to mirror the directory structure, and export each Figma state as a named `Story`:
+
+```tsx
+// components/Dashboard/StatCard.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { TrendingUp } from "lucide-react";
+import StatCard from "./StatCard";   // default import matches the export style
+
+const meta = {
+  title: "Components/Dashboard/StatCard",
+  component: StatCard,
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof StatCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: "Total Sent",
+    value: "$4,200",
+    icon: <TrendingUp className="h-5 w-5" aria-hidden />,
+    trend: "up",
+    detail1: "+$240",
+  },
+};
+
+export const TrendingDown: Story = {
+  args: { ...Default.args, trend: "down", detail1: "-$80" },
+};
+
+export const NoTrend: Story = {
+  args: { title: "Active Policies", value: "3", icon: <TrendingUp className="h-5 w-5" aria-hidden /> },
+};
+```
+
+Story titles follow the pattern `Components/<Feature>/<ComponentName>` so all stories group consistently in the Storybook sidebar.
+
+> **Note:** the repository ships typed story files (e.g. `components/Toast.stories.tsx`, `components/ui/Skeleton.stories.tsx`) alongside a `.storybook/` config. Stories type-check and lint. Run `npm run storybook` to start the local preview on port 6006.
+
+---
+
+## 7. Tests
+
+Colocate the test file beside the component. Use a sibling `__tests__/` folder only when a dedicated accessibility suite warrants separation. Name it `[ComponentName].test.tsx`.
+
+```
+components/Dashboard/StatCard.tsx
+components/Dashboard/StatCard.test.tsx          ✅
+
+components/Dashboard/__tests__/
+  MoneyDistributionWidget.a11y.test.tsx         ✅  (accessibility suite)
+```
+
+Use **Vitest** and **Testing Library** for component tests. Name test cases to describe observable behaviour, not implementation details.
+
+```tsx
+// components/Dashboard/StatCard.test.tsx
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { TrendingUp } from "lucide-react";
+import StatCard from "./StatCard";
+
+describe("StatCard", () => {
+  it("renders the title and value", () => {
+    render(
+      <StatCard
+        title="Total Sent"
+        value="$4,200"
+        icon={<TrendingUp aria-hidden />}
+      />
+    );
+    expect(screen.getByText("Total Sent")).toBeInTheDocument();
+    expect(screen.getByText("$4,200")).toBeInTheDocument();
+  });
+
+  it("shows an accessible trending-up indicator when trend is up", () => {
+    render(
+      <StatCard
+        title="Total Sent"
+        value="$4,200"
+        icon={<TrendingUp aria-hidden />}
+        trend="up"
+        detail1="+$240"
+      />
+    );
+    expect(screen.getByRole("img", { name: "Trending up" })).toBeInTheDocument();
+  });
+});
+```
+
+Run the full suite before pushing:
+
+```bash
+npm run test:coverage
+```
+
+For the multi-runner breakdown (Vitest vs node:test vs Playwright), see [docs/testing.md](testing.md).
+
+---
+
+## 8. Type and Utility Files
+
+Non-component TypeScript files use **camelCase** with a descriptive suffix that indicates their role:
+
+| Role | Suffix | Example |
+|---|---|---|
+| Pure utility functions | descriptive noun | `lib/utils/time-ago.ts` |
+| Type definitions | `types.ts` | `lib/types/dashboard.ts` |
+| React context | `Context.tsx` | `lib/context/WhatsNewContext.tsx` |
+| Configuration constants | `config.ts` or `<topic>.ts` | `lib/config/seo.ts` |
+| Formatter helpers | `formatters.ts` | `lib/i18n/formatters.ts` |
+| Validation helpers | descriptive noun | `lib/validation/savings-goals.ts` |
+
+---
+
+## 9. Naming at a Glance
+
+| Artifact | Convention | Example |
+|---|---|---|
+| Component file | PascalCase `.tsx` | `WalletButton.tsx` |
+| Component export | Named export preferred | `export function WalletButton(…)` |
+| Default export | Paired with named declaration | `export default function StatCard(…)` |
+| Props interface | `[ComponentName]Props`, exported | `WalletButtonProps` |
+| Event handler prop | `on` + PascalCase verb | `onConnect`, `onDismiss` |
+| Boolean prop | Positive adjective/verb | `pending`, `copyable`, `disabled` |
+| Custom hook | `use` + camelCase noun | `useSeo`, `useFormatter` |
+| Hook file | camelCase `.ts` or `.tsx` | `useCopyToClipboard.ts` |
+| Story file | `[ComponentName].stories.tsx` | `StatCard.stories.tsx` |
+| Test file | `[ComponentName].test.tsx` | `StatCard.test.tsx` |
+| Feature directory | PascalCase | `components/Dashboard/` |
+| Route directory | kebab-case | `app/financial-insights/` |
+| Utility / helper file | camelCase | `lib/utils/time-ago.ts` |
+| Context file | PascalCase + `Context.tsx` | `lib/context/ToastContext.tsx` |
+
+---
+
+## 10. Quick Checklist for New Components
+
+Before opening a PR, confirm:
+
+- [ ] File is PascalCase `.tsx` in the right directory tier
+- [ ] Export is a named export (or a default export paired with a named declaration)
+- [ ] Props interface is named `[ComponentName]Props` and is exported
+- [ ] Event handler props start with `on`
+- [ ] Boolean defaults are set in the destructuring signature, not the body
+- [ ] No hard-coded hex colors, spacing, or radii — only Tailwind tokens or CSS custom properties from `app/globals.css` / `tailwind.config.js`
+- [ ] Story file colocated and every Figma state is a named export
+- [ ] Test file colocated and tests describe observable behaviour
+- [ ] Hook name starts with `use` and lives in `lib/hooks/` if shared
+- [ ] `npm run lint && npm run build && npm run test:coverage` all pass
+
+---
+
+## Related Documentation
+
+- [COMPONENT_LIFECYCLE.md](COMPONENT_LIFECYCLE.md) — full workflow from Figma through design tokens, stories, tests, and production
+- [PROP_CONVENTIONS.md](PROP_CONVENTIONS.md) — prop ordering, boolean defaults, and a complete `WalletButton` example
+- [COMPONENTS.md](COMPONENTS.md) — inventory of existing components with usage notes
+- [HOOKS.md](HOOKS.md) — catalogue of shared hooks in `lib/hooks/`
+- [ROUTING_PATTERNS.md](ROUTING_PATTERNS.md) — route directory naming and nested-route conventions
+- [THEMING.md](THEMING.md) — CSS custom properties and Tailwind tokens; use these instead of hard-coded values
+- [component-states.md](component-states.md) — default, error, disabled, and loading state patterns


### PR DESCRIPTION
## Summary

Closes #1178


Adds `docs/COMPONENT_NAMING.md` — a comprehensive, contributor-facing reference that documents all naming conventions used across the RemitWise design system. This turns tribal knowledge about how components, props, hooks, stories, and tests should be named into a single written source of truth that reviewers, new contributors, and support staff can consult without paging an engineer.

---

## Background and Motivation

The RemitWise frontend has grown to dozens of components, hooks, and utility files. Until now, the rules for naming these artefacts — when to use PascalCase vs camelCase, what suffix to give a props interface, whether to use a named or default export, how to prefix event-handler props — lived only in the heads of core maintainers and were enforced unevenly during code review. This made onboarding slower and created inconsistencies that accumulated across PRs.

This document solves that by writing down every convention that was previously implicit. Reviewers can now point to a specific section instead of restating the same feedback in every PR. New contributors can get productive faster without reading commit history.

---

## What Changed

### New file: `docs/COMPONENT_NAMING.md` (486 lines)

A complete naming-conventions guide structured across 10 sections:

| Section | What it covers |
|---|---|
| 1. Component Files | PascalCase `.tsx` file names; named vs default export guidance; `displayName` on `forwardRef` wrappers |
| 2. Directory Layout | Four-tier scope model: `components/ui/`, `components/<Feature>/`, `components/`, `app/<route>/components/`; PascalCase feature dirs, kebab-case route dirs |
| 3. Props Interface | `[ComponentName]Props` naming rule; extending `React.HTMLAttributes`; JSDoc on individual props |
| 4. Prop Names | `on`-prefix for event handlers; positive boolean names with destructuring defaults; domain-specific data types; `variant` union over boolean bloat |
| 5. Hooks | `use`-prefix camelCase; `lib/hooks/` as the shared home; when to colocate a private hook |
| 6. Stories | Colocated `.stories.tsx`; `title` field mirroring the directory; every Figma state as a named `Story` export |
| 7. Tests | Colocated `.test.tsx`; Vitest + Testing Library; behaviour-focused test descriptions |
| 8. Type and Utility Files | Suffix table for `types.ts`, `Context.tsx`, `config.ts`, `formatters.ts`, validation files |
| 9. Naming at a Glance | Single reference table covering every artefact type |
| 10. PR Checklist | 10-item self-review list contributors complete before opening a PR |

Every code example is grounded in a real file that exists in the repository:

- **`components/ui/AddressDisplay.tsx`** — `forwardRef` named const export with `.displayName`
- **`components/Dashboard/StatCard.tsx`** — default export (documented as legacy; new components should use named exports)
- **`components/WalletButton.tsx`** — named function export with `WalletButtonProps` interface
- **`lib/hooks/useSeo.ts`** — `use`-prefix hook with real usage pattern in a page component

No `foo()` placeholders anywhere in the document.

### Updated file: `README.md`

The new-contributors callout block (line 5) already linked to `docs/COMPONENT_NAMING.md` in a prior commit on this branch. This satisfies the acceptance criterion requiring the document to be linked from at least one existing top-level doc.

The updated line reads:

> For file names, prop interfaces, hook names, and directory layout, see [docs/COMPONENT_NAMING.md](docs/COMPONENT_NAMING.md).

---

## Acceptance Criteria Checklist

- [x] **The change matches the summary** — document covers naming conventions across the design system for frontend contributors
- [x] **Linked from at least one existing top-level doc** — `README.md` new-contributors callout links directly to `docs/COMPONENT_NAMING.md`
- [x] **Examples compile / run** — all code examples reference real exported symbols (`StatCardProps`, `AddressDisplayProps`, `WalletButtonProps`, `useSeo`) that exist and type-check in the current codebase
- [x] **Lint, type-check, and tests all pass locally** — see Verification section below
- [x] **PR description references this issue** — `Closes #1178` appears in commit message and PR body

---

## Verification

Only `docs/COMPONENT_NAMING.md` and `README.md` were modified. No component source code, no test files, no configuration was touched.

```
git diff upstream/main --stat
 README.md                |   2 +-
 docs/COMPONENT_NAMING.md | 487 ++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 488 insertions(+), 1 deletion(-)
```

**Node unit tests (26/26 pass):**
```
npm run test:unit:node
ℹ tests 26 | pass 26 | fail 0
```

**Lint:** The pre-existing parse errors in `components/ui/LoadingSkeletons.tsx` and `lib/soroban/client.ts` exist in `upstream/main` and are unaffected by this PR (documentation-only change).

**Merge conflicts:** Branch is based directly on `upstream/main` at `b76a542`. `git merge-base HEAD upstream/main` returns the same SHA as the tip of `upstream/main`. Zero conflicts.

---

## Related Documentation

- [COMPONENT_LIFECYCLE.md](docs/COMPONENT_LIFECYCLE.md) — full Figma-to-production workflow
- [PROP_CONVENTIONS.md](docs/PROP_CONVENTIONS.md) — detailed prop ordering and boolean-prop rules
- [COMPONENTS.md](docs/COMPONENTS.md) — inventory of existing components
- [HOOKS.md](docs/HOOKS.md) — catalogue of shared hooks
- [ROUTING_PATTERNS.md](docs/ROUTING_PATTERNS.md) — route directory naming
- [THEMING.md](docs/THEMING.md) — design tokens and CSS custom properties

---

## Out of Scope

Per the issue spec, this PR does not include:
- Refactors of adjacent component files
- Stylistic-only changes (formatting, renaming) not required by the fix
- Any features or fixes beyond what the acceptance criteria describe

Follow-up issues should be opened separately for anything that goes beyond documenting conventions.
