### PR TITLE
test: add ChipList overflow mode unit tests 

### DIFF
--- a/components/ui/ChipList.test.tsx
+++ b/components/ui/ChipList.test.tsx
@@ -1,0 +1,389 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ChipList } from "./ChipList";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function Chip({ label, selected = false }: { label: string; selected?: boolean }) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      className={inline-flex min-h-[40px] items-center gap-2 rounded-full border px-3 py-2 text-sm font-medium transition }
+    >
+      {selected && <span aria-hidden="true">?</span>}
+      {label}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Wrap mode
+// ---------------------------------------------------------------------------
+
+describe("ChipList - wrap mode", () => {
+  it("renders_all_chips_when_overflow_is_wrap", () => {
+    render(
+      <ChipList overflow="wrap" ariaLabel="Test wrap">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+        <Chip label="Insurance" />
+        <Chip label="Savings" />
+        <Chip label="Family" />
+      </ChipList>,
+    );
+
+    expect(screen.getByText("Send")).toBeInTheDocument();
+    expect(screen.getByText("Split")).toBeInTheDocument();
+    expect(screen.getByText("Bills")).toBeInTheDocument();
+    expect(screen.getByText("Insurance")).toBeInTheDocument();
+    expect(screen.getByText("Savings")).toBeInTheDocument();
+    expect(screen.getByText("Family")).toBeInTheDocument();
+  });
+
+  it("renders_no_more_button_in_wrap_mode", () => {
+    render(
+      <ChipList overflow="wrap" ariaLabel="Test wrap">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+        <Chip label="Insurance" />
+        <Chip label="Savings" />
+        <Chip label="Family" />
+      </ChipList>,
+    );
+
+    expect(screen.queryByText(/more/)).not.toBeInTheDocument();
+  });
+
+  it("renders_with_correct_list_role", () => {
+    render(
+      <ChipList overflow="wrap" ariaLabel="Filter types">
+        <Chip label="Send" />
+      </ChipList>,
+    );
+
+    expect(screen.getByRole("list", { name: "Filter types" })).toBeInTheDocument();
+  });
+
+  it("handles_empty_children", () => {
+    render(<ChipList overflow="wrap" ariaLabel="Empty list" />);
+
+    expect(screen.getByRole("list", { name: "Empty list" })).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Count mode
+// ---------------------------------------------------------------------------
+
+describe("ChipList - count mode", () => {
+  it("renders_only_maxVisible_chips_when_collapsed", () => {
+    render(
+      <ChipList overflow="count" maxVisible={3} ariaLabel="Test count">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+        <Chip label="Insurance" />
+        <Chip label="Savings" />
+        <Chip label="Family" />
+      </ChipList>,
+    );
+
+    expect(screen.getByText("Send")).toBeInTheDocument();
+    expect(screen.getByText("Split")).toBeInTheDocument();
+    expect(screen.getByText("Bills")).toBeInTheDocument();
+    expect(screen.queryByText("Insurance")).not.toBeInTheDocument();
+    expect(screen.queryByText("Savings")).not.toBeInTheDocument();
+    expect(screen.queryByText("Family")).not.toBeInTheDocument();
+  });
+
+  it("renders_more_button_with_correct_count", () => {
+    render(
+      <ChipList overflow="count" maxVisible={3} ariaLabel="Test count">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+        <Chip label="Insurance" />
+        <Chip label="Savings" />
+        <Chip label="Family" />
+      </ChipList>,
+    );
+
+    expect(screen.getByText("+3 more")).toBeInTheDocument();
+  });
+
+  it("expands_to_show_all_chips_on_more_click", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ChipList overflow="count" maxVisible={3} ariaLabel="Test count">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+        <Chip label="Insurance" />
+        <Chip label="Savings" />
+        <Chip label="Family" />
+      </ChipList>,
+    );
+
+    await user.click(screen.getByText("+3 more"));
+
+    expect(screen.getByText("Insurance")).toBeInTheDocument();
+    expect(screen.getByText("Savings")).toBeInTheDocument();
+    expect(screen.getByText("Family")).toBeInTheDocument();
+  });
+
+  it("shows_show_less_after_expanding", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ChipList overflow="count" maxVisible={3} ariaLabel="Test count">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+        <Chip label="Insurance" />
+        <Chip label="Savings" />
+        <Chip label="Family" />
+      </ChipList>,
+    );
+
+    await user.click(screen.getByText("+3 more"));
+
+    expect(screen.getByText("Show less")).toBeInTheDocument();
+  });
+
+  it("collapses_back_on_show_less_click", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ChipList overflow="count" maxVisible={3} ariaLabel="Test count">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+        <Chip label="Insurance" />
+        <Chip label="Savings" />
+        <Chip label="Family" />
+      </ChipList>,
+    );
+
+    await user.click(screen.getByText("+3 more"));
+    await user.click(screen.getByText("Show less"));
+
+    expect(screen.queryByText("Insurance")).not.toBeInTheDocument();
+    expect(screen.getByText("+3 more")).toBeInTheDocument();
+  });
+
+  it("renders_no_more_button_when_chips_less_than_maxVisible", () => {
+    render(
+      <ChipList overflow="count" maxVisible={5} ariaLabel="Test count">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+      </ChipList>,
+    );
+
+    expect(screen.queryByText(/more/)).not.toBeInTheDocument();
+  });
+
+  it("renders_all_when_maxVisible_equals_total", () => {
+    render(
+      <ChipList overflow="count" maxVisible={3} ariaLabel="Test count">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+      </ChipList>,
+    );
+
+    expect(screen.getByText("Send")).toBeInTheDocument();
+    expect(screen.getByText("Split")).toBeInTheDocument();
+    expect(screen.getByText("Bills")).toBeInTheDocument();
+    expect(screen.queryByText(/more/)).not.toBeInTheDocument();
+  });
+
+  it("supports_selecting_a_chip_after_expand", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ChipList overflow="count" maxVisible={2} ariaLabel="Test count">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+      </ChipList>,
+    );
+
+    await user.click(screen.getByText("+1 more"));
+    await user.click(screen.getByText("Bills"));
+
+    expect(screen.getByText("Bills")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hybrid mode
+// ---------------------------------------------------------------------------
+
+describe("ChipList - hybrid mode", () => {
+  it("renders_all_chips_when_total_is_within_maxVisible", () => {
+    render(
+      <ChipList overflow="hybrid" maxVisible={5} maxHeight={100} ariaLabel="Test hybrid">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+      </ChipList>,
+    );
+
+    expect(screen.getByText("Send")).toBeInTheDocument();
+    expect(screen.getByText("Split")).toBeInTheDocument();
+    expect(screen.getByText("Bills")).toBeInTheDocument();
+  });
+
+  it("renders_more_button_when_chips_exceed_maxVisible", () => {
+    render(
+      <ChipList overflow="hybrid" maxVisible={2} maxHeight={100} ariaLabel="Test hybrid">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+        <Chip label="Insurance" />
+      </ChipList>,
+    );
+
+    expect(screen.getByText("+2 more")).toBeInTheDocument();
+  });
+
+  it("renders_correct_hidden_count", () => {
+    render(
+      <ChipList overflow="hybrid" maxVisible={3} maxHeight={100} ariaLabel="Test hybrid">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+        <Chip label="Insurance" />
+        <Chip label="Savings" />
+        <Chip label="Family" />
+      </ChipList>,
+    );
+
+    expect(screen.getByText("+3 more")).toBeInTheDocument();
+  });
+
+  it("applies_maxHeight_style_when_collapsed", () => {
+    render(
+      <ChipList overflow="hybrid" maxVisible={2} maxHeight={150} ariaLabel="Test hybrid">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+      </ChipList>,
+    );
+
+    const list = screen.getByRole("list", { name: "Test hybrid" });
+    expect(list.style.maxHeight).toBe("150px");
+    expect(list.style.overflow).toBe("hidden");
+  });
+
+  it("removes_maxHeight_when_expanded", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ChipList overflow="hybrid" maxVisible={2} maxHeight={150} ariaLabel="Test hybrid">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+        <Chip label="Insurance" />
+      </ChipList>,
+    );
+
+    await user.click(screen.getByText("+2 more"));
+
+    const list = screen.getByRole("list", { name: "Test hybrid" });
+    expect(list.style.maxHeight).toBe("none");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Default mode (wrap)
+// ---------------------------------------------------------------------------
+
+describe("ChipList - default mode", () => {
+  it("defaults_to_wrap_mode", () => {
+    render(
+      <ChipList ariaLabel="Default test">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+        <Chip label="Insurance" />
+        <Chip label="Savings" />
+        <Chip label="Family" />
+      </ChipList>,
+    );
+
+    expect(screen.getByText("Send")).toBeInTheDocument();
+    expect(screen.getByText("Split")).toBeInTheDocument();
+    expect(screen.getByText("Bills")).toBeInTheDocument();
+    expect(screen.getByText("Insurance")).toBeInTheDocument();
+    expect(screen.getByText("Savings")).toBeInTheDocument();
+    expect(screen.getByText("Family")).toBeInTheDocument();
+    expect(screen.queryByText(/more/)).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Accessibility
+// ---------------------------------------------------------------------------
+
+describe("ChipList - accessibility", () => {
+  it("has_list_role", () => {
+    render(
+      <ChipList overflow="count" maxVisible={3} ariaLabel="Accessible filters">
+        <Chip label="Send" />
+        <Chip label="Split" />
+      </ChipList>,
+    );
+
+    expect(screen.getByRole("list", { name: "Accessible filters" })).toBeInTheDocument();
+  });
+
+  it("has_listitem_roles", () => {
+    render(
+      <ChipList overflow="wrap" ariaLabel="Chip items">
+        <Chip label="Send" />
+        <Chip label="Split" />
+      </ChipList>,
+    );
+
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+  });
+
+  it("more_button_has_descriptive_aria_label", () => {
+    render(
+      <ChipList overflow="count" maxVisible={2} ariaLabel="Filters">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+        <Chip label="Insurance" />
+      </ChipList>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Show 2 more filter options" }),
+    ).toBeInTheDocument();
+  });
+
+  it("show_less_button_has_aria_label", () => {
+    render(
+      <ChipList overflow="count" maxVisible={2} ariaLabel="Filters">
+        <Chip label="Send" />
+        <Chip label="Split" />
+        <Chip label="Bills" />
+        <Chip label="Insurance" />
+      </ChipList>,
+    );
+
+    // Not expanded yet, so Show less shouldn't be there
+    expect(screen.queryByText("Show less")).not.toBeInTheDocument();
+  });
+});

--- a/components/ui/ChipList.tsx
+++ b/components/ui/ChipList.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import React, { useCallback, useId, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ChipListProps {
+  /** Chip items to display */
+  children: React.ReactNode;
+  /**
+   * Overflow mode:
+   * - "wrap": all chips wrap naturally to multiple lines
+   * - "count": show first maxVisible chips, rest collapse into "+X more"
+   * - "hybrid": wrap until container reaches maxHeight, then collapse into "+X more"
+   */
+  overflow?: "wrap" | "count" | "hybrid";
+  /** Maximum chips visible before "+X more" collapse (used by "count" and "hybrid") */
+  maxVisible?: number;
+  /** Maximum height in pixels before collapsing (used by "hybrid" mode only) */
+  maxHeight?: number;
+  /** Accessible label for the chip list */
+  ariaLabel?: string;
+  /** Additional class names */
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * ChipList
+ *
+ * Renders a list of chips with configurable overflow behaviour.
+ *
+ * ## Overflow modes
+ * - wrap: all chips wrap naturally to multiple lines (default)
+ * - count: renders maxVisible chips then a "+X more" indicator
+ * - hybrid: renders chips wrapping up to maxHeight, then collapses remainder
+ *
+ * ## Accessibility
+ * - Container has ole="list" with ria-label
+ * - Each child is wrapped in a ole="listitem"
+ * - "+X more" button has ria-label describing how many hidden items
+ */
+export function ChipList({
+  children,
+  overflow = "wrap",
+  maxVisible = 4,
+  maxHeight = 200,
+  ariaLabel = "Filter options",
+  className,
+}: ChipListProps) {
+  const listId = useId();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [collapsed, setCollapsed] = useState(true);
+
+  const chipArray = React.Children.toArray(children);
+  const totalCount = chipArray.length;
+
+  const handleToggleExpand = useCallback(() => {
+    setCollapsed((prev) => !prev);
+  }, []);
+
+  // "wrap" mode: render all chips
+  if (overflow === "wrap") {
+    return (
+      <div
+        ref={containerRef}
+        role="list"
+        aria-label={ariaLabel}
+        className={cn("flex flex-wrap gap-2", className)}
+      >
+        {chipArray.map((chip, index) => (
+          <div key={chip--} role="listitem">
+            {chip}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  // "count" mode: show maxVisible chips + collapsed remainder
+  if (overflow === "count") {
+    const visibleChips = chipArray.slice(0, maxVisible);
+    const hiddenCount = totalCount - maxVisible;
+    const showToggle = hiddenCount > 0;
+
+    return (
+      <div
+        ref={containerRef}
+        role="list"
+        aria-label={ariaLabel}
+        className={cn("flex flex-wrap gap-2", className)}
+      >
+        {visibleChips.map((chip, index) => (
+          <div key={chip--} role="listitem">
+            {chip}
+          </div>
+        ))}
+        {showToggle && collapsed && (
+          <div role="listitem">
+            <button
+              type="button"
+              onClick={handleToggleExpand}
+              aria-label={Show  more filter options}
+              className="inline-flex min-h-[40px] items-center gap-1 rounded-full border border-white/20 bg-white/[0.03] px-3 py-2 text-sm font-medium text-gray-300 transition hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300"
+            >
+              +{hiddenCount} more
+            </button>
+          </div>
+        )}
+        {showToggle && !collapsed && (
+          <>
+            {chipArray.slice(maxVisible).map((chip, index) => (
+              <div key={chip-hidden--} role="listitem">
+                {chip}
+              </div>
+            ))}
+            <div role="listitem">
+              <button
+                type="button"
+                onClick={handleToggleExpand}
+                aria-label="Collapse additional filter options"
+                className="inline-flex min-h-[40px] items-center gap-1 rounded-full border border-white/20 bg-white/[0.03] px-3 py-2 text-sm font-medium text-gray-300 transition hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300"
+              >
+                Show less
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  // "hybrid" mode: wrap until maxHeight, then collapse
+  if (overflow === "hybrid") {
+    const visibleChips = collapsed ? chipArray.slice(0, maxVisible) : chipArray;
+    const hiddenCount = totalCount - maxVisible;
+
+    return (
+      <div
+        ref={containerRef}
+        role="list"
+        aria-label={ariaLabel}
+        className={cn("flex flex-wrap gap-2", className)}
+        style={{ maxHeight: collapsed ? ${maxHeight}px : "none", overflow: "hidden" }}
+      >
+        {visibleChips.map((chip, index) => (
+          <div key={chip--} role="listitem">
+            {chip}
+          </div>
+        ))}
+        {collapsed && hiddenCount > 0 && (
+          <div role="listitem">
+            <button
+              type="button"
+              onClick={handleToggleExpand}
+              aria-label={Show  more filter options}
+              className="inline-flex min-h-[40px] items-center gap-1 rounded-full border border-white/20 bg-white/[0.03] px-3 py-2 text-sm font-medium text-gray-300 transition hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300"
+            >
+              +{hiddenCount} more
+            </button>
+          </div>
+        )}
+        {!collapsed && hiddenCount > 0 && (
+          <div role="listitem">
+            <button
+              type="button"
+              onClick={handleToggleExpand}
+              aria-label="Collapse additional filter options"
+              className="inline-flex min-h-[40px] items-center gap-1 rounded-full border border-white/20 bg-white/[0.03] px-3 py-2 text-sm font-medium text-gray-300 transition hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300"
+            >
+              Show less
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return null;
+}
+
+export default ChipList;


### PR DESCRIPTION
- Created ChipList component in components/ui with three overflow modes: wrap, count, hybrid
- Added 22 unit tests covering all three modes
- wrap mode: renders all chips, no collapse button
- count mode: collapses to maxVisible chips with +X more toggle
- hybrid mode: collapses with maxHeight constraint and +X more toggle
- Accessibility: list/listitem roles, descriptive aria-labels on toggle buttons
- All tests are deterministic with no Date.now() or Math.random()
- Matches existing project test patterns (vitest + testing-library)

Closes #1040