### PR TITLE
docs: add accessible-focus baseline guide and tests (closes #1221)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ remitwise-frontend/
 
 The full keyboard shortcut reference lives at [docs/KEYBOARD_SHORTCUTS.md](docs/KEYBOARD_SHORTCUTS.md) — every registered shortcut, where it's handled, and how to add or change one.
 
+The accessible-focus baseline is documented at [docs/ACCESSIBLE_FOCUS_BASELINE.md](docs/ACCESSIBLE_FOCUS_BASELINE.md) — focus-visible styles, focus trap hooks, dialog focus management, and testing patterns.
+
 ## API Routes
 
 See [API Routes Documentation](./docs/API_ROUTES.md) for details on authentication and available endpoints.

--- a/docs/ACCESSIBLE_FOCUS_BASELINE.md
+++ b/docs/ACCESSIBLE_FOCUS_BASELINE.md
@@ -1,0 +1,207 @@
+# Accessible-Focus Baseline
+
+> **Audience:** Contributors adding or changing interactive UI in RemitWise.
+> **Goal:** One reference for how focus is managed across the app — global styles, hooks, testing patterns, and the review contract.
+
+## Principle
+
+Every interactive element must be reachable and operable by keyboard alone, and the user must always know which element has focus (WCAG 2.1 AA, SC 2.4.7 Focus Visible).
+
+## Global focus-visible style
+
+A single global rule in `app/globals.css:173` ensures every focusable element gets a visible ring when focused via keyboard:
+
+```css
+*:focus-visible {
+  outline: 2px solid #D72323 !important;
+  outline-offset: 2px !important;
+}
+```
+
+- The ring uses the brand red (`#D72323`) for sufficient contrast on both light and dark backgrounds.
+- `!important` guarantees the ring is never accidentally removed by a component stylesheet.
+- The `:focus-visible` pseudoclass means mouse clicks do **not** trigger the ring (see [focus-visible polyfill tests](../tests/unit/ui/focus-visible-polyfill.test.tsx)).
+
+### Per-component overrides
+
+When a component needs a thicker or offset ring, use the custom Tailwind tokens from `tailwind.config.js:44`:
+
+```tsx
+className="focus-visible:outline-none focus-visible:ring-focus focus-visible:ring-brand-red/40 focus-visible:ring-offset-focus focus-visible:ring-offset-black"
+```
+
+| Token | Value | Purpose |
+|-------|-------|---------|
+| `ring-focus` | `3px` | Wider ring for emphasis |
+| `ring-offset-focus` | `4px` | Larger offset to separate ring from the element |
+
+The `focus-visible:outline-none` paired with `focus-visible:ring-*` keeps the native outline suppressed while using the styled ring. Never remove focus styles without providing a visible replacement.
+
+## Focus trap hooks
+
+Two hooks handle modal/dialog focus trapping. Choose the one that matches your component's needs.
+
+### `useFocusTrap` (basic) — `lib/hooks/useFocusTrap.ts`
+
+A lightweight trap that cycles Tab/Shift+Tab within the container and calls `onEscape`:
+
+```tsx
+const containerRef = useFocusTrap({ isActive, onEscape });
+```
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `isActive` | `boolean` | yes | Activates the trap when true |
+| `onEscape` | `() => void` | no | Called when Escape is pressed |
+
+**Used by:** components that need trap-only behaviour without overlay-click or `prefersReducedMotion` integration.
+
+### `useFocusTrap` (advanced) — `src/lib/hooks/useFocusTrap.ts`
+
+Full-featured trap with overlay click, initial focus targeting, focus restoration toggling, and reduced-motion awareness:
+
+```tsx
+const modalRef = useFocusTrap({
+  isActive,
+  onEscape: onClose,
+  onOverlayClick: onClose,
+  restoreFocusOnClose: true,
+  initialFocusRef,
+});
+```
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `isActive` | `boolean` | yes | — | Activates the trap when true |
+| `onEscape` | `() => void` | no | — | Escape key callback |
+| `onOverlayClick` | `() => void` | no | — | Backdrop click callback |
+| `restoreFocusOnClose` | `boolean` | no | `true` | Returns focus to the trigger element on close |
+| `initialFocusRef` | `RefObject<HTMLElement>` | no | — | Element to receive focus on open; falls back to first focusable |
+
+**Used by:** `WalletDropdown`, `ShortcutHelpModal`, `HowItWorksModal`, `EmergencyTransferModal`.
+
+### Focusable-element selector
+
+Both hooks query focusable elements using:
+
+```ts
+'button:not([disabled]), a[href]:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), details summary, [tabindex]:not([tabindex="-1"]):not([disabled])'
+```
+
+Elements with `aria-hidden="true"` are filtered out of the focusable set.
+
+## Dialog focus management (`useDialog`)
+
+The `lib/hooks/useDialog.ts` hook provides a full dialog interaction contract:
+
+1. **On open:** The previously focused element is remembered; the dialog root receives focus.
+2. **While open:** Escape closes the dialog. The dialog gets `role="dialog"` and `aria-modal="true"`.
+3. **On close:** Focus is restored to the remembered element.
+
+```tsx
+const { dialogProps, triggerProps } = useDialog({ initialOpen: false });
+
+return (
+  <>
+    <button {...triggerProps}>Open</button>
+    <div {...dialogProps}>{/* dialog content */}</div>
+  </>
+);
+```
+
+The dialog root renders with `tabIndex={-1}` so it can receive programmatic focus without appearing in the Tab sequence.
+
+## Roving tabindex pattern
+
+For widgets with arrow-key navigation (e.g. calendar grids, menu bars), use the roving tabindex pattern:
+
+- Exactly one child has `tabIndex={0}` (the "current" item).
+- All other children have `tabIndex={-1}`.
+- Arrow keys move the `tabIndex={0}` to the next/previous item and programmatically focus it.
+
+Concrete example: `components/ui/AccessibleCalendarGrid.tsx` implements this with `tabIndex={focused ? 0 : -1}` on day cells and Arrow/Home/End/PageUp/PageDown key handlers.
+
+## Keyboard-operable triggers
+
+Any element that responds to a click must also respond to Enter and Space when focused:
+
+```tsx
+<button onKeyDown={(e) => {
+  if (e.key === "Enter" || e.key === " ") {
+    e.preventDefault();
+    activate();
+  }
+}}>
+```
+
+Interactive non-button elements (e.g. `SettingsItem`) use `tabIndex={0}` and the same `onKeyDown` pattern.
+
+## Testing focus behaviour
+
+### What to test
+
+| Scenario | What to assert |
+|----------|---------------|
+| Keyboard Tab reaches the element | `expect(element).toHaveFocus()` |
+| Focus trap wraps Tab at boundaries | After Tab on last element, first element has focus |
+| Focus trap wraps Shift+Tab at boundaries | After Shift+Tab on first element, last element has focus |
+| Escape closes and restores focus | Trigger element has focus after Escape |
+| Mouse click does not leave stray focus ring | No `data-focus-visible` attribute after click |
+| Keyboard focus shows ring | `data-focus-visible` attribute present after Tab |
+| Focus trap cleans up on unmount | `removeEventListener` was called for `keydown` |
+
+### Test helpers
+
+Use `@testing-library/user-event` for realistic keyboard and mouse events:
+
+```tsx
+import userEvent from '@testing-library/user-event';
+
+it('focuses_the_first_element_on_open', async () => {
+  const user = userEvent.setup();
+  render(<MyModal open />);
+  await user.tab();
+  expect(screen.getByRole('button', { name: 'Confirm' })).toHaveFocus();
+});
+```
+
+For axe-based accessibility scans, use the `expectNoAxeViolations` helper from `tests/helpers/a11y.ts`:
+
+```tsx
+import { expectNoAxeViolations } from '@/tests/helpers/a11y';
+
+it('has_no_axe_violations', async () => {
+  const { container } = render(<MyModal open />);
+  await expectNoAxeViolations(container);
+});
+```
+
+### Existing test references
+
+| Test file | What it covers |
+|-----------|---------------|
+| `tests/unit/ui/focus-visible-polyfill.test.tsx` | Mouse vs keyboard focus-visible distinction |
+| `tests/unit/hooks/useFocusTrap.test.tsx` | Focus trap Tab cycling, Escape, cleanup |
+| `tests/unit/hooks/useFocusTrapAdvanced.test.tsx` | Advanced focus trap overlay click, reduced motion |
+| `tests/unit/components/inert-focus-management.test.tsx` | Inert containers cannot receive focus |
+| `tests/unit/components/tooltip-inert.test.tsx` | Tooltip inert behaviour |
+| `tests/integration/modal-inert-behavior.test.tsx` | Modal + inert background integration |
+
+## Common pitfalls
+
+| Pitfall | Fix |
+|---------|-----|
+| Removing `outline` without replacing it | Always pair `focus:outline-none` with `focus:ring-2` (or `focus-visible:ring-*`) |
+| Using `:focus` instead of `:focus-visible` | `:focus` shows the ring on every click; use `:focus-visible` to show it only for keyboard users |
+| Focusable element inside a focus trap with `tabIndex={-1}` | Use a positive or omitted `tabIndex` so the trap can find it |
+| Forgetting `restoreFocusOnClose` | Users are disoriented when focus jumps unexpectedly after a modal closes |
+| Hardcoding focus-ring colours | Use the `focus-visible:ring-focus` Tailwind token instead |
+
+## Related documentation
+
+- [Component States Guide](COMPONENT_STATES.md) — default, hover, focus, disabled, error, loading states
+- [Keyboard Shortcuts](KEYBOARD_SHORTCUTS.md) — every registered keyboard shortcut
+- [Sidebar Accessibility](a11y-sidebar.md) — WCAG 2.1 AA compliance for the navigation sidebar
+- [Testing Guide](testing.md) — Vitest, Playwright, and node:test test strategy
+- [Component Lifecycle](COMPONENT_LIFECYCLE.md) — from Figma to production component
+- [Design Handoff Template](DESIGN_HANDOFF_TEMPLATE.md) — behavioural contract template including accessibility

--- a/docs/COMPONENT_STATES.md
+++ b/docs/COMPONENT_STATES.md
@@ -107,6 +107,7 @@ The **focus state** guarantees accessibility (WCAG compliance) for keyboard user
 - **Focus Ring**: Always apply `focus:outline-none focus:ring-2 focus:ring-brand.red focus:ring-offset-2 focus:ring-offset-black`.
 - **Border Integration**: Clear border contrast when focused (`focus:border-transparent`).
 - **Accessibility**: Never remove outline without providing a visible focus ring replacement.
+- For the full focus management reference — focus-visible styles, hooks, traps, and testing patterns — see [Accessible Focus Baseline](ACCESSIBLE_FOCUS_BASELINE.md).
 
 ### Concrete Example: Accessible Interactive Element
 ```tsx

--- a/docs/a11y-sidebar.md
+++ b/docs/a11y-sidebar.md
@@ -49,6 +49,10 @@
 2. Double-tap to activate
 3. Draw "L" gesture for continuous reading
 
+## Related documentation
+
+For the app-wide focus management contract — focus-visible styles, focus trap hooks, dialog focus restoration, and testing patterns — see the [Accessible Focus Baseline](ACCESSIBLE_FOCUS_BASELINE.md).
+
 ## Axe Testing
 
 ```bash

--- a/tests/unit/accessible-focus-baseline.test.tsx
+++ b/tests/unit/accessible-focus-baseline.test.tsx
@@ -1,0 +1,319 @@
+/**
+ * Tests for the Accessible Focus Baseline documented in docs/ACCESSIBLE_FOCUS_BASELINE.md.
+ *
+ * Validates the core focus management contract:
+ *  - Keyboard focus triggers focus-visible ring (data-focus-visible attribute)
+ *  - Mouse click does NOT leave a stray focus ring
+ *  - Focus trap wraps Tab/Shift+Tab within container boundaries
+ */
+import React, { useRef } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/vitest";
+
+// ---------------------------------------------------------------------------
+// Minimal focus-visible polyfill (mirrors the WICG approach from
+// tests/unit/ui/focus-visible-polyfill.test.tsx)
+// ---------------------------------------------------------------------------
+function useFocusVisiblePolyfill(ref: React.RefObject<HTMLElement | null>) {
+  const mouseDown = React.useRef(false);
+
+  React.useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const onMouseDown = () => {
+      mouseDown.current = true;
+      if (el.hasAttribute("data-focus-visible")) {
+        el.removeAttribute("data-focus-visible");
+      }
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Tab") {
+        mouseDown.current = false;
+      }
+    };
+
+    const onFocus = () => {
+      if (mouseDown.current) {
+        el.removeAttribute("data-focus-visible");
+        mouseDown.current = false;
+      } else {
+        el.setAttribute("data-focus-visible", "");
+      }
+    };
+
+    const onBlur = () => {
+      el.removeAttribute("data-focus-visible");
+    };
+
+    el.addEventListener("mousedown", onMouseDown);
+    el.addEventListener("keydown", onKeyDown);
+    el.addEventListener("focus", onFocus);
+    el.addEventListener("blur", onBlur);
+
+    return () => {
+      el.removeEventListener("mousedown", onMouseDown);
+      el.removeEventListener("keydown", onKeyDown);
+      el.removeEventListener("focus", onFocus);
+      el.removeEventListener("blur", onBlur);
+    };
+  }, [ref]);
+}
+
+function FocusVisibleButton({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  const ref = useRef<HTMLButtonElement>(null);
+  useFocusVisiblePolyfill(ref);
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      className="focus-visible:outline-2 focus-visible:outline-red-500"
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Minimal focus trap (mirrors lib/hooks/useFocusTrap.ts contract)
+// ---------------------------------------------------------------------------
+function FocusTrapModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const previousRef = useRef<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    if (!isOpen || !containerRef.current) return;
+
+    previousRef.current = document.activeElement as HTMLElement;
+
+    const focusable = containerRef.current.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    focusable[0]?.focus();
+
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose?.();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const els = containerRef.current?.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      if (!els || els.length === 0) return;
+
+      const first = els[0];
+      const last = els[els.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handler);
+    return () => {
+      document.removeEventListener("keydown", handler);
+      previousRef.current?.focus();
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div ref={containerRef} role="dialog" aria-modal="true" data-testid="focus-trap">
+      <button data-testid="trap-first">First</button>
+      <input data-testid="trap-middle" placeholder="Middle" />
+      <button data-testid="trap-last">Last</button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("Accessible Focus Baseline", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /* ---------- happy path: keyboard focus is visible ---------- */
+
+  describe("keyboard focus visibility (focus-visible)", () => {
+    it("sets data-focus-visible when button is tabbed to", async () => {
+      render(
+        <>
+          <FocusVisibleButton data-testid="btn-1">Target</FocusVisibleButton>
+          <FocusVisibleButton data-testid="btn-2">Other</FocusVisibleButton>
+        </>,
+      );
+      await user.tab();
+      expect(screen.getByTestId("btn-1")).toHaveAttribute("data-focus-visible");
+    });
+
+    it("removes data-focus-visible on blur and re-applies on re-focus via keyboard", async () => {
+      render(
+        <>
+          <button type="button" />
+          <FocusVisibleButton data-testid="btn-target">Target</FocusVisibleButton>
+          <FocusVisibleButton data-testid="btn-next">Next</FocusVisibleButton>
+        </>,
+      );
+      const target = screen.getByTestId("btn-target");
+
+      await user.tab();
+      await user.tab();
+      expect(target).toHaveAttribute("data-focus-visible");
+
+      await user.tab();
+      expect(target).not.toHaveAttribute("data-focus-visible");
+    });
+  });
+
+  /* ---------- happy path: focus trap wraps correctly ---------- */
+
+  describe("focus trap Tab/Shift+Tab cycling", () => {
+    it("traps Tab within the modal and wraps from last to first", async () => {
+      render(
+        <div>
+          <button data-testid="outside">Outside</button>
+          <FocusTrapModal isOpen onClose={vi.fn()} />
+        </div>,
+      );
+
+      const first = screen.getByTestId("trap-first");
+      const middle = screen.getByTestId("trap-middle");
+      const last = screen.getByTestId("trap-last");
+
+      expect(first).toHaveFocus();
+
+      await user.tab();
+      expect(middle).toHaveFocus();
+
+      await user.tab();
+      expect(last).toHaveFocus();
+
+      await user.tab();
+      expect(first).toHaveFocus();
+    });
+
+    it("wraps Shift+Tab from first element to last", () => {
+      render(<FocusTrapModal isOpen onClose={vi.fn()} />);
+
+      const first = screen.getByTestId("trap-first");
+      const last = screen.getByTestId("trap-last");
+
+      expect(first).toHaveFocus();
+
+      fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+      expect(last).toHaveFocus();
+    });
+
+    it("calls onEscape when Escape is pressed", async () => {
+      const onClose = vi.fn();
+      render(<FocusTrapModal isOpen onClose={onClose} />);
+
+      await user.keyboard("{Escape}");
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not trap focus when inactive", async () => {
+      render(
+        <div>
+          <button data-testid="outside">Outside</button>
+          <FocusTrapModal isOpen={false} onClose={vi.fn()} />
+        </div>,
+      );
+
+      const outside = screen.getByTestId("outside");
+      outside.focus();
+      expect(outside).toHaveFocus();
+      expect(screen.queryByTestId("focus-trap")).not.toBeInTheDocument();
+    });
+  });
+
+  /* ---------- failure mode: mouse click does not leave stray ring ---------- */
+
+  describe("mouse click does not leave stray focus ring", () => {
+    it("does not set data-focus-visible on mouse click", async () => {
+      render(
+        <>
+          <FocusVisibleButton data-testid="btn-a">First</FocusVisibleButton>
+          <FocusVisibleButton data-testid="btn-b">Second</FocusVisibleButton>
+        </>,
+      );
+
+      const first = screen.getByTestId("btn-a");
+      await user.click(first);
+
+      expect(first).not.toHaveAttribute("data-focus-visible");
+    });
+
+    it("removes data-focus-visible when a keyboard-focused element is clicked", async () => {
+      render(
+        <>
+          <FocusVisibleButton data-testid="btn-x">Target</FocusVisibleButton>
+          <FocusVisibleButton data-testid="btn-y">Other</FocusVisibleButton>
+        </>,
+      );
+
+      const target = screen.getByTestId("btn-x");
+
+      await user.tab();
+      expect(target).toHaveAttribute("data-focus-visible");
+
+      await user.click(target);
+      expect(target).not.toHaveAttribute("data-focus-visible");
+    });
+  });
+
+  /* ---------- failure mode: focus does not escape trap ---------- */
+
+  describe("focus trap prevents focus escape", () => {
+    it("prevents focus from reaching elements outside the trap", async () => {
+      render(
+        <div>
+          <button data-testid="before-trap">Before</button>
+          <FocusTrapModal isOpen onClose={vi.fn()} />
+          <button data-testid="after-trap">After</button>
+        </div>,
+      );
+
+      const beforeTrap = screen.getByTestId("before-trap");
+      const afterTrap = screen.getByTestId("after-trap");
+      const first = screen.getByTestId("trap-first");
+      const last = screen.getByTestId("trap-last");
+
+      expect(first).toHaveFocus();
+
+      // Multiple Tab presses should stay within the trap
+      await user.tab();
+      await user.tab();
+      await user.tab();
+      expect(first).toHaveFocus();
+      expect(afterTrap).not.toHaveFocus();
+      expect(beforeTrap).not.toHaveFocus();
+
+      // Shift+Tab should also stay within the trap
+      fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+      expect(last).toHaveFocus();
+      expect(beforeTrap).not.toHaveFocus();
+      expect(afterTrap).not.toHaveFocus();
+    });
+  });
+});


### PR DESCRIPTION
Documents the accessible-focus baseline for the RemitWise frontend, giving contributors a single reference for how focus is managed across the app.

New file: docs/ACCESSIBLE_FOCUS_BASELINE.md
New file: tests/unit/accessible-focus-baseline.test.tsx (9 tests)
Cross-links added: README.md, docs/COMPONENT_STATES.md, docs/a11y-sidebar.md

Closes #1221