### PR TITLE
feat: add just check recipe (lint + typecheck + test)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,10 @@ All commands below are verified against `package.json`. For contributor testing 
 ### Quick reference
 
 ```bash
+just check                # Run lint + typecheck + test (requires `just`)
+npm run check             # Run lint + typecheck + test (no extra deps)
 npm run lint              # ESLint across the whole project
+npm run typecheck         # TypeScript type-check (tsc --noEmit)
 npm run build             # Next.js production build (also runs tsc)
 npm run test              # Alias for test:unit
 npm run test:unit         # Runs BOTH node:test suites AND Vitest unit tests (see below)

--- a/PR_SUMMARY_1225.md
+++ b/PR_SUMMARY_1225.md
@@ -1,0 +1,29 @@
+## Summary
+
+Add a `just check` recipe (and `npm run check`) that runs lint + typecheck + test in a single command, tightening the contributor feedback loop.
+
+## Changes
+
+- **`package.json`** – Added two npm scripts:
+  - `typecheck`: runs `tsc` (TypeScript type-checking)
+  - `check`: chains `npm run lint && npm run typecheck && npm test`
+- **`justfile`** (new) – A `check` recipe that delegates to `npm run check`, giving `just` users a uniform entry point.
+- **`CONTRIBUTING.md`** – Added `just check` and `npm run check` to the quick reference.
+- **`docs/testing.md`** – Updated the pre-PR checklist to use `npm run typecheck` and `npm run check` instead of raw `npx tsc --noEmit`.
+- **`docs/TESTING_STANDARDS.md`** – Updated the type-checking checklist item to prefer `npm run typecheck`.
+
+## Usage
+
+```bash
+# With `just` installed
+just check
+
+# Without `just`
+npm run check
+```
+
+## Idempotency
+
+All scripts are safe to re-run. The `check` recipe and `check` script are simple sequential compositions of existing idempotent commands (`lint`, `tsc`, `test`).
+
+Closes #1225

--- a/docs/TESTING_STANDARDS.md
+++ b/docs/TESTING_STANDARDS.md
@@ -218,7 +218,7 @@ npx playwright test tests/e2e/send-flow.spec.ts:31
 Before opening or requesting review on a Pull Request, ensure that you have run and verified the following locally:
 
 - [ ] **1. Linting Passes:** `npm run lint` completes with zero errors or warnings.
-- [ ] **2. Type Checking Passes:** `npx tsc --noEmit` (or `npm run build`) completes without TypeScript errors.
+- [ ] **2. Type Checking Passes:** `npm run typecheck` (or `npx tsc --noEmit` or `npm run build`) completes without TypeScript errors.
 - [ ] **3. Unit Tests Pass:** `npm test` executes cleanly and all unit tests pass.
 - [ ] **4. Integration / E2E Tests Pass:** If your changes touch API routes, database schemas, or user flows, `npm run test:integration` and `npm run test:e2e` pass.
 - [ ] **5. New Logic Is Tested:** Tests are included for all newly added functions, hooks, components, routes, or bug fixes.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -234,13 +234,13 @@ Before opening a PR, run the same checks CI runs (see
 
 ```bash
 npm run lint            # ESLint must pass
-npx tsc --noEmit        # type-check (npm run build runs this as part of next build)
+npm run typecheck        # type-check (npm run build runs tsc as part of next build)
 npm run test            # unit suites
 npm run test:integration# integration suites (needs DATABASE_URL)
 npm run test:e2e        # Playwright (CI installs chromium first)
 ```
 
-For local development the fast loop is `npm run lint && npx tsc --noEmit && npm run test`;
+For local development the fast loop is `npm run check` (or `npm run lint && npm run typecheck && npm run test`);
 run `npm run test:coverage`, `test:integration`, and `test:e2e` before pushing anything
 that touches API routes, validation, or user flows.
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,2 @@
+check:
+    npm run check

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "check:img-alt": "node scripts/check-img-alt.js",
     "lint": "eslint . && npm run check:img-alt",
     "check:img-alt": "node scripts/check-img-alt.js",
+    "typecheck": "tsc",
+    "check": "npm run lint && npm run typecheck && npm test",
     "test": "npm run test:unit",
     "test:coverage": "node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner --coverage",
     "test:watch": "node node_modules/vitest/vitest.mjs --config vitest.config.mjs --configLoader runner",


### PR DESCRIPTION
## Summary

Add a `just check` recipe (and `npm run check`) that runs lint + typecheck + test in a single command, tightening the contributor feedback loop.

## Changes

- **`package.json`** – Added two npm scripts:
  - `typecheck`: runs `tsc` (TypeScript type-checking)
  - `check`: chains `npm run lint && npm run typecheck && npm test`
- **`justfile`** (new) – A `check` recipe that delegates to `npm run check`, giving `just` users a uniform entry point.
- **`CONTRIBUTING.md`** – Added `just check` and `npm run check` to the quick reference.
- **`docs/testing.md`** – Updated the pre-PR checklist to use `npm run typecheck` and `npm run check` instead of raw `npx tsc --noEmit`.
- **`docs/TESTING_STANDARDS.md`** – Updated the type-checking checklist item to prefer `npm run typecheck`.

## Usage

```bash
# With `just` installed
just check

# Without `just`
npm run check
```

## Idempotency

All scripts are safe to re-run. The `check` recipe and `check` script are simple sequential compositions of existing idempotent commands (`lint`, `tsc`, `test`).

Closes #1225
