### PR TITLE
feat: expose auth-issuer URL as runtime env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,14 @@ BILLS_CONTRACT_ID=CACDYF3CYMJEJTIVFESQYZTN67GO2R5D5IUABTCUG3HXQSRXCSOROBAN
 SESSION_PASSWORD=supersecurelongsessionpasswordatleast32characters!!
 
 # ============================================
+# Auth Issuer URL
+# ============================================
+# The URL of the authentication issuer. Used to identify the issuer in
+# SEP-10 Web Authentication challenges and as the `iss` claim in tokens.
+# Defaults to http://localhost:3000 if not set.
+AUTH_ISSUER=http://localhost:3000
+
+# ============================================
 # Auth Secret (used in tests / API)
 # ============================================
 AUTH_SECRET=test-secret-for-local-dev-only

--- a/lib/config/auth.test.ts
+++ b/lib/config/auth.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const ORIGINAL_ENV = { ...process.env }
+
+beforeEach(() => {
+  vi.resetModules()
+  process.env = { ...ORIGINAL_ENV }
+})
+
+describe('AUTH_CONFIG', () => {
+  it('uses the default URL when AUTH_ISSUER is not set', async () => {
+    delete process.env.AUTH_ISSUER
+    const { AUTH_CONFIG } = await import('@/lib/config/auth')
+    expect(AUTH_CONFIG.issuer).toBe('http://localhost:3000')
+  })
+
+  it('reads AUTH_ISSUER from the environment when set', async () => {
+    process.env.AUTH_ISSUER = 'https://auth.remitwise.com'
+    const { AUTH_CONFIG } = await import('@/lib/config/auth')
+    expect(AUTH_CONFIG.issuer).toBe('https://auth.remitwise.com')
+  })
+})

--- a/lib/config/auth.ts
+++ b/lib/config/auth.ts
@@ -1,0 +1,3 @@
+export const AUTH_CONFIG = {
+  issuer: process.env.AUTH_ISSUER || 'http://localhost:3000',
+}


### PR DESCRIPTION
## Summary

Expose the auth-issuer URL as a runtime environment variable via a dedicated config module, following the principle of sane default first with environment override.

## Background

The app's authentication flow needs a well-known issuer URL for SEP-10 Web Authentication challenges and as the `iss` claim in tokens. Previously this value was hard-coded or absent. This change makes it configurable at runtime through a single environment variable, with a sensible local-development default.

## Changes

### `lib/config/auth.ts` (new)
- Exports `AUTH_CONFIG` object with an `issuer` property
- Defaults to `http://localhost:3000` (suitable for local dev)
- Overridable via the `AUTH_ISSUER` environment variable
- Follows the existing config module pattern used by `lib/config/stellar.ts`, `lib/config/seo.ts`, etc.
- Env var is read at the config boundary — not deep inside business logic — per the implementation hints

### `.env.example`
- Added `AUTH_ISSUER` entry with documentation comment explaining its purpose (SEP-10 issuer identification, token `iss` claim)
- Placed alongside related auth configuration (`AUTH_SECRET`) for discoverability

### `lib/config/auth.test.ts` (new)
- **Happy path**: verifies that setting `AUTH_ISSUER` to a custom URL is reflected in the config
- **Failure mode**: verifies that when `AUTH_ISSUER` is absent, the default `http://localhost:3000` is used
- Uses `vi.resetModules()` to ensure each test gets a fresh module evaluation (since the config is computed at import time)

## Usage

```bash
# Default (local dev)
# AUTH_ISSUER defaults to http://localhost:3000

# Custom issuer
AUTH_ISSUER=https://auth.remitwise.com npm run dev

# In code
import { AUTH_CONFIG } from '@/lib/config/auth'
console.log(AUTH_CONFIG.issuer) // 'https://auth.remitwise.com'
```

## Verification

- `npm run typecheck` — passes (no type errors in new files)
- `npm run lint` — clean
- `npm test` — new test file included in the `lib/**/*.test.ts` glob pattern; covers both default and override paths

## Idempotency

The config module is stateless — reading `process.env.AUTH_ISSUER` at import time with a fallback default. Multiple imports return the same computed value. No side effects.

Closes #1229
