### PR TITLE
feat: Add QuickRefreshButton and tests

### DIFF
--- a/components/QuickRefreshButton.tsx
+++ b/components/QuickRefreshButton.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { RefreshCw } from "lucide-react";
+import { useClientTranslator } from "@/lib/i18n/client";
+
+export default function QuickRefreshButton() {
+  const queryClient = useQueryClient();
+  const { t } = useClientTranslator();
+
+  const handleRefresh = () => {
+    // Triggers refetch on all mounted queries
+    queryClient.refetchQueries({ type: "active" });
+  };
+
+  return (
+    <button
+      onClick={handleRefresh}
+      aria-label={t("quickRefresh.label") || "Quick Refresh"}
+      className="inline-flex items-center justify-center gap-2 rounded-md bg-white/[0.02] px-3 py-2 text-sm font-medium text-white hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red/50 transition-colors"
+    >
+      <RefreshCw className="h-4 w-4" aria-hidden="true" />
+      <span>{t("quickRefresh.button") || "Refresh"}</span>
+    </button>
+  );
+}

--- a/tests/unit/components/QuickRefreshButton.test.tsx
+++ b/tests/unit/components/QuickRefreshButton.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+
+const refetchQueries = vi.fn()
+
+vi.mock('@tanstack/react-query', () => {
+  return {
+    useQueryClient: () => ({
+      refetchQueries
+    })
+  }
+})
+
+vi.mock('@/lib/i18n/client', () => ({
+  useClientTranslator: () => ({
+    t: (key: string) => {
+      if (key === 'quickRefresh.label') return 'Quick Refresh'
+      if (key === 'quickRefresh.button') return 'Refresh'
+      return key
+    },
+  }),
+}))
+
+import QuickRefreshButton from '@/components/QuickRefreshButton'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('QuickRefreshButton', () => {
+  it('renders the refresh button', () => {
+    render(<QuickRefreshButton />)
+    const button = screen.getByRole('button', { name: 'Quick Refresh' })
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveTextContent('Refresh')
+  })
+
+  it('triggers refetch on all mounted queries when clicked', async () => {
+    render(<QuickRefreshButton />)
+    const button = screen.getByRole('button', { name: 'Quick Refresh' })
+    
+    const user = userEvent.setup()
+    await user.click(button)
+    
+    expect(refetchQueries).toHaveBeenCalledTimes(1)
+    expect(refetchQueries).toHaveBeenCalledWith({ type: 'active' })
+  })
+})


### PR DESCRIPTION
Closes #1136 


This PR introduces the `QuickRefreshButton` component and its corresponding unit tests to ensure it triggers a refetch on all mounted queries.

## Changes
- **Added `QuickRefreshButton`:** A component that utilizes `@tanstack/react-query` to call `queryClient.refetchQueries({ type: 'active' })` when clicked.
- **Added Unit Tests:** Included executable test cases in `tests/unit/components/QuickRefreshButton.test.tsx` using `vitest` and `@testing-library/react`. The tests mock the `useQueryClient` hook and verify that `refetchQueries` is invoked exactly once with `{ type: 'active' }`.
- **Accessibility:** Ensured the component has a proper `aria-label` matching standard a11y practices.

## Acceptance Criteria Met
- [x] The change matches the summary above.
- [x] The new test passes (and correctly fails if the `queryClient.refetchQueries` call is omitted).
- [x] Lint, type-check, and tests all pass locally.