### PR TITLE
docs: add typography scale documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is a Next.js-based frontend skeleton that provides the UI structure for all
 - **Next.js 14** - React framework with App Router
 - **TypeScript** - Type safety
 - **Tailwind CSS** - Utility-first styling
+- **Typography Scale** - See [docs/TYPOGRAPHY_SCALE.md](docs/TYPOGRAPHY_SCALE.md) for the project typography scale, font weights, line heights, and usage guidance.
 - **Lucide React** - Icon library — see [docs/ICON_SYSTEM.md](docs/ICON_SYSTEM.md) for usage, sizing, and adding custom icons
 
 ## Features (Placeholders)

--- a/docs/TYPOGRAPHY_SCALE.md
+++ b/docs/TYPOGRAPHY_SCALE.md
@@ -1,0 +1,147 @@
+# Typography Scale
+
+## Audience
+
+This guide is intended for contributors working on the RemitWise frontend.
+
+## Overview
+
+RemitWise uses Tailwind CSS's default typography utilities rather than a custom typography scale in `tailwind.config.js`. Contributors should reuse the existing utilities to maintain visual consistency across the application.
+
+## Font Sizes
+
+The project commonly uses the following Tailwind font-size utilities:
+
+| Utility | Typical Usage |
+|---------|---------------|
+| `text-xs` | Badges, labels, helper text, table metadata |
+| `text-sm` | Body text, form labels, descriptions |
+| `text-base` | Primary body copy |
+| `text-lg` | Section headings |
+| `text-xl` | Dialog titles |
+| `text-2xl` | Page headings |
+| `text-3xl` | Statistics and dashboard metrics |
+| `text-4xl` | Hero or landing page headings |
+
+## Font Weights
+
+Use semantic weights consistently.
+
+| Utility | Usage |
+|---------|-------|
+| `font-normal` | Standard body copy |
+| `font-medium` | Interactive labels and controls |
+| `font-semibold` | Section headings and emphasis |
+| `font-bold` | Primary page headings and key metrics |
+
+## Line Heights
+
+Prefer Tailwind's built-in line-height utilities.
+
+| Utility | Typical Usage |
+|---------|---------------|
+| `leading-5` | Compact supporting text |
+| `leading-6` | Standard body copy |
+| `leading-7` | Larger headings |
+| `leading-relaxed` | Long-form descriptive content |
+| `leading-none` | Large numeric values and display text |
+
+## Examples
+
+```tsx
+<h1 className="text-2xl font-bold">
+  Dashboard
+</h1>
+
+<h2 className="text-lg font-semibold">
+  Account Summary
+</h2>
+
+<p className="text-sm leading-6">
+  Review your recent transactions and account activity.
+</p>
+
+<span className="text-xs font-medium">
+  Pending
+</span>
+```
+
+## Rationale
+
+- Reuse Tailwind's standard typography utilities instead of introducing one-off values.
+- Keep headings, body text, and metadata visually consistent across the application.
+- Prefer semantic utility classes over arbitrary font sizes unless there is a documented design requirement.
+- When adding new UI, match existing typography before creating new patterns.# Typography Scale
+
+## Audience
+
+This guide is intended for contributors working on the RemitWise frontend.
+
+## Overview
+
+RemitWise uses Tailwind CSS's default typography utilities rather than a custom typography scale in `tailwind.config.js`. Contributors should reuse the existing utilities to maintain visual consistency across the application.
+
+## Font Sizes
+
+The project commonly uses the following Tailwind font-size utilities:
+
+| Utility | Typical Usage |
+|---------|---------------|
+| `text-xs` | Badges, labels, helper text, table metadata |
+| `text-sm` | Body text, form labels, descriptions |
+| `text-base` | Primary body copy |
+| `text-lg` | Section headings |
+| `text-xl` | Dialog titles |
+| `text-2xl` | Page headings |
+| `text-3xl` | Statistics and dashboard metrics |
+| `text-4xl` | Hero or landing page headings |
+
+## Font Weights
+
+Use semantic weights consistently.
+
+| Utility | Usage |
+|---------|-------|
+| `font-normal` | Standard body copy |
+| `font-medium` | Interactive labels and controls |
+| `font-semibold` | Section headings and emphasis |
+| `font-bold` | Primary page headings and key metrics |
+
+## Line Heights
+
+Prefer Tailwind's built-in line-height utilities.
+
+| Utility | Typical Usage |
+|---------|---------------|
+| `leading-5` | Compact supporting text |
+| `leading-6` | Standard body copy |
+| `leading-7` | Larger headings |
+| `leading-relaxed` | Long-form descriptive content |
+| `leading-none` | Large numeric values and display text |
+
+## Examples
+
+```tsx
+<h1 className="text-2xl font-bold">
+  Dashboard
+</h1>
+
+<h2 className="text-lg font-semibold">
+  Account Summary
+</h2>
+
+<p className="text-sm leading-6">
+  Review your recent transactions and account activity.
+</p>
+
+<span className="text-xs font-medium">
+  Pending
+</span>
+```
+
+## Rationale
+
+- Reuse Tailwind's standard typography utilities instead of introducing one-off values.
+- Keep headings, body text, and metadata visually consistent across the application.
+- Prefer semantic utility classes over arbitrary font sizes unless there is a documented design requirement.
+- When adding new UI, match existing typography before creating new patterns.


### PR DESCRIPTION
## Summary

Adds a typography scale guide for contributors and links it from the README.

## Changes

- Added `docs/TYPOGRAPHY_SCALE.md`
- Documented:
  - Tailwind font sizes
  - Font weights
  - Line-height utilities
  - Usage examples
  - Typography rationale
- Added a link to the typography guide in `README.md`

## Testing

- Documentation only
- No code changes