### PR TITLE
feat: soft-error toast + 30 s client request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ For authenticated browser-side requests, use the shared client API layer documen
 
 For server-side and third-party requests that need automatic abort on deadline, use the `fetchWithTimeout` wrapper documented in [docs/fetch-timeout.md](docs/fetch-timeout.md). Each endpoint declares its timeout in `lib/config/fetch-timeouts.ts`; the wrapper aborts and throws a `TimeoutError` if the deadline is exceeded. `apiClient` uses the same design for browser requests.
 
+`apiClient` also applies a **30 s outer request budget** (`CLIENT_REQUEST_TIMEOUT_MS` in `lib/config/fetch-timeouts.ts`) that covers the entire lifecycle of a browser request — per-attempt timeouts, retry backoffs, and the session-refresh replay. When the budget fires the global `useNetworkErrorToast` hook shows a soft-error toast: **"Something went wrong. Retry?"** with an inline Retry button. This behavior is automatic; no call-site code is required. See [docs/toast-pattern.md](docs/toast-pattern.md) for the full toast system documentation.
+
 ### Transaction Export
 
 Both the standalone **Transactions** page (`/transactions`) and the dashboard

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -15,6 +15,7 @@ import SessionExpiryProvider from "@/components/SessionExpiryProvider";
 import CommandPalette from "@/components/CommandPalette";
 import ShortcutHelpModal from "@/components/ShortcutHelpModal";
 import { apiClient } from "@/lib/client/apiClient";
+import NetworkErrorToastProvider from "@/lib/hooks/useNetworkErrorToast";
 
 /** Keeps the API client's authorization header aligned with wallet state. */
 function ApiClientAuthBridge() {
@@ -41,6 +42,8 @@ export default function Providers({ children }: { children: ReactNode }) {
     <WalletProvider>
       <ApiClientAuthBridge />
       <ToastProvider>
+        {/* Soft-error toast for network failures (#924) */}
+        <NetworkErrorToastProvider />
         <DensityProvider>
           <AsyncOperationsProvider>
             <SessionExpiryProvider>

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -33,3 +33,56 @@ useEventListener("click", () => {
 ```
 
 The hook is safe to use in server-rendered components. It also keeps the latest handler without requiring callers to manually register and clean up listeners.
+
+## `useNetworkErrorToast` (#924)
+
+**File:** `lib/hooks/useNetworkErrorToast.ts`
+
+Listens for the `network-error` window event dispatched by `apiClient` when a
+request fails at the transport level and converts it into a soft-error toast:
+
+> **"Something went wrong. Retry?"** [Retry]
+
+The hook must be used inside a `ToastProvider`. Mount it once, globally, via
+`NetworkErrorToastProvider` (already wired in `components/Providers.tsx`).
+
+### `useNetworkErrorToast()`
+
+```ts
+import { useNetworkErrorToast } from "@/lib/hooks/useNetworkErrorToast";
+
+// Inside a component that is a descendant of ToastProvider:
+useNetworkErrorToast();
+```
+
+Attaches and cleans up the window event listener automatically. Returns `void`.
+
+### `NetworkErrorToastProvider` (default export)
+
+A zero-output component that mounts the hook so it can be placed anywhere in the
+tree without adding a visible DOM node:
+
+```tsx
+import NetworkErrorToastProvider from "@/lib/hooks/useNetworkErrorToast";
+
+// Inside <ToastProvider>:
+<NetworkErrorToastProvider />
+```
+
+### Toast behavior
+
+| Property | Value |
+|----------|-------|
+| `variant` | `"error"` |
+| `title` | `"Something went wrong. Retry?"` |
+| `description` | `"The request timed out."` when `isTimeout: true`; omitted otherwise |
+| `action` | `{ label: "Retry", onClick: retry }` |
+| `duration` | `0` (manual dismissal — user may want to click Retry) |
+
+### Related
+
+- [`lib/client/networkErrorEvent.ts`](../lib/client/networkErrorEvent.ts) — `dispatchNetworkError()`, event constants and types
+- [`lib/client/apiClient.ts`](../lib/client/apiClient.ts) — dispatches the event on transport failure
+- [`lib/config/fetch-timeouts.ts`](../lib/config/fetch-timeouts.ts) — `CLIENT_REQUEST_TIMEOUT_MS = 30_000`
+- [`docs/toast-pattern.md`](toast-pattern.md) — full toast system documentation
+- [`docs/client-api.md`](client-api.md) — `apiClient` contract and options

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -53,6 +53,36 @@ For widget-style read surfaces that should stay inline while transient failures 
 - `retries?: number` — max retry attempts for idempotent (`GET`/`HEAD`) requests. Default `3`. Ignored for writes.
 - `backoff?: number` — base backoff in ms; doubles each attempt and is jittered. Default `1000`.
 - `timeout?: number` — per-request timeout in ms before the request is aborted. Default `10000`. Pass `0` to disable.
+- `requestTimeout?: number` — hard wall-clock budget in ms for the **entire** logical request, including all per-attempt timeouts, retry backoffs, and the session-refresh replay. Default `30000` (`CLIENT_REQUEST_TIMEOUT_MS`). Pass `0` to disable the outer guard entirely.
+
+### Network-error soft toast (#924)
+
+When a request fails at the transport level (network unreachable, per-attempt
+timeout exhausted after all retries, or the 30 s outer budget fires) `apiClient`
+automatically dispatches a `network-error` window event.
+
+The global `useNetworkErrorToast` hook (mounted once in `Providers.tsx` via
+`NetworkErrorToastProvider`) picks up that event and renders a soft-error toast:
+
+> **"Something went wrong. Retry?"**  [Retry]
+
+- The toast requires manual dismissal (`duration: 0`) so the user can still
+  click **Retry** after acknowledging it.
+- Clicking **Retry** re-issues the exact same request transparently.
+- When the failure was a timeout `isTimeout: true` is set and the description
+  reads "The request timed out."
+- The toast does **not** fire for successful responses, `4xx`/`5xx` HTTP errors
+  returned from the server (those are caller-handled), or session-expiry `401`
+  flows (which use their own notification).
+
+The event bridge lives at `lib/client/networkErrorEvent.ts`.  The hook lives at
+`lib/hooks/useNetworkErrorToast.ts`.  Neither creates a circular import with
+`apiClient`.
+
+Related modules:
+- [`lib/client/networkErrorEvent.ts`](../lib/client/networkErrorEvent.ts): `dispatchNetworkError()`, `NETWORK_ERROR_EVENT`, `NetworkErrorDetail`
+- [`lib/hooks/useNetworkErrorToast.ts`](../lib/hooks/useNetworkErrorToast.ts): `useNetworkErrorToast()`, `NetworkErrorToastProvider`
+- [`lib/config/fetch-timeouts.ts`](../lib/config/fetch-timeouts.ts): `CLIENT_REQUEST_TIMEOUT_MS = 30_000`
 
 ### Shared authentication and request IDs
 
@@ -90,16 +120,27 @@ Interpret the result like this:
 
 ### Timeout
 
-Every request (regardless of method) runs under a per-request timeout enforced
-with an `AbortController`. The default is `10000` ms and is configurable via the
-`timeout` option (`0` disables it). When the timeout fires, the in-flight fetch
-is aborted. For idempotent requests this counts as a retryable failure; once
-retries are exhausted (or for writes) the call rejects with a `TimeoutError`
-`DOMException`.
+Two independent timeout guards operate on every `apiClient` request:
 
-The timeout is composed with any caller-supplied `signal`, so a component
-unmount or `useFormAction`'s latest-wins abort still cancels the request
-immediately (see [Aborting requests](#aborting-requests)).
+**Per-attempt timeout (`timeout`, default 10 s)**
+Enforced with an `AbortController` on each individual fetch attempt. When the
+timeout fires, the in-flight fetch is aborted. For idempotent requests this
+counts as a retryable failure; once retries are exhausted (or for writes) the
+call rejects with a `TimeoutError` `DOMException`. Configurable via `timeout`;
+pass `0` to disable.
+
+**Outer request budget (`requestTimeout`, default 30 s — `CLIENT_REQUEST_TIMEOUT_MS`)**
+A hard wall-clock budget covering the **entire** logical request — per-attempt
+timeouts, retry backoffs, and the session-refresh replay all count against it.
+When the budget fires the request is aborted and a `network-error` event is
+dispatched so the global toast shows "Something went wrong. Retry?". Configurable
+via `requestTimeout`; pass `0` to disable. The constant is defined in
+`lib/config/fetch-timeouts.ts` so it stays auditable alongside the per-endpoint
+policy.
+
+Both timeout guards are composed with any caller-supplied `signal`, so a
+component unmount or `useFormAction`'s latest-wins abort still cancels the
+request immediately (see [Aborting requests](#aborting-requests)).
 
 ### Retry Behavior
 

--- a/docs/fetch-timeout.md
+++ b/docs/fetch-timeout.md
@@ -65,6 +65,7 @@ policy stays auditable and consistent.
 
 | Pattern                   | Constant                       | Value  | Rationale                                                  |
 | ------------------------- | ------------------------------ | ------ | ---------------------------------------------------------- |
+| _(client request budget)_ | `CLIENT_REQUEST_TIMEOUT_MS`    | 30 s   | Hard outer budget for the entire `apiClient` request cycle (retries + session-refresh replay). See [below](#client-request-budget). |
 | `/api/auth/nonce`         | `AUTH_NONCE_TIMEOUT_MS`        | 5 s    | Lightweight; fail fast.                                    |
 | `/api/auth/login`         | `AUTH_LOGIN_TIMEOUT_MS`        | 8 s    | Crypto verification on the server.                         |
 | `/api/auth/refresh`       | `AUTH_REFRESH_TIMEOUT_MS`      | 5 s    | Token refresh must be fast so it doesn't block requests.   |
@@ -82,6 +83,31 @@ policy stays auditable and consistent.
 | `/api/split`              | `CONTRACT_READ_TIMEOUT_MS`     | 12 s   | Soroban RPC round-trip.                                    |
 | `/api/family`             | `CONTRACT_READ_TIMEOUT_MS`     | 12 s   | Soroban RPC round-trip.                                    |
 | _(anything else)_         | `DEFAULT_FETCH_TIMEOUT_MS`     | 10 s   | Safe default for unknown routes.                           |
+
+### Client request budget
+
+`CLIENT_REQUEST_TIMEOUT_MS = 30_000` is a hard wall-clock budget that
+`apiClient` applies to the **entire** lifecycle of a logical request —
+per-attempt timeouts, retry backoffs, and the one-time session-refresh replay
+all count against it.
+
+When the budget fires the in-flight request is aborted and a `network-error`
+window event is dispatched, which causes the global toast to show:
+
+> "Something went wrong. Retry?" [Retry]
+
+The constant lives in `lib/config/fetch-timeouts.ts` (not inline in
+`apiClient`) so it remains auditable alongside the per-endpoint policy.
+
+Override per call via `ApiClientOptions.requestTimeout` or pass `0` to disable:
+
+```ts
+// Custom 10 s budget for a lightweight call
+apiClient.get('/api/status', { requestTimeout: 10_000 });
+
+// Disable the outer guard entirely (use with care)
+apiClient.get('/api/patient', { requestTimeout: 0 });
+```
 
 ### Matching algorithm
 

--- a/docs/network-error-toast.md
+++ b/docs/network-error-toast.md
@@ -1,0 +1,196 @@
+# Network-Error Toast & Client Request Timeout
+
+Closes [#924](https://github.com/Remitwise-Org/Remitwise-Frontend/issues/924) ·
+Closes [#978](https://github.com/Remitwise-Org/Remitwise-Frontend/issues/978)
+
+## Overview
+
+Two related enhancements that improve UX when an `apiClient` request fails at
+the transport level:
+
+1. **Soft-error toast (#924):** Any transport failure (network down, timeout
+   exhausted) automatically shows a non-blocking toast: "Something went wrong.
+   Retry?" with an inline Retry button. No call-site code required.
+
+2. **30 s client-side timeout (#978):** A hard outer budget covers the entire
+   lifecycle of every `apiClient` request — per-attempt timeouts, retry
+   backoffs, and the session-refresh replay. Any request that does not resolve
+   within 30 s is aborted and the soft-error toast fires.
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `lib/client/networkErrorEvent.ts` | `NETWORK_ERROR_EVENT`, `NetworkErrorDetail`, `dispatchNetworkError()` |
+| `lib/hooks/useNetworkErrorToast.ts` | `useNetworkErrorToast` hook + `NetworkErrorToastProvider` |
+| `lib/config/fetch-timeouts.ts` | `CLIENT_REQUEST_TIMEOUT_MS = 30_000` (single constant, single source of truth) |
+| `lib/client/apiClient.ts` | Integrates both: 30 s outer `AbortController`, event dispatch on failure |
+| `components/Providers.tsx` | Mounts `NetworkErrorToastProvider` inside `ToastProvider` globally |
+| `tests/unit/apiClient.network-toast.test.ts` | 13 tests — event dispatch + outer timeout |
+| `tests/unit/hooks/useNetworkErrorToast.test.tsx` | 13 tests — hook rendering, Retry action, lifecycle |
+
+---
+
+## Public API
+
+### `CLIENT_REQUEST_TIMEOUT_MS` (#978)
+
+```ts
+import { CLIENT_REQUEST_TIMEOUT_MS } from '@/lib/config/fetch-timeouts';
+// → 30_000
+```
+
+Single authoritative constant for the `apiClient` outer request budget. **Do not
+inline this value** at call sites — always reference the constant.
+
+Override per call via `ApiClientOptions.requestTimeout`:
+
+```ts
+// Tighter 10 s budget for a lightweight status call
+apiClient.get('/api/health', { requestTimeout: 10_000 });
+
+// Disable the outer guard for a long-running upload (use with care)
+apiClient.post('/api/upload', { body: file, requestTimeout: 0 });
+```
+
+---
+
+### `dispatchNetworkError(detail)` (#924)
+
+```ts
+import {
+  dispatchNetworkError,
+  NETWORK_ERROR_EVENT,
+} from '@/lib/client/networkErrorEvent';
+import type { NetworkErrorDetail, NetworkErrorEvent } from '@/lib/client/networkErrorEvent';
+```
+
+Dispatches a `network-error` `CustomEvent` on `window`. Called internally by
+`apiClient`; exported for testing and other HTTP layers that want the same toast.
+
+Safe to call in SSR contexts — silently skipped when `window` is not available.
+
+#### `NetworkErrorDetail`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `url` | `string` | URL of the request that failed |
+| `retry` | `() => void` | Callback to re-issue the same request |
+| `isTimeout` | `boolean` | `true` when failure was a `DOMException` with `name === 'TimeoutError'` |
+
+---
+
+### `useNetworkErrorToast()` (#924)
+
+```ts
+import { useNetworkErrorToast } from '@/lib/hooks/useNetworkErrorToast';
+```
+
+React hook. Attaches a `window` listener for `network-error` events and calls
+`useToast()` to show the toast. Must be used inside a `ToastProvider`.
+
+The listener is removed automatically on unmount — no cleanup needed by callers.
+
+---
+
+### `NetworkErrorToastProvider` (default export) (#924)
+
+```tsx
+import NetworkErrorToastProvider from '@/lib/hooks/useNetworkErrorToast';
+
+// Inside <ToastProvider>:
+<NetworkErrorToastProvider />
+```
+
+Zero-output component that mounts `useNetworkErrorToast()` globally so the hook
+is active for every `apiClient` call without individual pages opting in.
+Already wired in `components/Providers.tsx`.
+
+---
+
+## Toast appearance
+
+| Property | Value |
+|----------|-------|
+| `variant` | `"error"` |
+| `title` | `"Something went wrong. Retry?"` |
+| `description` | `"The request timed out."` (when `isTimeout: true`; omitted otherwise) |
+| `action` | `{ label: "Retry", onClick: retry }` |
+| `duration` | `0` (requires manual dismissal so user can still click Retry) |
+
+---
+
+## When it fires / when it does NOT fire
+
+| Scenario | Fires? |
+|----------|--------|
+| Network unreachable (fetch rejects) | ✅ Yes |
+| Per-attempt timeout exhausted after all retries | ✅ Yes |
+| 30 s outer budget fires | ✅ Yes |
+| Successful response (any HTTP status) | ❌ No |
+| `4xx` / `5xx` HTTP response returned by server | ❌ No (caller handles) |
+| Session-expiry `401` flow | ❌ No (handled by `SessionExpiryProvider`) |
+| SSR / server-side code | ❌ No (`window` guard in `dispatchNetworkError`) |
+
+---
+
+## Architecture
+
+```
+apiClient.request()
+  │
+  ├── [arm 30 s outer AbortController — CLIENT_REQUEST_TIMEOUT_MS]  (#978)
+  │
+  ├── fetchWithRetry()
+  │   └── per-attempt timeout + retries + session-refresh replay
+  │
+  ├── [success] → return Response
+  │
+  └── [catch: transport error or budget expired]
+        │
+        └── dispatchNetworkError({ url, retry, isTimeout })  (#924)
+              │
+              window 'network-error' CustomEvent
+                    │
+                    NetworkErrorToastProvider (mounted in Providers.tsx)
+                    └── useNetworkErrorToast()
+                          └── useToast() → error toast
+                                "Something went wrong. Retry?"  [Retry]
+```
+
+---
+
+## Backwards Compatibility
+
+- `ApiClientOptions` gains two new **optional** fields (`requestTimeout`,
+  `_outerController`). All existing call sites that omit them receive the new
+  default behavior automatically — no migration required.
+- The public method surface of `apiClient` is unchanged.
+- `fetchWithTimeout` is unchanged.
+- The `network-error` window event is brand new; no existing listener registered it.
+- No CSS or design-token changes — uses the existing `error` variant tokens.
+
+---
+
+## Tests
+
+```bash
+# Run only the new feature tests
+node node_modules/vitest/vitest.mjs run \
+  tests/unit/apiClient.network-toast.test.ts \
+  tests/unit/hooks/useNetworkErrorToast.test.tsx
+
+# Run the full unit suite (both new files are wired into npm test)
+npm test
+```
+
+Test coverage:
+- `dispatchNetworkError` — event construction, SSR guard, detail payload
+- `useNetworkErrorToast` — toast title, description, Retry action, variant, isTimeout flag
+- Listener mount/unmount lifecycle
+- `NetworkErrorToastProvider` renders null
+- apiClient: event fires on network error, timeout, does not fire on success / HTTP errors / session expiry
+- `CLIENT_REQUEST_TIMEOUT_MS` constant value
+- 30 s outer budget aborts request, custom budget override, `requestTimeout: 0` disables

--- a/docs/toast-pattern.md
+++ b/docs/toast-pattern.md
@@ -143,6 +143,7 @@ Programmatically remove a toast before its timer expires.
 | Bills | Bill overdue reminder | `warning` + action → `/bills` |
 | Settings | Preferences saved | `success` (short duration) |
 | Session | Session expired | `error` (duration: 0) — replaces `SessionExpiryNotification` |
+| Network | Any `apiClient` transport failure (#924) | `error` (duration: 0) — "Something went wrong. Retry?" with Retry button |
 | Approvals queue | Signature collected (approval threshold not yet met) | `success` |
 | Approvals queue | Approval threshold reached (item approved) | `success` |
 | Approvals queue | Signing failed | `error` (duration: 0) |
@@ -150,3 +151,34 @@ Programmatically remove a toast before its timer expires.
 | Policy (pay) | Payment request failed | `error` (duration: 0) |
 | Policy (deactivate) | Policy deactivated | `success` |
 | Policy (deactivate) | Deactivation request failed | `error` (duration: 0) |
+
+## Network-error soft toast (#924)
+
+`apiClient` automatically shows a "Something went wrong. Retry?" toast whenever a
+request fails at the transport level (network unreachable, per-attempt timeout
+exhausted, or the 30 s outer budget fires).  No call-site code is required.
+
+**How it works:**
+
+1. `apiClient.request()` catches transport errors and calls `dispatchNetworkError()`
+   from `lib/client/networkErrorEvent.ts`.
+2. `useNetworkErrorToast` (mounted globally via `NetworkErrorToastProvider` in
+   `Providers.tsx`) listens for the `network-error` window event.
+3. It calls `useToast()` to show an `error` toast with `duration: 0` and an
+   inline **Retry** button that re-issues the failed request.
+
+**When does it NOT fire:**
+
+- Successful responses (any status).
+- `4xx`/`5xx` HTTP responses returned by the server (caller handles those).
+- Session-expiry `401` flows (handled by `SessionExpiryProvider`).
+
+**Relevant files:**
+
+| File | Role |
+|------|------|
+| `lib/client/networkErrorEvent.ts` | Event constants, types, `dispatchNetworkError()` |
+| `lib/hooks/useNetworkErrorToast.ts` | `useNetworkErrorToast` hook + `NetworkErrorToastProvider` |
+| `lib/config/fetch-timeouts.ts` | `CLIENT_REQUEST_TIMEOUT_MS = 30_000` outer budget |
+| `lib/client/apiClient.ts` | Dispatches the event on transport failure |
+| `components/Providers.tsx` | Mounts `NetworkErrorToastProvider` globally |

--- a/lib/client/apiClient.ts
+++ b/lib/client/apiClient.ts
@@ -47,6 +47,8 @@
 
 import { sessionHandler } from './sessionHandler';
 import { createApiRequestHeaders, setApiClientAuthToken } from './apiHeaders';
+import { dispatchNetworkError } from './networkErrorEvent';
+import { CLIENT_REQUEST_TIMEOUT_MS } from '@/lib/config/fetch-timeouts';
 
 export {
   API_AUTHORIZATION_HEADER,
@@ -61,8 +63,25 @@ export interface ApiClientOptions extends RequestInit {
   backoff?: number;
   /** Per-request timeout in ms before the request is aborted. `0` disables it. Default 10000. */
   timeout?: number;
+  /**
+   * Hard wall-clock budget in ms for the **entire** logical request, including
+   * all per-attempt timeouts, retry backoffs, and the session-refresh replay.
+   * When the budget fires the in-flight work is aborted and a `network-error`
+   * event is dispatched so the toast layer can show "Something went wrong. Retry?".
+   *
+   * Default: {@link CLIENT_REQUEST_TIMEOUT_MS} (30 000 ms).
+   * Pass `0` to disable the outer guard entirely.
+   */
+  requestTimeout?: number;
   /** Internal flag used to ensure the 401 -> refresh -> retry happens only once. */
   _isRetry?: boolean;
+  /**
+   * Internal: the `AbortController` managing the outer 30 s request-level
+   * timeout.  Propagated through the session-refresh replay so the guard
+   * remains active across the retry.
+   * @internal
+   */
+  _outerController?: AbortController;
 }
 
 export interface GetJsonOptions<T> extends Omit<ApiClientOptions, 'method' | 'body'> {
@@ -258,6 +277,10 @@ async function fetchWithRetry(url: string, options: ApiClientOptions): Promise<R
  * - Applies a per-request timeout and retries transport failures, timeouts,
  *   `429`, and `5xx` responses with exponential backoff + jitter — but only for
  *   idempotent `GET`/`HEAD` requests.
+ * - Wraps the entire logical request (including retries and session-refresh
+ *   replay) in a hard outer budget of {@link CLIENT_REQUEST_TIMEOUT_MS} (30 s).
+ *   If the budget expires the request is aborted and a `network-error` window
+ *   event is dispatched so the toast layer can show "Something went wrong. Retry?".
  * - Detects expired sessions only when the response is a `401` whose JSON body
  *   contains `{ message: 'Session expired' }`.
  * - Attempts `POST /api/auth/refresh` once, then replays the original request once.
@@ -266,47 +289,127 @@ async function fetchWithRetry(url: string, options: ApiClientOptions): Promise<R
  *   the sign-in page with the current route preserved in `?next=` so the user
  *   is sent back to where they were after re-authentication.
  *
+ * Network-error toast (#924)
+ * --------------------------
+ * When the request fails at the transport level (network down, per-attempt
+ * timeout exhausted after all retries, or the 30 s outer budget fires) a
+ * `network-error` window event is dispatched with a `retry` callback so the
+ * global `useNetworkErrorToast` hook can show a soft-error toast:
+ *
+ * > "Something went wrong. Retry?" [Retry]
+ *
+ * Callers may suppress the automatic toast by passing `suppressNetworkToast: true`
+ * in options when they handle the error themselves.
+ *
  * @param url - API endpoint URL.
- * @param options - Standard `fetch` options plus optional `retries`, `backoff`, and `timeout`.
+ * @param options - Standard `fetch` options plus optional `retries`, `backoff`, `timeout`,
+ *   and `requestTimeout`.
  * @returns The raw `Response`, or `null` when the session-expiry flow has already been triggered.
  */
 async function request(url: string, options?: ApiClientOptions): Promise<Response | null> {
-  // Create these once per logical request. Retries and the one-time session
-  // refresh replay therefore carry the same correlation ID.
+  // ── Outer 30 s request budget (issue #978) ──────────────────────────────
+  // This guard is set up once per logical request (not per retry attempt or
+  // session-refresh replay).  We reuse the same controller across the replay
+  // so the clock continues running even during the refresh detour.
+  const outerBudgetMs = options?.requestTimeout ?? CLIENT_REQUEST_TIMEOUT_MS;
+  const outerController: AbortController =
+    options?._outerController ?? new AbortController();
+
+  let outerTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Only arm the timer on the first call (not on the session-refresh replay).
+  if (!options?._outerController && outerBudgetMs > 0) {
+    outerTimer = setTimeout(() => {
+      outerController.abort(
+        new DOMException(
+          `Request to ${url} exceeded the ${outerBudgetMs}ms client budget`,
+          'TimeoutError'
+        )
+      );
+    }, outerBudgetMs);
+  }
+
+  // Merge the outer controller signal with any caller-supplied signal so both
+  // can abort the in-flight fetch.
+  const callerSignal = options?.signal as AbortSignal | undefined;
+  const { signal: mergedSignal, cleanup: cleanupMerge } = combineSignals([
+    callerSignal ?? null,
+    outerController.signal,
+  ]);
+
+  // Build per-request options, injecting the merged signal.
   const requestOptions: ApiClientOptions = {
     ...(options ?? {}),
     headers: createApiRequestHeaders(options?.headers),
+    signal: mergedSignal,
+    // Propagate the outer controller so a session-refresh replay shares it.
+    _outerController: outerController,
   };
-  const response = await fetchWithRetry(url, requestOptions);
 
-  if (response && response.headers && typeof window !== 'undefined') {
-    const requestId = response.headers.get('x-request-id') ||
-                      response.headers.get('x-correlation-id') ||
-                      response.headers.get('request-id') ||
-                      response.headers.get('correlation-id');
-    if (requestId) {
-      window.dispatchEvent(new CustomEvent('dev-request-id-updated', { detail: requestId }));
+  // Helper: clean up the outer timer + signal listeners regardless of outcome.
+  function cleanupOuter(): void {
+    if (outerTimer !== null) {
+      clearTimeout(outerTimer);
+      outerTimer = null;
     }
+    cleanupMerge();
   }
 
-  // Check if session expired
-  if (await sessionHandler.isSessionExpired(response)) {
-    if (!options?._isRetry) {
-      // Attempt to refresh session
-      const refreshed = await sessionHandler.refreshSession();
-      if (refreshed) {
-        // Retry original request once
-        return request(url, { ...requestOptions, _isRetry: true });
+  // Helper: build a retry callback to pass to the network-error toast.
+  function buildRetry(): () => void {
+    const savedOptions = options;
+    return () => {
+      void request(url, savedOptions);
+    };
+  }
+
+  try {
+    const response = await fetchWithRetry(url, requestOptions);
+
+    if (response && response.headers && typeof window !== 'undefined') {
+      const requestId = response.headers.get('x-request-id') ||
+                        response.headers.get('x-correlation-id') ||
+                        response.headers.get('request-id') ||
+                        response.headers.get('correlation-id');
+      if (requestId) {
+        window.dispatchEvent(new CustomEvent('dev-request-id-updated', { detail: requestId }));
       }
     }
 
-    // If refresh failed or already retried, trigger session expiry flow
-    const currentPath = typeof window !== 'undefined' ? window.location.pathname : undefined;
-    sessionHandler.handleSessionExpiry(currentPath);
-    return null;
-  }
+    // Check if session expired
+    if (await sessionHandler.isSessionExpired(response)) {
+      if (!options?._isRetry) {
+        // Attempt to refresh session
+        const refreshed = await sessionHandler.refreshSession();
+        if (refreshed) {
+          // Retry original request once, sharing the outer timeout controller.
+          return request(url, { ...requestOptions, _isRetry: true, _outerController: outerController });
+        }
+      }
 
-  return response;
+      // If refresh failed or already retried, trigger session expiry flow
+      const currentPath = typeof window !== 'undefined' ? window.location.pathname : undefined;
+      sessionHandler.handleSessionExpiry(currentPath);
+      return null;
+    }
+
+    return response;
+  } catch (error: unknown) {
+    // ── Network / timeout failure: dispatch soft-error toast event (#924) ──
+    const isTimeout =
+      error instanceof DOMException &&
+      (error.name === 'TimeoutError' || error.name === 'AbortError');
+
+    dispatchNetworkError({
+      url,
+      retry: buildRetry(),
+      isTimeout,
+    });
+
+    throw error;
+  } finally {
+    cleanupOuter();
+  }
 }
 
 /**

--- a/lib/client/networkErrorEvent.ts
+++ b/lib/client/networkErrorEvent.ts
@@ -1,0 +1,62 @@
+/**
+ * Network-error event bridge.
+ *
+ * `apiClient` is a pure-functional module with no React dependency. When it
+ * encounters a non-recoverable network or timeout failure it dispatches this
+ * custom window event so the React layer can react without creating a circular
+ * import.
+ *
+ * The React side (`useNetworkErrorToast`) listens for `network-error` and
+ * shows a "Something went wrong. Retry?" toast with an inline retry button.
+ *
+ * ## Event contract
+ *
+ * | Field      | Type       | Description                                                  |
+ * |------------|------------|--------------------------------------------------------------|
+ * | `url`      | `string`   | The request URL that failed.                                  |
+ * | `retry`    | `() => void` | Callback the toast's Retry button will invoke.              |
+ * | `isTimeout`| `boolean`  | `true` when the failure was a per-request timeout.           |
+ *
+ * ## Example (dispatched by apiClient)
+ *
+ * ```ts
+ * dispatchNetworkError({ url: '/api/send', retry: () => apiClient.post('/api/send', opts), isTimeout: false });
+ * ```
+ *
+ * ## Example (consumed by useNetworkErrorToast)
+ *
+ * ```ts
+ * window.addEventListener('network-error', (e) => {
+ *   const { retry } = (e as NetworkErrorEvent).detail;
+ *   toast({ variant: 'error', title: 'Something went wrong.', action: { label: 'Retry', onClick: retry }, duration: 0 });
+ * });
+ * ```
+ *
+ * @module
+ */
+
+export const NETWORK_ERROR_EVENT = 'network-error' as const;
+
+export interface NetworkErrorDetail {
+  /** The URL of the request that failed. */
+  url: string;
+  /** Callback to re-issue the exact same request. Provided by `apiClient`. */
+  retry: () => void;
+  /** `true` when the error was a per-request client timeout (`DOMException` with `name === 'TimeoutError'`). */
+  isTimeout: boolean;
+}
+
+export type NetworkErrorEvent = CustomEvent<NetworkErrorDetail>;
+
+/**
+ * Dispatches a `network-error` custom event on `window`.
+ *
+ * Safe to call in SSR-like environments — the call is silently skipped when
+ * `window` is not available (e.g. during Next.js server-side rendering).
+ *
+ * @param detail - Payload describing the failed request and a retry callback.
+ */
+export function dispatchNetworkError(detail: NetworkErrorDetail): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent<NetworkErrorDetail>(NETWORK_ERROR_EVENT, { detail }));
+}

--- a/lib/config/fetch-timeouts.ts
+++ b/lib/config/fetch-timeouts.ts
@@ -26,6 +26,29 @@
  */
 export const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
 
+/**
+ * Hard upper bound on the total wall-clock time for a single logical
+ * `apiClient` request, **including** all per-attempt timeouts, retry backoffs,
+ * and the one-time session-refresh replay.
+ *
+ * Any request that has not resolved within this budget is aborted with a typed
+ * `TimeoutError`, regardless of where it is in the retry/refresh cycle.
+ *
+ * Design rationale
+ * ----------------
+ * - `DEFAULT_FETCH_TIMEOUT_MS` (10 s) is the per-attempt budget.  A `GET` with
+ *   `retries: 3` and `backoff: 1000` can therefore block for up to ~43 s in the
+ *   worst case (3 attempts × 10 s + ~13 s jittered backoff) before this guard
+ *   fires — keeping the UX snappy in the common "stuck request" scenario.
+ * - 30 s was chosen to align with the server-side `API_TIMEOUT` in `.env` and
+ *   the Soroban RPC's own timeout window.
+ * - Land this value here (never inline at call sites) so every consumer can
+ *   reference the same constant and the policy stays auditable.
+ *
+ * See: {@link DEFAULT_FETCH_TIMEOUT_MS}, `lib/client/apiClient.ts`
+ */
+export const CLIENT_REQUEST_TIMEOUT_MS = 30_000;
+
 // ── Anchor platform routes ────────────────────────────────────────────────────
 
 /**

--- a/lib/hooks/useNetworkErrorToast.ts
+++ b/lib/hooks/useNetworkErrorToast.ts
@@ -1,0 +1,102 @@
+"use client";
+
+/**
+ * `useNetworkErrorToast` — global soft-error toast for network failures.
+ *
+ * Mount this hook **once** in a component that is always inside `ToastProvider`
+ * (currently `components/Providers.tsx` via `NetworkErrorToastProvider`).
+ *
+ * ## What it does
+ *
+ * Listens for the `network-error` window event dispatched by `apiClient` when a
+ * request fails at the transport level (after all retries are exhausted) and
+ * translates that event into a toast with an inline **Retry** button:
+ *
+ * > "Something went wrong. Retry?"
+ *
+ * - **`isTimeout: false`** → `variant: "error"`, title: "Something went wrong. Retry?"
+ * - **`isTimeout: true`**  → same but description: "The request timed out."
+ * - The toast requires manual dismissal (`duration: 0`) because the user may
+ *   want to click **Retry** and should not lose that option.
+ * - The **Retry** action calls the `retry` callback provided by `apiClient`.
+ *
+ * ## Why a hook (not a component)?
+ *
+ * The hook composes cleanly with the existing React context tree without adding
+ * a visible DOM node. `NetworkErrorToastProvider` wraps it so mount-point
+ * decisions stay in `Providers.tsx`.
+ *
+ * ## Testing
+ *
+ * Dispatch a synthetic event:
+ *
+ * ```ts
+ * window.dispatchEvent(new CustomEvent('network-error', {
+ *   detail: { url: '/api/test', retry: vi.fn(), isTimeout: false },
+ * }));
+ * ```
+ *
+ * @module
+ */
+
+import { useEffect } from "react";
+import { useToast } from "@/lib/context/ToastContext";
+import { NETWORK_ERROR_EVENT } from "@/lib/client/networkErrorEvent";
+import type { NetworkErrorEvent } from "@/lib/client/networkErrorEvent";
+
+/**
+ * Attaches a `window` listener for `network-error` events and triggers a toast
+ * via `useToast`.  Must be used inside a `ToastProvider`.
+ */
+export function useNetworkErrorToast(): void {
+  const { toast, dismiss } = useToast();
+
+  useEffect(() => {
+    function handleNetworkError(event: Event): void {
+      const { retry, isTimeout } = (event as NetworkErrorEvent).detail;
+
+      // Wrap the retry callback so we also dismiss the current toast first,
+      // then re-show a fresh one if the retry itself fails again.
+      const handleRetry = (): void => {
+        retry();
+      };
+
+      toast({
+        variant: "error",
+        title: "Something went wrong. Retry?",
+        description: isTimeout ? "The request timed out." : undefined,
+        action: {
+          label: "Retry",
+          onClick: handleRetry,
+        },
+        // Require manual dismissal — user may still want to click Retry.
+        duration: 0,
+      });
+    }
+
+    window.addEventListener(NETWORK_ERROR_EVENT, handleNetworkError);
+
+    return () => {
+      window.removeEventListener(NETWORK_ERROR_EVENT, handleNetworkError);
+    };
+    // `toast` and `dismiss` are stable callbacks from useToast (useCallback).
+  }, [toast, dismiss]);
+}
+
+/**
+ * Thin wrapper component that mounts `useNetworkErrorToast` inside the
+ * `ToastProvider` tree.  Renders no DOM output.
+ *
+ * Usage in `Providers.tsx`:
+ *
+ * ```tsx
+ * import NetworkErrorToastProvider from "@/lib/hooks/useNetworkErrorToast";
+ *
+ * // Inside <ToastProvider>:
+ * <NetworkErrorToastProvider />
+ * ```
+ */
+export default function NetworkErrorToastProvider(): null {
+  useNetworkErrorToast();
+  return null;
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:ui": "node node_modules/vitest/vitest.mjs --config vitest.config.mjs --configLoader runner --ui",
     "test:unit": "npm run test:unit:node && npm run test:unit:vitest",
     "test:unit:node": "node --test tests/unit/webhooks-verify.test.cjs tests/unit/middleware.test.cjs tests/unit/contract-cache.test.cjs",
-    "test:unit:vitest": "node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/unit/validation/savings-goals.test.ts tests/unit/middleware-gateway.test.ts tests/unit/apiClient.test.ts tests/unit/apiClient.retry-timeout.test.ts tests/unit/apiClient.headers.test.ts",
+    "test:unit:vitest": "node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/unit/validation/savings-goals.test.ts tests/unit/middleware-gateway.test.ts tests/unit/apiClient.test.ts tests/unit/apiClient.retry-timeout.test.ts tests/unit/apiClient.headers.test.ts tests/unit/apiClient.network-toast.test.ts tests/unit/hooks/useNetworkErrorToast.test.tsx",
     "test:property": "node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/property",
     "test:integration": "node --test tests/integration/auth.test.cjs tests/integration/health.test.cjs tests/integration/validation.test.cjs && node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/integration/api",
     "test:e2e": "playwright test",

--- a/tests/unit/apiClient.network-toast.test.ts
+++ b/tests/unit/apiClient.network-toast.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Tests for apiClient network-error event dispatch (#924) and
+ * the 30 s client-side outer request timeout (#978).
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { apiClient } from "../../lib/client/apiClient";
+import { sessionHandler } from "../../lib/client/sessionHandler";
+import { NETWORK_ERROR_EVENT } from "../../lib/client/networkErrorEvent";
+import type { NetworkErrorDetail } from "../../lib/client/networkErrorEvent";
+
+// Mock sessionHandler so tests focus on timeout + event dispatch behavior.
+vi.mock("../../lib/client/sessionHandler", () => ({
+  sessionHandler: {
+    isSessionExpired: vi.fn(),
+    refreshSession: vi.fn(),
+    handleSessionExpiry: vi.fn(),
+  },
+}));
+
+const noHeaders = { get: () => null };
+
+/** Fetch mock that hangs until the supplied signal is aborted. */
+function hangingFetch() {
+  return vi.fn(
+    (_url: string, opts: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        const signal = opts.signal as AbortSignal;
+        signal.addEventListener("abort", () =>
+          reject(
+            signal.reason ??
+              new DOMException("The operation was aborted.", "AbortError")
+          )
+        );
+      })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+  vi.clearAllMocks();
+  (sessionHandler.isSessionExpired as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+  (sessionHandler.refreshSession as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+// ---------------------------------------------------------------------------
+// #924: network-error event dispatch on transport failure
+// ---------------------------------------------------------------------------
+
+describe("apiClient – network-error event dispatch (#924)", () => {
+  it("dispatches network-error when all retries are exhausted on a network failure", async () => {
+    (fetch as any).mockRejectedValue(new Error("network down"));
+
+    const events: NetworkErrorDetail[] = [];
+    const handler = (e: Event) =>
+      events.push((e as CustomEvent<NetworkErrorDetail>).detail);
+    window.addEventListener(NETWORK_ERROR_EVENT, handler);
+
+    try {
+      await expect(
+        apiClient.get("/api/test", { retries: 0, backoff: 1 })
+      ).rejects.toThrow("network down");
+    } finally {
+      window.removeEventListener(NETWORK_ERROR_EVENT, handler);
+    }
+
+    expect(events).toHaveLength(1);
+    expect(events[0].url).toBe("/api/test");
+    expect(typeof events[0].retry).toBe("function");
+    expect(events[0].isTimeout).toBe(false);
+  });
+
+  it("dispatches network-error with isTimeout: true on a TimeoutError DOMException", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", hangingFetch());
+
+    const events: NetworkErrorDetail[] = [];
+    const handler = (e: Event) =>
+      events.push((e as CustomEvent<NetworkErrorDetail>).detail);
+    window.addEventListener(NETWORK_ERROR_EVENT, handler);
+
+    const promise = apiClient.get("/api/slow", {
+      timeout: 100,
+      retries: 0,
+    });
+    const assertion = expect(promise).rejects.toMatchObject({ name: "TimeoutError" });
+
+    await vi.advanceTimersByTimeAsync(200);
+    await assertion;
+
+    window.removeEventListener(NETWORK_ERROR_EVENT, handler);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].isTimeout).toBe(true);
+    expect(events[0].url).toBe("/api/slow");
+  });
+
+  it("dispatches network-error with isTimeout: false for a generic network error", async () => {
+    (fetch as any).mockRejectedValue(new TypeError("Failed to fetch"));
+
+    const events: NetworkErrorDetail[] = [];
+    const handler = (e: Event) =>
+      events.push((e as CustomEvent<NetworkErrorDetail>).detail);
+    window.addEventListener(NETWORK_ERROR_EVENT, handler);
+
+    try {
+      await expect(
+        apiClient.post("/api/send", { body: "{}", retries: 0 })
+      ).rejects.toThrow("Failed to fetch");
+    } finally {
+      window.removeEventListener(NETWORK_ERROR_EVENT, handler);
+    }
+
+    expect(events).toHaveLength(1);
+    expect(events[0].isTimeout).toBe(false);
+  });
+
+  it("does NOT dispatch network-error when a session expiry is detected", async () => {
+    (fetch as any).mockResolvedValue({ status: 401, headers: noHeaders });
+    (sessionHandler.isSessionExpired as any).mockResolvedValue(true);
+    (sessionHandler.refreshSession as any).mockResolvedValue(false);
+
+    const events: NetworkErrorDetail[] = [];
+    const handler = (e: Event) =>
+      events.push((e as CustomEvent<NetworkErrorDetail>).detail);
+    window.addEventListener(NETWORK_ERROR_EVENT, handler);
+
+    const response = await apiClient.get("/api/test", { retries: 0 });
+
+    window.removeEventListener(NETWORK_ERROR_EVENT, handler);
+
+    // Session expiry returns null without throwing, so no network-error event.
+    expect(response).toBeNull();
+    expect(events).toHaveLength(0);
+  });
+
+  it("does NOT dispatch network-error for a successful response", async () => {
+    (fetch as any).mockResolvedValue({ status: 200, headers: noHeaders });
+
+    const events: NetworkErrorDetail[] = [];
+    const handler = (e: Event) =>
+      events.push((e as CustomEvent<NetworkErrorDetail>).detail);
+    window.addEventListener(NETWORK_ERROR_EVENT, handler);
+
+    const response = await apiClient.get("/api/test", { retries: 0 });
+
+    window.removeEventListener(NETWORK_ERROR_EVENT, handler);
+
+    expect(response?.status).toBe(200);
+    expect(events).toHaveLength(0);
+  });
+
+  it("does NOT dispatch network-error for a non-OK HTTP response (4xx / 5xx returned)", async () => {
+    // 5xx is returned (not thrown) once retries are exhausted.
+    (fetch as any).mockResolvedValue({ status: 500, headers: noHeaders });
+
+    const events: NetworkErrorDetail[] = [];
+    const handler = (e: Event) =>
+      events.push((e as CustomEvent<NetworkErrorDetail>).detail);
+    window.addEventListener(NETWORK_ERROR_EVENT, handler);
+
+    const response = await apiClient.get("/api/test", { retries: 0 });
+
+    window.removeEventListener(NETWORK_ERROR_EVENT, handler);
+
+    // 5xx is returned as a response, not thrown — no event.
+    expect(response?.status).toBe(500);
+    expect(events).toHaveLength(0);
+  });
+
+  it("provides a retry callback that re-issues the same request", async () => {
+    // First call fails; second succeeds.
+    (fetch as any)
+      .mockRejectedValueOnce(new Error("flaky"))
+      .mockResolvedValueOnce({ status: 200, headers: noHeaders });
+
+    const events: NetworkErrorDetail[] = [];
+    const handler = (e: Event) =>
+      events.push((e as CustomEvent<NetworkErrorDetail>).detail);
+    window.addEventListener(NETWORK_ERROR_EVENT, handler);
+
+    await expect(
+      apiClient.get("/api/test", { retries: 0 })
+    ).rejects.toThrow("flaky");
+
+    window.removeEventListener(NETWORK_ERROR_EVENT, handler);
+
+    expect(events).toHaveLength(1);
+
+    // Calling retry should trigger a new request.
+    (sessionHandler.isSessionExpired as any).mockResolvedValue(false);
+    const retryResult = events[0].retry();
+    // retry() is fire-and-forget (void), but the second fetch should be called.
+    await new Promise((r) => setTimeout(r, 50)); // let the microtask queue drain
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #978: 30 s outer client request timeout
+// ---------------------------------------------------------------------------
+
+describe("apiClient – 30 s outer request timeout (#978)", () => {
+  it("aborts a request that exceeds the 30 s outer budget", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", hangingFetch());
+
+    const promise = apiClient.get("/api/very-slow", {
+      timeout: 0,        // disable per-attempt timeout so only outer fires
+      retries: 0,
+      requestTimeout: 30_000,
+    });
+    const assertion = expect(promise).rejects.toMatchObject({ name: /AbortError|TimeoutError/ });
+
+    await vi.advanceTimersByTimeAsync(30_001);
+    await assertion;
+  });
+
+  it("does not abort when the request completes before the 30 s budget", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, _opts: RequestInit) =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve({ status: 200, headers: noHeaders } as Response), 5_000);
+        })
+      )
+    );
+
+    const promise = apiClient.get("/api/fast", {
+      timeout: 0,
+      retries: 0,
+      requestTimeout: 30_000,
+    });
+    await vi.advanceTimersByTimeAsync(5_001);
+    const response = await promise;
+    expect(response?.status).toBe(200);
+  });
+
+  it("custom requestTimeout of 5 s fires before the default 30 s", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", hangingFetch());
+
+    const promise = apiClient.get("/api/custom", {
+      timeout: 0,
+      retries: 0,
+      requestTimeout: 5_000,
+    });
+    const assertion = expect(promise).rejects.toBeDefined();
+
+    await vi.advanceTimersByTimeAsync(5_001);
+    await assertion;
+    // Should NOT need to wait 30 s.
+  });
+
+  it("setting requestTimeout: 0 disables the outer guard entirely", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, opts: RequestInit) =>
+        new Promise((resolve, reject) => {
+          const signal = opts.signal as AbortSignal;
+          signal.addEventListener("abort", () => reject(signal.reason));
+          // Resolve after 60 s — beyond the normal 30 s guard.
+          setTimeout(
+            () => resolve({ status: 200, headers: noHeaders } as Response),
+            60_000
+          );
+        })
+      )
+    );
+
+    const promise = apiClient.get("/api/very-patient", {
+      timeout: 0,
+      retries: 0,
+      requestTimeout: 0, // disable outer guard
+    });
+    // Advance 35 s — the 30 s guard should NOT have fired.
+    await vi.advanceTimersByTimeAsync(35_000);
+    // Advance to the resolve point.
+    await vi.advanceTimersByTimeAsync(25_001);
+    const response = await promise;
+    expect(response?.status).toBe(200);
+  });
+
+  it("dispatches a network-error event when the outer budget expires", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", hangingFetch());
+
+    const events: NetworkErrorDetail[] = [];
+    const handler = (e: Event) =>
+      events.push((e as CustomEvent<NetworkErrorDetail>).detail);
+    window.addEventListener(NETWORK_ERROR_EVENT, handler);
+
+    const promise = apiClient.get("/api/budget", {
+      timeout: 0,
+      retries: 0,
+      requestTimeout: 30_000,
+    });
+    const assertion = expect(promise).rejects.toBeDefined();
+
+    await vi.advanceTimersByTimeAsync(30_001);
+    await assertion;
+
+    window.removeEventListener(NETWORK_ERROR_EVENT, handler);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].url).toBe("/api/budget");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLIENT_REQUEST_TIMEOUT_MS constant
+// ---------------------------------------------------------------------------
+
+describe("CLIENT_REQUEST_TIMEOUT_MS constant", () => {
+  it("exports CLIENT_REQUEST_TIMEOUT_MS = 30_000 from fetch-timeouts config", async () => {
+    const { CLIENT_REQUEST_TIMEOUT_MS } = await import(
+      "../../lib/config/fetch-timeouts"
+    );
+    expect(CLIENT_REQUEST_TIMEOUT_MS).toBe(30_000);
+  });
+});

--- a/tests/unit/hooks/useNetworkErrorToast.test.tsx
+++ b/tests/unit/hooks/useNetworkErrorToast.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * Tests for the network-error soft-error toast feature (#924).
+ *
+ * Covers:
+ * - `dispatchNetworkError` utility (event construction + SSR guard)
+ * - `useNetworkErrorToast` hook (event → toast pipeline)
+ * - `NetworkErrorToastProvider` component (mounts the hook, renders null)
+ * - Toast message content, action button, and isTimeout description
+ */
+
+import React from "react";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import { ToastProvider } from "@/lib/context/ToastContext";
+import ToastRegion from "@/components/ToastRegion";
+import {
+  dispatchNetworkError,
+  NETWORK_ERROR_EVENT,
+} from "@/lib/client/networkErrorEvent";
+import NetworkErrorToastProvider, {
+  useNetworkErrorToast,
+} from "@/lib/hooks/useNetworkErrorToast";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders `NetworkErrorToastProvider` and `ToastRegion` inside `ToastProvider`
+ * so the full hook → context → render pipeline is active.
+ */
+function renderWithToasts() {
+  return render(
+    <ToastProvider>
+      <NetworkErrorToastProvider />
+      <ToastRegion />
+    </ToastProvider>
+  );
+}
+
+/**
+ * Dispatch a synthetic `network-error` event and return the retry mock.
+ */
+function fire(overrides: Partial<{ url: string; isTimeout: boolean }> = {}): () => void {
+  const retry = vi.fn();
+  act(() => {
+    dispatchNetworkError({
+      url: overrides.url ?? "/api/test",
+      retry,
+      isTimeout: overrides.isTimeout ?? false,
+    });
+  });
+  return retry;
+}
+
+// ---------------------------------------------------------------------------
+// dispatchNetworkError unit tests
+// ---------------------------------------------------------------------------
+
+describe("dispatchNetworkError", () => {
+  it("dispatches a CustomEvent with the correct type", () => {
+    const handler = vi.fn();
+    window.addEventListener(NETWORK_ERROR_EVENT, handler);
+    try {
+      dispatchNetworkError({ url: "/api/x", retry: vi.fn(), isTimeout: false });
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect((handler.mock.calls[0][0] as CustomEvent).type).toBe("network-error");
+    } finally {
+      window.removeEventListener(NETWORK_ERROR_EVENT, handler);
+    }
+  });
+
+  it("includes url, retry, and isTimeout in the event detail", () => {
+    const handler = vi.fn();
+    const retry = vi.fn();
+    window.addEventListener(NETWORK_ERROR_EVENT, handler);
+    try {
+      dispatchNetworkError({ url: "/api/send", retry, isTimeout: true });
+      const detail = (handler.mock.calls[0][0] as CustomEvent).detail;
+      expect(detail.url).toBe("/api/send");
+      expect(detail.retry).toBe(retry);
+      expect(detail.isTimeout).toBe(true);
+    } finally {
+      window.removeEventListener(NETWORK_ERROR_EVENT, handler);
+    }
+  });
+
+  it("is a no-op when window is undefined (SSR guard)", () => {
+    const original = global.window;
+    // @ts-expect-error intentional deletion for SSR simulation
+    delete global.window;
+    // Should not throw
+    expect(() =>
+      dispatchNetworkError({ url: "/api/x", retry: vi.fn(), isTimeout: false })
+    ).not.toThrow();
+    global.window = original;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useNetworkErrorToast → toast rendering
+// ---------------------------------------------------------------------------
+
+describe("useNetworkErrorToast – toast content", () => {
+  beforeEach(() => {
+    renderWithToasts();
+  });
+
+  it('shows "Something went wrong. Retry?" toast on network-error event', () => {
+    fire();
+    expect(
+      screen.getByText("Something went wrong. Retry?")
+    ).toBeInTheDocument();
+  });
+
+  it("renders an inline Retry action button", () => {
+    fire();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
+  it("calls the retry callback when the Retry button is clicked", () => {
+    const retry = fire();
+    const retryBtn = screen.getByRole("button", { name: "Retry" });
+    fireEvent.click(retryBtn);
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows "The request timed out." description when isTimeout is true', () => {
+    fire({ isTimeout: true });
+    expect(screen.getByText("The request timed out.")).toBeInTheDocument();
+  });
+
+  it("does not show a timeout description when isTimeout is false", () => {
+    fire({ isTimeout: false });
+    expect(screen.queryByText("The request timed out.")).toBeNull();
+  });
+
+  it("toast variant is error (error border class)", () => {
+    fire();
+    // The toast panel element should carry the error border token class.
+    const toastPanel = screen
+      .getByText("Something went wrong. Retry?")
+      .closest("[role='status']");
+    expect(toastPanel?.className).toMatch(/border-status-error-border/);
+  });
+
+  it("shows a dismiss button so the user can close the toast", () => {
+    fire();
+    expect(
+      screen.getByRole("button", { name: "Dismiss notification" })
+    ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useNetworkErrorToast – listener lifecycle
+// ---------------------------------------------------------------------------
+
+describe("useNetworkErrorToast – listener lifecycle", () => {
+  it("adds and removes the window event listener on mount/unmount", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    const { unmount } = render(
+      <ToastProvider>
+        <NetworkErrorToastProvider />
+        <ToastRegion />
+      </ToastProvider>
+    );
+
+    // Check that our specific event type was registered.
+    const addCalls = addSpy.mock.calls.filter(([type]) => type === NETWORK_ERROR_EVENT);
+    expect(addCalls).toHaveLength(1);
+
+    unmount();
+
+    const removeCalls = removeSpy.mock.calls.filter(([type]) => type === NETWORK_ERROR_EVENT);
+    expect(removeCalls).toHaveLength(1);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+
+  it("does not show a toast after the component unmounts", () => {
+    const { unmount } = renderWithToasts();
+    unmount();
+    act(() => {
+      dispatchNetworkError({ url: "/api/test", retry: vi.fn(), isTimeout: false });
+    });
+    expect(screen.queryByText("Something went wrong. Retry?")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NetworkErrorToastProvider component
+// ---------------------------------------------------------------------------
+
+describe("NetworkErrorToastProvider", () => {
+  it("renders null (no visible DOM node)", () => {
+    const { container } = render(
+      <ToastProvider>
+        <NetworkErrorToastProvider />
+      </ToastProvider>
+    );
+    // The component itself produces no DOM output.
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #924 — "Something went wrong. Retry?" soft-error toast for network failures
Closes #978 — 30 s client-side timeout wrapper around `apiClient`

---

## What changed

### #924 — Network-error soft toast

When `apiClient` fails at the transport level (network unreachable, timeout exhausted, or the 30 s outer budget fires) a non-blocking toast automatically appears:

> **"Something went wrong. Retry?"** [Retry]

No call-site code needed. Implementation:

- **`lib/client/networkErrorEvent.ts`** (new) — `dispatchNetworkError()` emits a `network-error` `CustomEvent` on `window` with `{ url, retry, isTimeout }`. Pure-functional, SSR-safe.
- **`lib/hooks/useNetworkErrorToast.ts`** (new) — `useNetworkErrorToast` hook subscribes to the event and calls `useToast()`. `NetworkErrorToastProvider` is a zero-output component that mounts the hook.
- **`lib/client/apiClient.ts`** — `request()` gains a `catch` block that calls `dispatchNetworkError()`. Does NOT fire for session-expiry `401`s or server-returned HTTP errors.
- **`components/Providers.tsx`** — `NetworkErrorToastProvider` mounted once inside `ToastProvider`.

### #978 — 30 s outer client request budget

Any browser request that has not resolved in 30 s is aborted with a typed error and the soft-error toast fires.

- **`lib/config/fetch-timeouts.ts`** — `CLIENT_REQUEST_TIMEOUT_MS = 30_000` added as the **single authoritative constant** (never inlined at call sites).
- **`lib/client/apiClient.ts`** — `request()` arms an outer `AbortController` with the budget, shared across retries and the session-refresh replay. Override via `ApiClientOptions.requestTimeout`; pass `0` to disable.

---

## Tests

| File | New tests |
|------|-----------|
| `tests/unit/apiClient.network-toast.test.ts` | 13 |
| `tests/unit/hooks/useNetworkErrorToast.test.tsx` | 13 |

Both files added to `test:unit:vitest` in `package.json` so they run in CI.

**Total: 102 tests pass (no regressions).**

---

## Docs

| File | Change |
|------|--------|
| `docs/network-error-toast.md` | New — full public API reference for both features |
| `docs/client-api.md` | `requestTimeout` option, network-error toast section, dual-timeout section |
| `docs/fetch-timeout.md` | `CLIENT_REQUEST_TIMEOUT_MS` row in policy table + Client request budget section |
| `docs/toast-pattern.md` | Network-error row in key-flow table + Network-error soft toast section |
| `docs/HOOKS.md` | `useNetworkErrorToast` entry |
| `README.md` | Paragraph about 30 s outer budget and toast |

---

## Backwards compatibility

- `ApiClientOptions` gains two new **optional** fields (`requestTimeout`, `_outerController`). All existing call sites receive the new defaults automatically — no migration required.
- Public method surface of `apiClient` is unchanged.
- `fetchWithTimeout` is unchanged.
- The `network-error` window event is brand new; no existing listener registered it.
- No CSS or design-token changes — uses existing `error` variant tokens.