### PR TITLE
docs: add guidelines for emojis in UI copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is a Next.js-based frontend skeleton that provides the UI structure for all
 - [Elevation and shadow guidance](./docs/ELEVATION.md)
 - [Period lifecycle and state machine](./docs/PERIOD_LIFECYCLE.md)
 - [Internal jargon glossary (contributors)](./docs/GLOSSARY.md)
+- [Where emojis are allowed in UI copy (contributors)](./docs/EMOJIS_IN_UI.md)
 
 - **Next.js 14** - React framework with App Router
 - **TypeScript** - Type safety

--- a/docs/EMOJIS_IN_UI.md
+++ b/docs/EMOJIS_IN_UI.md
@@ -1,0 +1,44 @@
+# Emojis in UI Copy
+
+**Audience:** Contributors
+
+This document defines where emojis are allowed in RemitWise UI copy to maintain a consistent and professional user experience. 
+
+## Allowed Locations
+
+Emojis are allowed in the following specific contexts:
+
+1. **Empty States & Success Screens:** 
+   We use emojis to add a touch of personality to empty states or when celebrating a user's success.
+   *Example:*
+   > "You have no new bills to pay! 🎉"
+   > "Transfer completed successfully 🚀"
+
+2. **Marketing Banners within the App:**
+   Internal promotional banners can use emojis sparingly to grab attention.
+   *Example:*
+   > "Try our new Savings Goal feature 💰"
+
+## Restricted Locations
+
+Emojis are **NOT** allowed in the following areas:
+
+1. **Primary Navigation & Menus:**
+   Keep navigation labels clean and text-only (or use standard Lucide React icons, see [ICON_SYSTEM.md](./ICON_SYSTEM.md)).
+   *Example (Do not use):* 
+   > "🏠 Dashboard"
+
+2. **Forms & Input Labels:**
+   Input fields and labels must remain professional and accessible.
+   *Example (Do not use):*
+   > "Email Address 📧"
+
+3. **Error Messages & Alerts:**
+   Critical information should be clear and serious.
+   *Example (Do not use):*
+   > "Failed to send money ❌"
+
+## Best Practices
+
+- **Limit usage:** No more than one emoji per sentence or block of text.
+- **Accessibility:** Emojis should complement the text, not replace it. Screen readers announce emojis literally, so ensure the sentence still makes sense without it.


### PR DESCRIPTION
Closes #1041 
## Description

This PR adds documentation on where emojis are permitted in the RemitWise UI copy. Previously, this was tribal knowledge. Defining these guidelines will help reviewers verify behavior against the documented intent, allow new contributors to get productive without reading every commit, and enable the support team to answer common questions without paging an engineer.

Closes #[issue-number]

### Acceptance Criteria
- [x] Document added defining where emojis are allowed in UI copy.
- [x] The audience is focused on **contributors** and provides concrete examples instead of abstract definitions.
- [x] Linked from the top-level `README.md` for discoverability.
- [x] No unrelated refactors or stylistics-only changes were included.

### Changes made
- **`docs/EMOJIS_IN_UI.md`**: Created new guidelines for emoji usage covering allowed locations (e.g., success screens, empty states), restricted locations (e.g., primary navigation, error messages), and best practices.
- **`README.md`**: Updated the Overview section to cross-link the new document so it remains highly discoverable and does not rot.