### PR TITLE
docs: add COOKIE_HANDLING.md and EMPTY_STATE_ILLUSTRATIONS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The frontend includes placeholder pages and components for:
 
 ## Loading States
 
-Dashboard, Bills, and Insights now use route-level skeleton screens built from `components/ui/Skeleton.tsx` so primary panels load with stable layout blocks instead of ad-hoc spinners. For detailed guidelines and implementation patterns on all UI states (Default, Error, Disabled, and Loading), see [docs/component-states.md](docs/component-states.md).
+Dashboard, Bills, and Insights now use route-level skeleton screens built from `components/ui/Skeleton.tsx` so primary panels load with stable layout blocks instead of ad-hoc spinners. For detailed guidelines and implementation patterns on all UI states (Default, Error, Disabled, and Loading), see [docs/component-states.md](docs/component-states.md). For a complete catalog of which Lucide icon and copy go with each empty state across the app, see [docs/EMPTY_STATE_ILLUSTRATIONS.md](docs/EMPTY_STATE_ILLUSTRATIONS.md).
 
 ## Performance Budgets
 
@@ -61,7 +61,7 @@ PII scrubbing is applied before events leave the app:
 
 Keep the auth token out of the repo and store it only in CI secrets.
 
-For more details on tracking, cookies, and telemetry configuration, see the [Tracking and Opt-Out Guide](docs/tracking-and-opt-out.md).
+For more details on tracking, cookies, and telemetry configuration, see the [Tracking and Opt-Out Guide](docs/tracking-and-opt-out.md). For a full inventory of every first-party cookie (name, `HttpOnly`, `SameSite`, `Secure`, and where each is written), see [docs/COOKIE_HANDLING.md](docs/COOKIE_HANDLING.md).
 
 ## Getting Started
 

--- a/docs/COOKIE_HANDLING.md
+++ b/docs/COOKIE_HANDLING.md
@@ -1,0 +1,178 @@
+# Cookie Handling
+
+This document describes every first-party cookie that RemitWise sets: where it is written, what flags are applied, and why those choices were made. Audience: **contributors** who need to change auth, i18n, or analytics behaviour, and security reviewers who want to verify the defence-in-depth posture.
+
+---
+
+## Cookie inventory
+
+| Cookie name | Set by | `HttpOnly` | `SameSite` | `Secure` | `Max-Age` | Purpose |
+|---|---|---|---|---|---|---|
+| `remitwise_session` | Server (`lib/session.ts`) | ✅ Yes | `Lax` | Production only | Configurable (default 7 days) | Encrypted wallet session (iron-session) |
+| `remitwise_locale` | Client (`lib/i18n/cookie.ts`) | ❌ No | `Lax` | ❌ Never | 365 days | UI language preference |
+| `rw-analytics-consent` | Client (`lib/consent/consent.ts`) | ❌ No | `Lax` | When served over HTTPS | 180 days | User analytics opt-in/out |
+
+---
+
+## `remitwise_session`
+
+**Source:** `lib/session.ts`
+
+This is the primary authentication cookie. It stores a sealed [iron-session](https://github.com/vvo/iron-session) payload containing the user's Stellar wallet address, `createdAt`, and `expiresAt` timestamps. The payload is encrypted and integrity-protected with `SESSION_PASSWORD` (minimum 32 characters).
+
+### Cookie attributes
+
+| Attribute | Value | Rationale |
+|---|---|---|
+| `HttpOnly` | Yes | Prevents JavaScript from reading the session token; mitigates XSS-based session theft. |
+| `SameSite` | `Lax` | Blocks CSRF on cross-site POST requests while still allowing top-level navigations (e.g., OAuth redirects) to carry the cookie. |
+| `Secure` | `NODE_ENV === 'production'` | Enforces TLS in production; omitted in local dev so plain HTTP works. |
+| `Path` | `/` | Cookie is sent on all routes. |
+| `Max-Age` | `SESSION_MAX_AGE` env var (default `604800` — 7 days) | Session expires server-side via `expiresAt` regardless of the `Max-Age`, so the two clocks are independently enforced. |
+
+### Where it is written
+
+```typescript
+// lib/session.ts — cookie set after successful login
+export function getSessionCookieHeader(sealed: string): string {
+  const sessionMaxAge = getSessionMaxAge();
+  return `${SESSION_COOKIE}=${sealed}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${sessionMaxAge}${
+    process.env.NODE_ENV === 'production' ? '; Secure' : ''
+  }`;
+}
+```
+
+Sliding-window refresh re-sets the cookie via `next/headers` `cookies().set(...)` with the same flags:
+
+```typescript
+cookieStore.set({
+  name: SESSION_COOKIE,   // 'remitwise_session'
+  value: sealed,
+  path: '/',
+  httpOnly: true,
+  sameSite: 'lax',
+  maxAge: sessionMaxAge,
+  secure: process.env.NODE_ENV === 'production',
+});
+```
+
+### Clearing the cookie
+
+On logout or 401, the cookie is cleared by setting `Max-Age=0`:
+
+```typescript
+export function clearSessionCookie(): string {
+  return `${SESSION_COOKIE}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0${
+    process.env.NODE_ENV === 'production' ? '; Secure' : ''
+  }`;
+}
+```
+
+### Refresh behaviour
+
+When `SESSION_REFRESH_ENABLED=true` the sliding window is extended on every authenticated request. The refreshed cookie is written through `getSessionWithRefresh()` in `lib/session.ts`. When the env var is absent or `false`, sessions are fixed-window and expire at `expiresAt` without renewal.
+
+### Threat model note
+
+Without `HttpOnly`, XSS can exfiltrate the session token directly from `document.cookie`. The flag closes that vector. `SameSite=Lax` (rather than `None`) prevents the token from being attached to cross-origin sub-resource requests, blocking CSRF attacks that would otherwise allow an attacker's site to make authenticated API calls on behalf of the victim.
+
+---
+
+## `remitwise_locale`
+
+**Source:** `lib/i18n/cookie.ts`
+
+Stores the user's chosen UI language (`en` or `es`). This preference is read by both the server (via `NextRequest.cookies`) and the client (via `document.cookie`) to resolve the active locale before rendering.
+
+### Cookie attributes
+
+| Attribute | Value | Rationale |
+|---|---|---|
+| `HttpOnly` | **No** | Client-side code needs to read and update the locale when the user switches language without a full page reload. |
+| `SameSite` | `Lax` | Standard same-site protection; locale is non-sensitive. |
+| `Secure` | **No** | Language preference carries no secret; omitting `Secure` avoids breakage on non-TLS development environments and is acceptable given the data is non-sensitive. |
+| `Path` | `/` | Applies to all routes. |
+| `Max-Age` | `31 536 000` (365 days) | Long lifetime mirrors a typical user preference — the banner to re-prompt is not shown until the cookie expires or is cleared. |
+
+### Where it is written
+
+```typescript
+// lib/i18n/cookie.ts
+export function setLocaleCookie(locale: SupportedLocale): void {
+  if (typeof document === 'undefined') return;
+  document.cookie = `${COOKIE_NAME}=${locale}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
+}
+```
+
+Supported values are `"en"` and `"es"`. Any other value is rejected by `isValidLocale()` and treated as if no cookie were present.
+
+---
+
+## `rw-analytics-consent`
+
+**Source:** `lib/consent/consent.ts`
+
+Persists the user's analytics opt-in or opt-out choice (`"granted"` or `"denied"`). The flag drives whether Sentry replays and performance tracing are initialised.
+
+### Cookie attributes
+
+| Attribute | Value | Rationale |
+|---|---|---|
+| `HttpOnly` | **No** | The consent banner and Sentry initialisation code run client-side and must be able to read the stored choice without a round-trip. |
+| `SameSite` | `Lax` | Standard protection for a first-party preference cookie. |
+| `Secure` | When `window.location.protocol === 'https:'` | Added dynamically: set on HTTPS deployments, absent on local HTTP dev. |
+| `Path` | `/` | Applies site-wide. |
+| `Max-Age` | `15 552 000` (180 days) | Matches typical GDPR re-consent windows; the banner is re-shown after this period. |
+
+### Where it is written
+
+```typescript
+// lib/consent/consent.ts
+export function writeConsentCookie(value: ConsentValue): void {
+  if (typeof document === 'undefined') return;
+
+  const secure =
+    typeof window !== 'undefined' && window.location?.protocol === 'https:'
+      ? '; Secure'
+      : '';
+
+  document.cookie = [
+    `${CONSENT_COOKIE_NAME}=${value}`,   // 'rw-analytics-consent'
+    `max-age=${MAX_AGE_SECONDS}`,        // 180 days
+    'path=/',
+    'SameSite=Lax',
+    secure,
+  ]
+    .filter(Boolean)
+    .join('; ');
+}
+```
+
+### Consent resolution order
+
+1. **GPC signal active** → always `"denied"` (no user interaction required; legally binding under GPC spec).
+2. **Cookie present** → use stored value (`"granted"` or `"denied"`).
+3. **No cookie, EU locale detected** → `"undecided"` (show the consent banner).
+4. **No cookie, non-EU locale** → `"granted"` (opt-in by default).
+
+This is implemented in `getConsentState()` in `lib/consent/consent.ts`.
+
+---
+
+## Environment variables
+
+| Variable | Used by | Notes |
+|---|---|---|
+| `SESSION_PASSWORD` | `lib/session.ts` | **Required.** Minimum 32 characters. Generate with `openssl rand -base64 32`. |
+| `SESSION_MAX_AGE` | `lib/session.ts` | Optional. Integer seconds. Defaults to `604800` (7 days). |
+| `SESSION_REFRESH_ENABLED` | `lib/session.ts` | `"true"` enables sliding-window refresh. Defaults to disabled. |
+| `NODE_ENV` | `lib/session.ts` | Set to `"production"` by Next.js in production builds; controls the `Secure` flag on `remitwise_session`. |
+
+---
+
+## Related documentation
+
+- [Frontend Session Handling](frontend-session-handling.md) — session lifecycle, 401 handling, and logout flow.
+- [Tracking and Opt-Out Guide](tracking-and-opt-out.md) — Sentry configuration and consent-gated tracing.
+- [Security](SECURITY.md) — overall security posture and responsible disclosure.
+- [Auth Implementation](AUTH_IMPLEMENTATION.md) — wallet-based nonce challenge-response flow.

--- a/docs/EMPTY_STATE_ILLUSTRATIONS.md
+++ b/docs/EMPTY_STATE_ILLUSTRATIONS.md
@@ -1,0 +1,434 @@
+# Empty-State Illustrations
+
+This document catalogs every empty state in RemitWise: which Lucide icon acts as the illustration, what copy is shown, and whether a call-to-action is present. Audience: **contributors** adding new views or changing existing ones.
+
+---
+
+## How empty states work
+
+All feature-widget empty states use one of two components:
+
+| Component | File | When to use |
+|---|---|---|
+| `WidgetEmptyState` (default export) | `components/ui/WidgetEmptyState.tsx` | Any widget or page that wants an icon, typed title, description, and an optional CTA link or action button. |
+| `WidgetEmptyState` (named export from `WidgetStates`) | `components/ui/WidgetStates.tsx` | Legacy usage in the Bills section; renders with a fixed `AlertCircle` icon and no CTA. **Prefer the default export for new work.** |
+
+The primary component renders a red circular icon badge, a bold title, a muted description, and an optional CTA:
+
+```tsx
+import WidgetEmptyState from '@/components/ui/WidgetEmptyState';
+import { PiggyBank } from 'lucide-react';
+
+<WidgetEmptyState
+  icon={PiggyBank}
+  title="No savings goals yet"
+  description="Create a goal to start tracking your savings progress."
+  ctaLabel="Create a goal"
+  ctaHref="/goals"
+/>
+```
+
+The icon prop accepts any `LucideIcon`. The red circle badge is always the same size (`h-12 w-12`); only the icon inside changes.
+
+---
+
+## Catalog
+
+### Dashboard widgets
+
+#### Recent Transactions (`components/Dashboard/RecentTransactionsWidget.tsx`)
+
+| Property | Value |
+|---|---|
+| Icon | `ArrowLeftRight` |
+| Title | "No transactions yet" |
+| Description | "Send money to a recipient and your activity will appear here." |
+| CTA | "Send money" → `/send` |
+
+Shown when `transactions` prop is an empty array.
+
+```tsx
+<WidgetEmptyState
+  icon={ArrowLeftRight}
+  title="No transactions yet"
+  description="Send money to a recipient and your activity will appear here."
+  ctaLabel="Send money"
+  ctaHref="/send"
+/>
+```
+
+---
+
+#### Savings by Goal (`components/Dashboard/SavingsByGoalWidget.tsx`)
+
+| Property | Value |
+|---|---|
+| Icon | `PiggyBank` |
+| Title | "No savings goals yet" |
+| Description | "Create a goal to start tracking your savings progress." |
+| CTA | "Create a goal" → `/goals` |
+
+Shown when `goals` prop is an empty array.
+
+```tsx
+<WidgetEmptyState
+  icon={PiggyBank}
+  title="No savings goals yet"
+  description="Create a goal to start tracking your savings progress."
+  ctaLabel="Create a goal"
+  ctaHref="/goals"
+/>
+```
+
+---
+
+#### Money Distribution (`components/Dashboard/MoneyDistributionWidget.tsx`)
+
+| Property | Value |
+|---|---|
+| Icon | `PieChart` |
+| Title | "No distribution data yet" |
+| Description | "Set up your money split to see how your funds are allocated." |
+| CTA | "Set up your split" → `/split` |
+
+Shown when `distributionData` prop is an empty array.
+
+```tsx
+<WidgetEmptyState
+  icon={PieChartIcon}
+  title="No distribution data yet"
+  description="Set up your money split to see how your funds are allocated."
+  ctaLabel="Set up your split"
+  ctaHref="/split"
+/>
+```
+
+---
+
+#### Six-Month Trends (`components/Dashboard/SixMonthTrendsWidget.tsx`)
+
+| Property | Value |
+|---|---|
+| Icon | `TrendingUp` |
+| Title | "No trends data yet" |
+| Description | "Keep using Remitwise to see your financial patterns over time." |
+| CTA | None |
+
+Shown when `trendsData` has no entries.
+
+```tsx
+<WidgetEmptyState
+  icon={TrendingUp}
+  title="No trends data yet"
+  description="Keep using Remitwise to see your financial patterns over time."
+/>
+```
+
+---
+
+### Insights
+
+#### Remittance Trend Chart (`components/Insights/remittanceTrendChart.tsx`)
+
+| Property | Value |
+|---|---|
+| Icon | `Activity` |
+| Title | "No activity timeline" |
+| Description | "Your remittance trend timeline will appear here once you send money." |
+| CTA | "Send money" → `/send` |
+
+Shown when the `data` array prop is empty.
+
+```tsx
+<WidgetEmptyState
+  icon={Activity}
+  title="No activity timeline"
+  description="Your remittance trend timeline will appear here once you send money."
+  ctaLabel="Send money"
+  ctaHref="/send"
+/>
+```
+
+See also [docs/activity-timeline-empty-state.md](activity-timeline-empty-state.md) for the full design rationale for this state.
+
+---
+
+#### Insights Page — no period data (`app/dashboard/insight/page.tsx`)
+
+| Property | Value |
+|---|---|
+| Icon | None (uses `WidgetStates.WidgetEmptyState`) |
+| Title | "No data available" |
+| Message | "Try selecting a different period." |
+| CTA | None |
+
+Shown when the API returns data but the selected period has no entries at all.
+
+```tsx
+import { WidgetEmptyState } from '@/components/ui/WidgetStates';
+
+<WidgetEmptyState title="No data available" message="Try selecting a different period." />
+```
+
+---
+
+#### Insights Page — no activity in period (`app/dashboard/insight/page.tsx`)
+
+| Property | Value |
+|---|---|
+| Icon | None (uses `WidgetStates.WidgetEmptyState`) |
+| Title | "No activity" |
+| Message | "You have no transactions in this period." |
+| CTA | None |
+
+Shown when the API returns a result where `spendingTotal + savingsTotal + billsTotal + insuranceTotal === 0`.
+
+```tsx
+<WidgetEmptyState title="No activity" message="You have no transactions in this period." />
+```
+
+---
+
+### Transaction pages
+
+Both `/transactions` (`app/transactions/page.tsx`) and `/dashboard/transaction-history` (`app/dashboard/transaction-history/page.tsx`) share the same two empty states.
+
+#### No transactions at all
+
+| Property | Value |
+|---|---|
+| Icon | `Inbox` |
+| Title | i18n key `transactionHistory.emptyState.title` |
+| Description | i18n key `transactionHistory.emptyState.description` |
+| CTA | i18n key `transactionHistory.emptyState.cta` → `/send` |
+
+Shown when the user has no transaction history whatsoever.
+
+```tsx
+<WidgetEmptyState
+  icon={Inbox}
+  title={t('transactionHistory.emptyState.title')}
+  description={t('transactionHistory.emptyState.description')}
+  ctaLabel={t('transactionHistory.emptyState.cta')}
+  ctaHref="/send"
+/>
+```
+
+---
+
+#### No results matching filters
+
+| Property | Value |
+|---|---|
+| Icon | `SearchX` |
+| Title | i18n key `transactionHistory.noResults.title` |
+| Description | i18n key `transactionHistory.noResults.description` |
+| CTA | i18n key `transactionHistory.noResults.clearFilters` (clears current filters) |
+
+Shown when the user has transactions but the active filter/search returns zero matches.
+
+```tsx
+<WidgetEmptyState
+  icon={SearchX}
+  title={t('transactionHistory.noResults.title')}
+  description={t('transactionHistory.noResults.description')}
+  ctaLabel={t('transactionHistory.noResults.clearFilters')}
+  onAction={clearFilters}
+/>
+```
+
+---
+
+### Bills
+
+Both Bills empty states use the legacy `WidgetEmptyState` from `components/ui/WidgetStates.tsx`, which renders a fixed `AlertCircle` icon and no CTA.
+
+#### Unpaid Bills (`components/Bills/UnpaidBillsSection.tsx`)
+
+| Property | Value |
+|---|---|
+| Icon | `AlertCircle` (built into `WidgetStates.WidgetEmptyState`) |
+| Title | "No unpaid bills" |
+| Message | "You're all caught up on your upcoming payments!" |
+| CTA | None |
+
+```tsx
+import { WidgetEmptyState } from '@/components/ui/WidgetStates';
+
+<WidgetEmptyState
+  title="No unpaid bills"
+  message="You're all caught up on your upcoming payments!"
+/>
+```
+
+---
+
+#### Recent Payments (`components/Bills/RecentPaymentsSection.tsx`)
+
+| Property | Value |
+|---|---|
+| Icon | `AlertCircle` (built into `WidgetStates.WidgetEmptyState`) |
+| Title | "No recent payments" |
+| Message | "Paid bills will appear here once processed." |
+| CTA | None |
+
+```tsx
+<WidgetEmptyState
+  title="No recent payments"
+  message="Paid bills will appear here once processed."
+/>
+```
+
+---
+
+### Send / Recurring schedules
+
+#### Recurring Schedules page (`app/send/recurring/page.tsx`)
+
+| Property | Value |
+|---|---|
+| Icon | `CalendarClock` |
+| Title | "No recurring schedules" |
+| Description | "Create a new schedule to start automating remittances." |
+| CTA | None |
+
+```tsx
+<WidgetEmptyState
+  icon={CalendarClock}
+  title="No recurring schedules"
+  description="Create a new schedule to start automating remittances."
+/>
+```
+
+---
+
+### Family wallet
+
+#### Family Member Detail Drawer — no member selected (`app/family/components/FamilyMemberDetailDrawer.tsx`)
+
+| Property | Value |
+|---|---|
+| Icon | `Users` |
+| Title | i18n key `familyDrawer.emptyTitle` (default: "No member selected") |
+| Description | i18n key `familyDrawer.emptyDescription` (default: "Select a member from the list to view details.") |
+| CTA | i18n key `familyDrawer.emptyCtaLabel` (default: "View family") → `/family` |
+
+```tsx
+<WidgetEmptyState
+  icon={Users}
+  title={t('familyDrawer.emptyTitle', 'No member selected')}
+  description={t('familyDrawer.emptyDescription', 'Select a member from the list to view details.')}
+  ctaLabel={t('familyDrawer.emptyCtaLabel', 'View family')}
+  ctaHref="/family"
+/>
+```
+
+---
+
+#### Family Member Detail Drawer — no activity for member (`app/family/components/FamilyMemberDetailDrawer.tsx`)
+
+| Property | Value |
+|---|---|
+| Icon | `Activity` |
+| Title | i18n key `familyDrawer.noActivityTitle` (default: "No recent activity") |
+| Description | i18n key `familyDrawer.noActivityDescription` (default: "This member has no spending recorded for the current cycle.") |
+| CTA | i18n key `familyDrawer.emptyCtaLabel` (default: "View family") → `/family` |
+
+```tsx
+<WidgetEmptyState
+  icon={Activity}
+  title={t('familyDrawer.noActivityTitle', 'No recent activity')}
+  description={t('familyDrawer.noActivityDescription', 'This member has no spending recorded for the current cycle.')}
+  ctaLabel={t('familyDrawer.emptyCtaLabel', 'View family')}
+  ctaHref="/family"
+/>
+```
+
+---
+
+#### Approvals Queue (`app/family/components/ApprovalsQueue.tsx`)
+
+| Property | Value |
+|---|---|
+| Icon | `Users` |
+| Title | i18n key `approvals_queue.empty_title` |
+| Description | i18n key `approvals_queue.empty_description` |
+| CTA | None |
+
+```tsx
+<WidgetEmptyState
+  icon={Users}
+  title={t('approvals_queue.empty_title')}
+  description={t('approvals_queue.empty_description')}
+/>
+```
+
+---
+
+### Admin panel (`app/admin/page.tsx`)
+
+#### No audit events
+
+| Property | Value |
+|---|---|
+| Icon | `Activity` |
+| Title | "No audit events" |
+| Description | "No audit events have been recorded yet." |
+| CTA | None |
+
+#### No users
+
+| Property | Value |
+|---|---|
+| Icon | `Users` |
+| Title | "No users" |
+| Description | "No users have been created yet." |
+| CTA | None |
+
+#### No DLQ events
+
+| Property | Value |
+|---|---|
+| Icon | `AlertTriangle` |
+| Title | "No DLQ events" |
+| Description | "Great! There are no failed webhook events in the dead-letter queue." |
+| CTA | None |
+
+---
+
+## Icon-to-context mapping
+
+The table below makes the semantic intent of each icon explicit so future additions are consistent.
+
+| Lucide icon | Semantic meaning in RemitWise | Used in |
+|---|---|---|
+| `Activity` | Timeline / event stream / member spend activity | Remittance Trend Chart, Family Member activity, Admin audit |
+| `AlertCircle` | Neutral "nothing here" notice (legacy Bills usage) | Unpaid Bills, Recent Payments |
+| `AlertTriangle` | Warning / operational concern | Admin DLQ empty state |
+| `ArrowLeftRight` | Send / transfer activity | Recent Transactions widget |
+| `CalendarClock` | Scheduled / recurring events | Recurring Schedules page |
+| `Inbox` | Zero-history state for a ledger | Transaction History pages |
+| `PieChart` | Budget allocation / distribution | Money Distribution widget |
+| `PiggyBank` | Savings goals | Savings by Goal widget |
+| `SearchX` | No results for an active query | Transaction filter empty state |
+| `TrendingUp` | Financial trends over time | Six-Month Trends widget |
+| `Users` | Family / member context | Family Drawer, Approvals Queue, Admin users |
+
+---
+
+## Adding a new empty state
+
+1. Import the icon from `lucide-react`. Check the table above first — reuse an existing icon if the context matches.
+2. Use `WidgetEmptyState` (default export from `components/ui/WidgetEmptyState.tsx`).
+3. Provide a `ctaHref` or `onAction` whenever the user has a clear next step to resolve the empty state.
+4. Add a row to this document before opening your PR.
+
+---
+
+## Related documentation
+
+- [`components/ui/WidgetEmptyState.tsx`](../components/ui/WidgetEmptyState.tsx) — primary empty-state component source.
+- [`components/ui/WidgetStates.tsx`](../components/ui/WidgetStates.tsx) — legacy `WidgetEmptyState` and `WidgetErrorState`.
+- [Component States Guide](COMPONENT_STATES.md) — full guide to Default, Hover, Focus, Disabled, Error, and Loading states.
+- [Icon System](ICON_SYSTEM.md) — icon sizing conventions, usage rules, and how to add custom icons.
+- [Activity Timeline Empty State](activity-timeline-empty-state.md) — design rationale for the Remittance Trend Chart empty state.


### PR DESCRIPTION
## Summary

This PR closes two documentation issues in a single commit:

- **#1162** — Add `docs/COOKIE_HANDLING.md`: full inventory of all first-party cookies with their `HttpOnly`, `SameSite`, and `Secure` flags, where each is written in the codebase, and threat-model notes for the session cookie.
- **#1171** — Add `docs/EMPTY_STATE_ILLUSTRATIONS.md`: complete catalog of every empty state across the app — which Lucide icon is used, the copy (title + description), and CTA destination.

Both documents are linked from the top-level `README.md` so they are discoverable without knowing they exist.

## Changes

### `docs/COOKIE_HANDLING.md` (new)
- Inventory table for all three first-party cookies: `remitwise_session`, `remitwise_locale`, `rw-analytics-consent`
- Per-cookie attribute breakdown (HttpOnly, SameSite, Secure, Max-Age) with rationale
- Code snippets showing exactly where each cookie is written (`lib/session.ts`, `lib/i18n/cookie.ts`, `lib/consent/consent.ts`)
- Threat model note: explains what an attacker gains without `HttpOnly` + `SameSite` on the session cookie
- Environment variable reference table

### `docs/EMPTY_STATE_ILLUSTRATIONS.md` (new)
- How the two `WidgetEmptyState` variants work and when to use each
- Per-screen catalog covering Dashboard widgets, Insights, Transaction pages, Bills, Recurring Schedules, Family Wallet, and Admin panel
- Icon-to-context semantic mapping table so future additions stay consistent
- "Adding a new empty state" recipe

### `README.md` (updated)
- Linked `COOKIE_HANDLING.md` from the Sentry/tracking section
- Linked `EMPTY_STATE_ILLUSTRATIONS.md` from the Loading States section

## Threat mitigated (issue #1162)

Without `HttpOnly` on the session cookie, an XSS payload can read `document.cookie` directly and exfiltrate the iron-session token. Without `SameSite=Lax`, a cross-origin attacker page can make authenticated requests that carry the cookie. Both flags are already applied; this PR documents that intent so reviewers can verify it is upheld.

Closes #1162
Closes #1171