### PR TITLE
feat(auth): add useCredentialRevoke() hook

### DIFF
--- a/lib/client/useCredentialRevoke.ts
+++ b/lib/client/useCredentialRevoke.ts
@@ -1,0 +1,92 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { sessionHandler } from './sessionHandler';
+import { safeRedirectPath } from './logout';
+
+const REVOKE_TIMEOUT_MS = 5000;
+
+export interface RevokeCredentialOptions {
+  /**
+   * Browser location to navigate to after a successful revoke.
+   * Defaults to `'/'`.
+   */
+  redirectTo?: string;
+}
+
+export interface UseCredentialRevokeState {
+  /** True while a revoke request is in flight. */
+  isRevoking: boolean;
+  /** Message from the most recently failed revoke attempt, or `null`. */
+  error: string | null;
+  /**
+   * Revokes the current session credential via `POST /api/auth/logout`.
+   * Always clears local auth state, regardless of the server response.
+   * Resolves `true` on a server-acknowledged revoke, `false` otherwise.
+   * On success, navigates the browser to `redirectTo`.
+   */
+  revoke: (options?: RevokeCredentialOptions) => Promise<boolean>;
+}
+
+/**
+ * Hook form of the sign-out flow that surfaces `isRevoking`/`error` state to
+ * the caller instead of redirecting immediately, so UI that wants to confirm
+ * or report failure (e.g. a "revoke this session" action on a security page)
+ * has something to render before navigation happens.
+ *
+ * Shares the same server contract and redirect-sanitization logic as
+ * {@link logout} in `./logout`; use that helper instead for a fire-and-forget
+ * sign-out button that doesn't need in-place loading/error UI.
+ */
+export function useCredentialRevoke(): UseCredentialRevokeState {
+  const [isRevoking, setIsRevoking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const revoke = useCallback(async (options: RevokeCredentialOptions = {}): Promise<boolean> => {
+    const { redirectTo = '/' } = options;
+    const safeTarget = safeRedirectPath(redirectTo);
+
+    setIsRevoking(true);
+    setError(null);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), REVOKE_TIMEOUT_MS);
+
+    let success = false;
+    try {
+      const response = await fetch('/api/auth/logout', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+
+      if (response.ok) {
+        success = true;
+      } else {
+        setError(`Revoke request failed with status ${response.status}`);
+      }
+    } catch (err) {
+      clearTimeout(timeoutId);
+      if (err instanceof Error && err.name === 'AbortError') {
+        setError(`Revoke request timed out after ${REVOKE_TIMEOUT_MS}ms`);
+      } else {
+        setError(err instanceof Error ? err.message : 'Revoke request failed');
+      }
+    } finally {
+      // Always clear local auth state so the client is never stuck "logged in".
+      sessionHandler.clearAuthState();
+      setIsRevoking(false);
+    }
+
+    if (success && typeof window !== 'undefined') {
+      window.location.href = safeTarget;
+    }
+
+    return success;
+  }, []);
+
+  return { isRevoking, error, revoke };
+}

--- a/tests/unit/useCredentialRevoke.test.ts
+++ b/tests/unit/useCredentialRevoke.test.ts
@@ -1,0 +1,167 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useCredentialRevoke } from '@/lib/client/useCredentialRevoke';
+
+const mockClearAuthState = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/client/sessionHandler', () => ({
+  sessionHandler: {
+    clearAuthState: mockClearAuthState,
+  },
+}));
+
+describe('useCredentialRevoke', () => {
+  let locationHref = '';
+
+  beforeEach(() => {
+    mockClearAuthState.mockClear();
+    locationHref = '';
+    // Redefine only `window.location` on the real jsdom window so React's
+    // renderer keeps working; replacing the whole `window` global (as
+    // logout-client.test.ts does for the non-hook `logout()` helper) breaks
+    // React's scheduler here.
+    Object.defineProperty(window, 'location', {
+      value: {
+        get href() { return locationHref; },
+        set href(v: string) { locationHref = v; },
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('starts idle with no error', () => {
+    const { result } = renderHook(() => useCredentialRevoke());
+
+    expect(result.current.isRevoking).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('calls the logout endpoint, clears auth state, and redirects to / on success', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: 'Logged out successfully' }),
+    }));
+
+    const { result } = renderHook(() => useCredentialRevoke());
+
+    let success: boolean | undefined;
+    await act(async () => {
+      success = await result.current.revoke();
+    });
+
+    expect(fetch).toHaveBeenCalledWith('/api/auth/logout', expect.objectContaining({ method: 'POST' }));
+    expect(mockClearAuthState).toHaveBeenCalledTimes(1);
+    expect(success).toBe(true);
+    expect(locationHref).toBe('/');
+    expect(result.current.isRevoking).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('redirects to a custom safe path on success', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: 'ok' }),
+    }));
+
+    const { result } = renderHook(() => useCredentialRevoke());
+
+    await act(async () => {
+      await result.current.revoke({ redirectTo: '/settings/security' });
+    });
+
+    expect(locationHref).toBe('/settings/security');
+  });
+
+  it('sanitizes an unsafe redirect target and falls back to /', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: 'ok' }),
+    }));
+
+    const { result } = renderHook(() => useCredentialRevoke());
+
+    await act(async () => {
+      await result.current.revoke({ redirectTo: 'https://evil.com' });
+    });
+
+    expect(locationHref).toBe('/');
+  });
+
+  it('clears auth state and reports an error on a non-OK response, without redirecting', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    }));
+
+    const { result } = renderHook(() => useCredentialRevoke());
+
+    let success: boolean | undefined;
+    await act(async () => {
+      success = await result.current.revoke();
+    });
+
+    expect(mockClearAuthState).toHaveBeenCalledTimes(1);
+    expect(success).toBe(false);
+    expect(locationHref).toBe('');
+    expect(result.current.error).toBe('Revoke request failed with status 500');
+    expect(result.current.isRevoking).toBe(false);
+  });
+
+  it('clears auth state and reports an error on a network failure, without redirecting', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network failure')));
+
+    const { result } = renderHook(() => useCredentialRevoke());
+
+    let success: boolean | undefined;
+    await act(async () => {
+      success = await result.current.revoke();
+    });
+
+    expect(mockClearAuthState).toHaveBeenCalledTimes(1);
+    expect(success).toBe(false);
+    expect(locationHref).toBe('');
+    expect(result.current.error).toBe('Network failure');
+  });
+
+  it('reports a timeout error on AbortError, without redirecting', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(
+      Object.assign(new Error('Aborted'), { name: 'AbortError' }),
+    ));
+
+    const { result } = renderHook(() => useCredentialRevoke());
+
+    let success: boolean | undefined;
+    await act(async () => {
+      success = await result.current.revoke();
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe('Revoke request timed out after 5000ms');
+    expect(locationHref).toBe('');
+  });
+
+  it('clears any previous error at the start of a new revoke attempt', async () => {
+    vi.stubGlobal('fetch', vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ message: 'ok' }) }));
+
+    const { result } = renderHook(() => useCredentialRevoke());
+
+    await act(async () => {
+      await result.current.revoke();
+    });
+    expect(result.current.error).toBe('Revoke request failed with status 500');
+
+    await act(async () => {
+      await result.current.revoke();
+    });
+    expect(result.current.error).toBeNull();
+    expect(locationHref).toBe('/');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `useCredentialRevoke()` in `lib/client/useCredentialRevoke.ts`, a hook wrapper around the existing session-invalidation flow (`POST /api/auth/logout`).
- Unlike the existing fire-and-forget `logout()` helper, this hook surfaces `isRevoking`/`error` state so callers (e.g. a confirm dialog on a security/settings page) can show feedback before navigating away.
- Reuses `safeRedirectPath` from `lib/client/logout.ts` and `sessionHandler.clearAuthState()` so redirect sanitization and local-state teardown stay consistent with the existing sign-out path — no new auth logic introduced.

## Notes for reviewers
This app authenticates via Stellar wallet public keys rather than traditional credentials, and there was no existing `useMoney()`/credential abstraction to build on, so this is scoped as a minimal additive wrapper around the current session/logout flow rather than a new subsystem.

## Test plan
- [x] `npx vitest run tests/unit/useCredentialRevoke.test.ts tests/unit/logout-client.test.ts` — 33/33 passing
- [x] `npx tsc --noEmit` — no new errors introduced (same 38 pre-existing errors on `main`, unrelated to this change)
- [x] `npx eslint lib/client/useCredentialRevoke.ts tests/unit/useCredentialRevoke.test.ts` — clean

Closes #1223