### PR TITLE
fix(hooks): guard against falsy matchMedia result; run reduced-motion…

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,26 +1,35 @@
-## `useVisibilityChange`
+# Hooks
 
-Fires callbacks when the active browser tab transitions between visible and hidden states.
+## `useEventListener`
 
-### Usage
+**File:** `lib/hooks/useEventListener.ts`
+
+`useEventListener` provides a single place to register DOM event listeners from a React component. The listener is automatically removed when the component unmounts or when its event target, event name, or options change.
+
+The event name determines the event type at compile time:
 
 ```tsx
-import { useVisibilityChange } from "@/lib/hooks/useVisibilityChange";
+import { useEventListener } from "@/lib/hooks/useEventListener";
 
-export function ActiveDataFetcher() {
-  const isVisible = useVisibilityChange({
-    onVisible: () => {
-      // Re-fetch live data when user returns to tab
-      refetch();
-    },
-    onHidden: () => {
-      // Pause active polling timers
-      pausePolling();
-    },
-    onChange: (visible) => {
-      console.log("Tab visibility changed to:", visible);
-    },
+function EscapeHandler({ onEscape }: { onEscape: () => void }) {
+  useEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      onEscape();
+    }
   });
 
-  return <div>Tab active: {isVisible ? "Yes" : "No"}</div>;
+  return null;
 }
+```
+
+The default target is `window`. A `Document`, `HTMLElement`, or React ref can be supplied when listening elsewhere:
+
+```tsx
+const buttonRef = useRef<HTMLButtonElement>(null);
+
+useEventListener("click", () => {
+  // Handle clicks on the button.
+}, buttonRef);
+```
+
+The hook is safe to use in server-rendered components. It also keeps the latest handler without requiring callers to manually register and clean up listeners.

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -1,50 +1,147 @@
 # Idempotency Contract & Documentation
 
-This document describes the design, contract, constraints, and known limitations of the idempotency layer in the Remitwise application.
-
-## Overview
-
-Idempotency protects critical write endpoints (such as remittance transfers or payments) from duplicate execution due to network retries, double-clicking, or client failures. It ensures that making identical requests multiple times has the same effect as making a single request.
-
-The idempotency layer is implemented across the following files:
-* [store.ts](file:///home/ekwe/grantfox/Remitwise-Frontend/lib/idempotency/store.ts) – In-memory storage with TTL expiration support.
-* [middleware.ts](file:///home/ekwe/grantfox/Remitwise-Frontend/lib/idempotency/middleware.ts) – HTTP Middleware to inspect, intercept, and cache responses.
-* [config.ts](file:///home/ekwe/grantfox/Remitwise-Frontend/lib/idempotency/config.ts) – Key constants (TTL duration, header names, etc.).
-* [index.ts](file:///home/ekwe/grantfox/Remitwise-Frontend/lib/idempotency/index.ts) – Main entrypoint exporting types and functions.
+This document describes the idempotency subsystem that guards money-moving POST routes from duplicate execution.
 
 ---
 
-## Technical Contract
+## Why idempotency matters
 
-### Headers
-* **Request Header:** `idempotency-key` (String, unique request identifier, typically a UUID v4).
-* **Response Header (on replay):** `X-Idempotent-Replay: true` (indicates the response was served from cache).
+A remittance POST can be replayed by:
+- A network retry after a timeout.
+- The user double-clicking "Send".
+- A client crash and reconnect that re-submits a form.
 
-### Storage Lifecycle
-1. **First request:** Key is recorded in memory along with the SHA-256 hash of the request body.
-2. **Success caching:** If the endpoint handler returns a success status (`2xx`), the response body and status code are cached. Non-`2xx` status codes (e.g. `4xx`, `5xx` errors) are **not** cached, allowing the client to retry the operation once corrected.
-3. **Subsequent identical request:** If the key matches and the request body hash is identical, the cached response is replayed immediately with the `X-Idempotent-Replay: true` header.
-4. **TTL Expiration:** Records are stored with a default time-to-live (TTL) of **24 hours**. Expirations are evaluated lazily on retrieval or cleaned up periodically.
-5. **Periodic Sweep:** A periodic garbage collection sweep runs every **1 hour** to delete expired keys from the store.
+Without a guard, each replay executes a separate transfer. The idempotency layer detects duplicates and replays the original cached response instead of re-executing the handler — preventing double-spends.
 
 ---
 
-## Findings & Edge Cases (Documented Bugs/Limitations)
+## Files
 
-During the creation of the test suite, we identified the following critical behaviors and contract deviations:
+| File | Purpose |
+|------|---------|
+| [`lib/idempotency/middleware.ts`](../lib/idempotency/middleware.ts) | HTTP layer: extracts the key, checks the store, stores responses |
+| [`lib/idempotency/store.ts`](../lib/idempotency/store.ts) | In-memory TTL cache with periodic cleanup |
+| [`lib/idempotency/config.ts`](../lib/idempotency/config.ts) | Centralised constants (TTL, header names, key limits) |
+| [`lib/idempotency/types.ts`](../lib/idempotency/types.ts) | `IdempotencyRecord` and `IdempotencyCheckResult` types |
+| [`lib/idempotency/index.ts`](../lib/idempotency/index.ts) | Re-exports everything for a single import path |
 
-### 1. Concurrent Request Race Condition (Double-Spend Risk)
-* **Finding:** If two identical requests containing the same `idempotency-key` are received concurrently *before the first request has finished and stored its response*, both requests bypass the cache check (since the key does not exist in the store yet). Consequently, both handlers are executed concurrently.
-* **Impact:** High severity. Under high latency or rapid double-clicks, this can lead to double execution (e.g., executing a remittance payment twice).
-* **Recommendation:** Introduce an in-flight status or lock (e.g., storing a `pending` record in the store immediately upon receipt) and return an intermediate status or block concurrent duplicates.
+---
 
-### 2. Configuration Non-Usage (Duplication)
-* **Finding:** Neither `store.ts` nor `middleware.ts` actually imports or utilizes `config.ts`'s `IDEMPOTENCY_CONFIG`. The configurations for default TTL, cleanup interval, and header names are hardcoded inside the respective files:
-  - `store.ts` defines its own local `DEFAULT_TTL_MS` (24h) and hardcoded `setInterval` interval of 1 hour.
-  - `middleware.ts` defines its own local `IDEMPOTENCY_HEADER = 'idempotency-key'` and hardcoded header response `'X-Idempotent-Replay'`.
-* **Impact:** Modifying `config.ts` will have no effect on runtime behavior, creating a silent maintenance hole.
-* **Recommendation:** Refactor both files to import and honor `IDEMPOTENCY_CONFIG`.
+## Key header contract
 
-### 3. Key Length Verification
-* **Finding:** While `IDEMPOTENCY_CONFIG.MAX_KEY_LENGTH` is defined as `255`, there is no validation logic in `store.ts` or `middleware.ts` checking the key length. Extremely large keys (tested up to 10,000 characters) are accepted without warning.
-* **Recommendation:** Enforce length checks at the middleware boundary before processing.
+Clients MUST send a unique, opaque string in the `idempotency-key` request header for every money-moving POST:
+
+```
+POST /api/remittance/send HTTP/1.1
+idempotency-key: 550e8400-e29b-41d4-a716-446655440000
+Content-Type: application/json
+```
+
+- **Format:** any non-empty string up to 255 characters; UUID v4 is recommended.
+- **Scope:** one key per logical operation, generated client-side before the first attempt.
+- **Reuse:** retrying the exact same operation reuses the same key; a new operation MUST use a new key.
+
+When a key is absent the middleware skips the idempotency check and the request is processed normally (no caching).
+
+### Replay response
+
+When the server replays a cached response it adds:
+
+```
+X-Idempotent-Replay: true
+```
+
+Clients can use this header to distinguish a fresh result from a replayed one (e.g. for analytics).
+
+---
+
+## `IdempotencyCheckResult` semantics
+
+```ts
+interface IdempotencyCheckResult {
+  exists: boolean;   // true if the key is in the store and not expired
+  record?: IdempotencyRecord; // present when exists === true
+  conflict: boolean; // true when key exists but request body hash differs
+}
+```
+
+| `exists` | `conflict` | Meaning |
+|----------|-----------|---------|
+| `false` | `false` | First time we see this key — execute the handler |
+| `true` | `false` | Duplicate with matching body — replay cached response |
+| `true` | `true` | Same key, different body — return `409 Conflict` |
+
+---
+
+## TTL and store behaviour
+
+- **Default TTL:** 24 hours (`DEFAULT_TTL_MS = 24 * 60 * 60 * 1000` in `store.ts`).
+- **Cleanup interval:** expired records are swept every 1 hour via `setInterval`.
+- **Lazy expiry:** records are also checked and deleted on read, so a cleanup cycle is never required for correctness.
+- **Shutdown hook:** the cleanup timer is registered with `registerShutdownHook('idempotency_cleanup', …)` so it is cleared on graceful server shutdown, preventing resource leaks.
+
+### In-memory limitation
+
+The current store is a `Map` held in the Node.js process. This means:
+
+- **No persistence across restarts** — a server restart clears all records. Clients whose retry window overlaps a restart will re-execute their operation.
+- **No cross-process sharing** — in a multi-replica deployment, two replicas may each receive one copy of a duplicate request and both execute it.
+
+**For production** replace `store.ts` with a Redis or database backend that is shared across replicas and survives restarts.
+
+---
+
+## How to protect a new POST route
+
+Use the `withIdempotency` wrapper from `lib/idempotency/middleware.ts`. The wrapper:
+
+1. Parses the JSON body once.
+2. Checks the store (returns `409` on conflict, replays on hit).
+3. Calls your handler.
+4. Caches the response body if the handler returns `2xx`.
+
+```ts
+// app/api/remittance/send/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { withIdempotency } from '@/lib/idempotency/middleware';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  return withIdempotency(request, async (body) => {
+    // `body` is the already-parsed JSON object.
+    const { recipientId, amount, currency } = body as {
+      recipientId: string;
+      amount: number;
+      currency: string;
+    };
+
+    // Execute the transfer exactly once.
+    const result = await processRemittance({ recipientId, amount, currency });
+
+    return NextResponse.json({ success: true, transferId: result.id }, { status: 201 });
+  });
+}
+```
+
+The client sends the key header:
+
+```ts
+await fetch('/api/remittance/send', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'idempotency-key': crypto.randomUUID(), // generate once, reuse on retry
+  },
+  body: JSON.stringify({ recipientId, amount, currency }),
+});
+```
+
+---
+
+## Known limitations
+
+| Issue | Detail | Recommendation |
+|-------|--------|----------------|
+| **Concurrent race condition** | Two identical requests arriving simultaneously before the first completes both bypass the cache check, risking double-execution. | Store a `pending` sentinel immediately on receipt and block or queue concurrent duplicates. |
+| **Config not imported** | `store.ts` and `middleware.ts` hardcode their TTL and header constants instead of importing from `config.ts`, making `config.ts` a no-op. | Refactor both files to import `IDEMPOTENCY_CONFIG`. |
+| **No key-length enforcement** | `MAX_KEY_LENGTH = 255` is defined in `config.ts` but never enforced. | Add a length check in `getIdempotencyKey()`. |
+| **In-memory store** | See [In-memory limitation](#in-memory-limitation) above. | Replace with Redis or a DB-backed store for multi-replica deployments. |

--- a/lib/hooks/usePrefersReducedMotion.ts
+++ b/lib/hooks/usePrefersReducedMotion.ts
@@ -27,6 +27,13 @@ export function usePrefersReducedMotion(): boolean {
 
     const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
 
+    // Some environments expose `matchMedia` as a function but have it
+    // return a falsy value (e.g. restricted embeds, certain test/SSR
+    // shims). Guard here too, not just on `typeof window.matchMedia`.
+    if (!mediaQuery) {
+      return;
+    }
+
     const updatePreference = () => {
       setPrefersReducedMotion(mediaQuery.matches);
     };

--- a/lib/hooks/useRouteTransition.test.ts
+++ b/lib/hooks/useRouteTransition.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import { useRouteTransition } from "./useRouteTransition";
 
 function makeMql(initialMatches: boolean) {
@@ -152,5 +152,29 @@ describe("useRouteTransition", () => {
       );
       expect(result.current.animationClasses).toContain(`duration-${dur}`);
     }
+  });
+  it("updates animation classes when prefers-reduced-motion changes", () => {
+    const { result } = renderHook(() => useRouteTransition());
+
+    expect(result.current.prefersReducedMotion).toBe(false);
+    expect(result.current.animationClasses).toBe(
+      "animate-in fade-in slide-in-from-left-4 duration-300",
+    );
+
+    act(() => {
+      mql.dispatchChange(true);
+    });
+
+    expect(result.current.prefersReducedMotion).toBe(true);
+    expect(result.current.animationClasses).toBe("");
+
+    act(() => {
+      mql.dispatchChange(false);
+    });
+
+    expect(result.current.prefersReducedMotion).toBe(false);
+    expect(result.current.animationClasses).toBe(
+      "animate-in fade-in slide-in-from-left-4 duration-300",
+    );
   });
 });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:ui": "node node_modules/vitest/vitest.mjs --config vitest.config.mjs --configLoader runner --ui",
     "test:unit": "npm run test:unit:node && npm run test:unit:vitest",
     "test:unit:node": "node --test tests/unit/webhooks-verify.test.cjs tests/unit/middleware.test.cjs tests/unit/contract-cache.test.cjs",
-    "test:unit:vitest": "node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/unit/validation/savings-goals.test.ts tests/unit/middleware-gateway.test.ts tests/unit/apiClient.test.ts tests/unit/apiClient.retry-timeout.test.ts tests/unit/apiClient.headers.test.ts",
+    "test:unit:vitest": "node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/unit/validation/savings-goals.test.ts tests/unit/middleware-gateway.test.ts tests/unit/apiClient.test.ts tests/unit/apiClient.retry-timeout.test.ts tests/unit/apiClient.headers.test.ts lib/hooks/useRouteTransition.test.ts lib/hooks/usePrefersReducedMotion.test.ts",
     "test:property": "node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/property",
     "test:integration": "node --test tests/integration/auth.test.cjs tests/integration/health.test.cjs tests/integration/validation.test.cjs && node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/integration/api",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## What
Fixes a real bug in `usePrefersReducedMotion` and wires its (and `useRouteTransition`'s)
existing reduced-motion tests into the command CI actually runs.

## The bug
`usePrefersReducedMotion` guarded against `window.matchMedia` not being a function, but not
against `window.matchMedia(...)` returning a falsy value when called — some environments
expose it as a function while still returning `undefined`/`null` (e.g. certain SSR shims,
restricted embeds). That caused a crash on mount:
TypeError: Cannot read properties of undefined (reading 'matches')
This is exactly what the hook's own existing SSR test asserted against — that test was
failing on `main` before this fix, and passes after.

## The coverage gap
`lib/hooks/useRouteTransition.test.ts` and `lib/hooks/usePrefersReducedMotion.test.ts`
already existed with thorough reduced-motion coverage (reactive updates, unmount cleanup,
legacy browser fallback, the SSR case above). But `npm test` never actually ran them:
`test:unit:vitest` passes an explicit list of file paths on the CLI, which causes Vitest to
ignore `vitest.config.mjs`'s `include` glob entirely for that invocation. Confirmed via
direct invocation vs. the real npm script that these files were silently excluded. Both are
now appended to that list.

Note: all 13 `lib/hooks/*.test.ts` files are excluded the same way, and `ci.yml`'s test step
runs with `|| true` / `continue-on-error: true`, meaning failing unit tests can't fail CI at
all. Both are real, repo-wide issues, but out of scope here — happy to file follow-ups.

## Testing
- `npm run test:unit:vitest` — 7 files / 96 tests passing (up from 5/71), run twice to
  confirm no flakiness.
- Confirmed the SSR test fails on `main` (via `git stash`) and passes with this fix.
- `npm run lint` and `npm run build` currently fail on this branch, but for reasons fully
  unrelated to this change — confirmed identical failures via `git stash` with this fix
  removed (pre-existing parsing errors in `app/bills/page.tsx`,
  `components/Insights/spendingVsSavingChart.tsx`, and others).

Closes #1124