### PR TITLE
docs: add BUNDLE_ANALYSIS.md workflow guide (closes #1113)

### DIFF
--- a/PR_BUNDLE_ANALYSIS.md
+++ b/PR_BUNDLE_ANALYSIS.md
@@ -1,0 +1,47 @@
+# Pull Request: Add docs/BUNDLE_ANALYSIS.md workflow doc
+
+**Closes #1113**
+
+## Summary
+
+Add a contributor-facing guide that documents how to run, interpret, and act on the Next.js bundle analyzer output. Bundle analysis knowledge was previously tribal; this makes it discoverable for new contributors and reviewers.
+
+## What changed
+
+| File | Change |
+|------|--------|
+| `docs/BUNDLE_ANALYSIS.md` | **New** — 126-line guide covering: audience (contributors), why bundle size matters, how to run the analyzer (macOS/Linux/Windows), report locations, treemap interpretation (stat/parsed/gzipped), bottleneck identification, and remediation strategies (dynamic imports, tree shaking, lightweight alternatives). |
+| `README.md` | Added "Bundle Analysis" section linking to the new doc + project structure tree entry. |
+| `next.config.js` | Wired `@next/bundle-analyzer` via `withBundleAnalyzer()`, gated behind `ANALYZE=true` env var. |
+| `docs/LOAD_TIME_BUDGETS.md` | Updated "Build-time bundle size check" section to reference the new guide; added cross-link to the related-documents table; updated future enhancement note. |
+| `package.json` | Added `@next/bundle-analyzer: ^16.2.11` as devDependency; removed duplicate `check:img-alt` script entry. |
+
+## How to verify
+
+1. **Run the analyzer locally:**
+   ```bash
+   # macOS/Linux
+   ANALYZE=true npm run build
+
+   # Windows PowerShell
+   $env:ANALYZE="true"; npm run build
+   ```
+   Confirm three HTML reports appear in `.next/analyze/`: `client.html`, `server.html`, `edge.html`.
+
+2. **Open `client.html` in a browser** and verify the interactive treemap loads with stat/parsed/gzipped size tooltips.
+
+3. **Lint passes** — `npm run lint` is clean (pre-existing errors in unrelated files are unchanged).
+
+4. **Unit tests pass** — `npm run test:unit` passes all 102 tests (26 node + 76 vitest).
+
+## Implementation notes
+
+- The analyzer is **local-only** — no CI step added. This matches the current workflow where bundle review is a manual contributor responsibility.
+- `ANALYZE=true` is the only env gate; no additional config files or GitHub Actions changes needed.
+- The `next.config.js` change wraps the existing `withSentryConfig()` call — order is `withBundleAnalyzer(withSentryConfig(...))` which is the recommended composition pattern.
+- Fixed a pre-existing duplicate `check:img-alt` script entry in `package.json` (line 14 was a duplicate of line 12).
+
+## Out of scope (follow-up issues)
+
+- CI integration for automated bundle size budgets (noted as future enhancement in `LOAD_TIME_BUDGETS.md`).
+- An `npm run analyze` convenience script wrapping `ANALYZE=true npm run build`.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Dashboard, Bills, and Insights now use route-level skeleton screens built from `
 
 Every page route has a per-route load-time budget based on its user impact tier. These budgets are enforced in CI via Lighthouse E2E tests and monitored in production through structured request logs. For the full route-to-budget map, measurement approach, and how to add budgets for new routes, see [docs/LOAD_TIME_BUDGETS.md](docs/LOAD_TIME_BUDGETS.md).
 
+## Bundle Analysis
+
+To measure, inspect, and optimize the JavaScript bundle size using `@next/bundle-analyzer`, see [docs/BUNDLE_ANALYSIS.md](docs/BUNDLE_ANALYSIS.md).
+
 ## Sentry
 
 Sentry is wired through the client, server, and edge config files with separate environment variables for each runtime:
@@ -231,6 +235,7 @@ remitwise-frontend/
 │   └── auth.ts              # Auth middleware
 ├── docs/                    # Documentation
 │   ├── API_ROUTES.md        # API routes documentation
+│   ├── BUNDLE_ANALYSIS.md   # Next.js bundle analyzer guide
 │   ├── component-states.md  # Standard UI states (default, error, disabled, loading) guide
 │   ├── contract-cache.md    # Contract caching architecture and guidelines
 │   ├── frame-budget-rules.md    # Frame budget performance guidelines

--- a/docs/BUNDLE_ANALYSIS.md
+++ b/docs/BUNDLE_ANALYSIS.md
@@ -1,0 +1,126 @@
+# Bundle Analysis Guide
+
+**Audience:** Contributors (frontend developers)
+
+This document explains how to use the Next.js bundle analyzer to measure, inspect, and optimize the JavaScript bundle size of RemitWise. Maintaining a lean bundle directly impacts our per-route load-time budgets and page performance.
+
+---
+
+## Why Bundle Size Matters
+
+JavaScript is the most expensive resource we deliver to the client. Unlike images or stylesheets, JS must be downloaded, decompressed, parsed, compiled, and finally executed by the browser's main thread. 
+
+An oversized bundle leads to:
+- Higher **LCP (Largest Contentful Paint)** and **FCP (First Contentful Paint)** on slow mobile connections.
+- Poorer **INP (Interaction to Next Paint)** because the main thread is blocked by parsing heavy scripts.
+- Budget failures during our automated performance tests (`npm run test:perf`).
+
+For more details on per-route limits, see [docs/LOAD_TIME_BUDGETS.md](./LOAD_TIME_BUDGETS.md).
+
+---
+
+## Running the Bundle Analyzer
+
+The bundle analyzer is configured to run on top of our production build when the `ANALYZE` environment variable is set to `true`.
+
+### Execution Commands
+
+Depending on your shell, use one of the following commands to start the analysis build:
+
+#### macOS / Linux (bash/zsh)
+```bash
+ANALYZE=true npm run build
+```
+
+#### Windows (PowerShell)
+```powershell
+$env:ANALYZE="true"; npm run build
+```
+
+#### Windows (CMD)
+```cmd
+set ANALYZE=true && npm run build
+```
+
+---
+
+## Locating and Viewing the Reports
+
+When the build finishes, three interactive HTML visualization files are generated in the `.next/analyze/` directory:
+
+1. **`client.html`** - Displays the sizes of chunks sent to the client browser (most critical for user performance).
+2. **`server.html`** - Displays the sizes of chunks run on the Node.js server.
+3. **`edge.html`** - Displays the sizes of chunks run in Edge middleware environments (e.g., `middleware.ts`).
+
+To view a report, open it directly in any browser. For example:
+```bash
+# macOS
+open .next/analyze/client.html
+
+# Windows
+Start-Process .next/analyze/client.html
+```
+
+---
+
+## Interpreting the Treemap
+
+The generated report uses an interactive treemap where the area of each block represents its size relative to the bundle.
+
+### 1. Understanding Size Definitions
+Hovering over any block in the treemap displays three distinct size metrics:
+* **Stat size:** The raw input size of the file before Webpack has processed it (no minification or compression).
+* **Parsed size:** The actual size of the JavaScript code after bundling, minification, and tree-shaking. This is the amount of JS the browser has to parse and compile.
+* **Gzipped size:** The compressed size of the code sent over the wire. This dictates download speeds and network transmission times.
+
+> [!TIP]
+> Always focus on **Parsed size** for execution overhead/main-thread performance, and **Gzipped size** for download performance.
+
+### 2. Identifying Bottlenecks
+When reviewing `client.html`, look out for:
+* **Large third-party packages** in `node_modules` (e.g., `@stellar/stellar-sdk`, `lucide-react`, or `recharts`).
+* **Large application chunks** (e.g., `app/financial-insights/page.js` containing heavy charting configurations).
+* **Duplicate dependencies** (e.g., two different versions of the same library nested within other node modules).
+
+---
+
+## Remediation Strategies
+
+If your change increases a route chunk size or introduces a heavy library, use the following techniques to mitigate the impact:
+
+### 1. Dynamic Imports (`next/dynamic`)
+Do not bundle heavy components on initial load if they are not immediately visible. Use dynamic imports with `next/dynamic` to split them into separate chunks that load on-demand.
+
+**Example: Dynamically importing a charts library (like Recharts) on the insights page**
+```tsx
+import dynamic from 'next/dynamic';
+
+const DynamicChart = dynamic(() => import('@/components/analytics/FinancialChart'), {
+  ssr: false,
+  loading: () => <div className="h-64 animate-pulse bg-gray-100 rounded-lg" />,
+});
+
+export default function FinancialInsightsPage() {
+  return (
+    <div>
+      <h1>Financial Insights</h1>
+      <DynamicChart />
+    </div>
+  );
+}
+```
+
+### 2. Proper Tree Shaking
+Ensure imports are structured so that Webpack can drop unused code. For example, avoid importing the entire library if you only need one function or icon.
+
+**Example: Importing Lucide icons**
+```tsx
+// ❌ BAD: Destructuring from main package can pull in excess modules in some environments
+import { ArrowUpRight } from 'lucide-react';
+
+//  GOOD: Direct path imports guarantee tree-shaking
+import ArrowUpRight from 'lucide-react/dist/esm/icons/arrow-up-right';
+```
+
+### 3. Lightweight Alternatives
+If a library is too large, search for lighter alternatives. For example, use standard date-fns instead of moment, or write a lightweight custom SVG if you only need a single complex vector path.

--- a/docs/LOAD_TIME_BUDGETS.md
+++ b/docs/LOAD_TIME_BUDGETS.md
@@ -176,9 +176,9 @@ This executes `tests/e2e/dashboard-performance.spec.ts`. To add similar tests fo
 
 ### 2. Build-time bundle size check
 
-The `npm run build` step produces a production bundle. While there is no automated size-limit gate yet, contributors should review the build output for unexpected bundle size increases. If a route's JavaScript chunk grows by more than 10% after a change, investigate and optimise before merging.
+The `npm run build` step produces a production bundle. While there is no automated size-limit gate yet, contributors should review the build output for unexpected bundle size increases. If a route's JavaScript chunk grows by more than 10% after a change, investigate and optimise before merging. Use `@next/bundle-analyzer` to analyze and inspect chunk details (see the [Bundle Analysis Guide](./BUNDLE_ANALYSIS.md) for usage instructions).
 
-Future enhancement: integrate `size-limit` or `@next/bundle-analyzer` for automated bundle budget enforcement.
+Future enhancement: integrate `size-limit` or automate budget checks in CI.
 
 ### 3. Runtime monitoring (operators)
 
@@ -270,6 +270,7 @@ Register the new test in the `test:perf` script in `package.json`:
 
 | Document | Relevance |
 |----------|-----------|
+| [BUNDLE_ANALYSIS.md](./BUNDLE_ANALYSIS.md) | How to run and interpret bundle size analyses |
 | [frame-budget-rules.md](./frame-budget-rules.md) | Interactive handler budgets (scroll ≤ 16 ms, click ≤ 100 ms) |
 | [metrics-logging.md](./metrics-logging.md) | Structured JSON log format and `durationMs` field |
 | [infrastructure.md](./infrastructure.md) | Request gateway, rate limiting, and middleware flow |

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,7 @@
 const { withSentryConfig } = require("@sentry/nextjs");
+const withBundleAnalyzer = require("@next/bundle-analyzer")({
+  enabled: process.env.ANALYZE === "true",
+});
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -45,7 +48,9 @@ const sentryWebpackPluginOptions = {
   disableLogger: true,
 };
 
-module.exports = withSentryConfig(
-  { ...nextConfig, rewrites, redirects },
-  sentryWebpackPluginOptions
+module.exports = withBundleAnalyzer(
+  withSentryConfig(
+    { ...nextConfig, rewrites, redirects },
+    sentryWebpackPluginOptions
+  )
 );

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "start": "next start",
     "check:img-alt": "node scripts/check-img-alt.js",
     "lint": "eslint . && npm run check:img-alt",
-    "check:img-alt": "node scripts/check-img-alt.js",
     "test": "npm run test:unit",
     "test:coverage": "node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner --coverage",
     "test:watch": "node node_modules/vitest/vitest.mjs --config vitest.config.mjs --configLoader runner",
@@ -54,6 +53,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^16.2.11",
     "@playwright/test": "^1.58.2",
     "@storybook/addon-essentials": "^8.6.18",
     "@storybook/react": "^8.6.18",


### PR DESCRIPTION
PR #1113 Add docs/BUNDLE_ANALYSIS.md workflow doc


## Summary

Add a contributor-facing guide that documents how to run, interpret, and act on the Next.js bundle analyzer output. Bundle analysis knowledge was previously tribal; this makes it discoverable for new contributors and reviewers.

## What changed

| File | Change |
|------|--------|
| `docs/BUNDLE_ANALYSIS.md` | **New** — 126-line guide covering: audience (contributors), why bundle size matters, how to run the analyzer (macOS/Linux/Windows), report locations, treemap interpretation (stat/parsed/gzipped), bottleneck identification, and remediation strategies (dynamic imports, tree shaking, lightweight alternatives). |
| `README.md` | Added "Bundle Analysis" section linking to the new doc + project structure tree entry. |
| `next.config.js` | Wired `@next/bundle-analyzer` via `withBundleAnalyzer()`, gated behind `ANALYZE=true` env var. |
| `docs/LOAD_TIME_BUDGETS.md` | Updated "Build-time bundle size check" section to reference the new guide; added cross-link to the related-documents table; updated future enhancement note. |
| `package.json` | Added `@next/bundle-analyzer: ^16.2.11` as devDependency; removed duplicate `check:img-alt` script entry. |

## How to verify

1. **Run the analyzer locally:**
   ```bash
   # macOS/Linux
   ANALYZE=true npm run build

   # Windows PowerShell
   $env:ANALYZE="true"; npm run build
   ```
   Confirm three HTML reports appear in `.next/analyze/`: `client.html`, `server.html`, `edge.html`.

2. **Open `client.html` in a browser** and verify the interactive treemap loads with stat/parsed/gzipped size tooltips.

3. **Lint passes** — `npm run lint` is clean (pre-existing errors in unrelated files are unchanged).

4. **Unit tests pass** — `npm run test:unit` passes all 102 tests (26 node + 76 vitest).

## Implementation notes

- The analyzer is **local-only** — no CI step added. This matches the current workflow where bundle review is a manual contributor responsibility.
- `ANALYZE=true` is the only env gate; no additional config files or GitHub Actions changes needed.
- The `next.config.js` change wraps the existing `withSentryConfig()` call — order is `withBundleAnalyzer(withSentryConfig(...))` which is the recommended composition pattern.
- Fixed a pre-existing duplicate `check:img-alt` script entry in `package.json` (line 14 was a duplicate of line 12).

## Out of scope (follow-up issues)

- CI integration for automated bundle size budgets (noted as future enhancement in `LOAD_TIME_BUDGETS.md`).
- An `npm run analyze` convenience script wrapping `ANALYZE=true npm run build`.

Closes #1113 