### PR TITLE
feat: add /api/session/refresh handler in the app router

### DIFF
--- a/app/api/session/refresh/route.ts
+++ b/app/api/session/refresh/route.ts
@@ -1,0 +1,23 @@
+import { getSessionWithRefresh, clearSessionCookie } from '@/lib/session';
+import { jsonSuccess, jsonError } from '@/lib/api/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST() {
+  const session = await getSessionWithRefresh();
+
+  if (!session?.address) {
+    return Response.json(
+      { error: 'Unauthorized', message: 'Session expired' },
+      {
+        status: 401,
+        headers: { 'Set-Cookie': clearSessionCookie() },
+      }
+    );
+  }
+
+  return jsonSuccess({
+    address: session.address,
+    expiresAt: session.expiresAt,
+  });
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -45,6 +45,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthStatus'
+  /session/refresh:
+    post:
+      summary: Refresh session
+      tags:
+        - Session
+      description: |
+        Extends the current session expiry using a sliding-window mechanism
+        when SESSION_REFRESH_ENABLED is true. Returns the authenticated
+        user's address and new expiry timestamp. Returns 401 if the session
+        is missing, invalid, or expired.
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          description: Session refreshed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionRefreshResponse'
+        '401':
+          description: Session expired or missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
   /remittance/quote:
     get:
       summary: Get Remittance Quote
@@ -825,6 +850,23 @@ components:
         coverageAmount:
           type: number
           example: 100000
+    SessionRefreshResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          type: object
+          properties:
+            address:
+              type: string
+              description: Stellar wallet public key of the authenticated user
+              example: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+            expiresAt:
+              type: number
+              description: Session expiry timestamp in milliseconds since epoch
+              example: 1700000000000
     WebhookDlqResponse:
       type: object
       properties:

--- a/tests/session/session-refresh-api.test.ts
+++ b/tests/session/session-refresh-api.test.ts
@@ -1,0 +1,105 @@
+// @ts-nocheck
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { cookies as cookiesImport } from 'next/headers';
+import { POST as postSessionRefresh } from '../../app/api/session/refresh/route';
+import { createSession } from '../../lib/session';
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}));
+
+const cookies = vi.mocked(cookiesImport) as unknown as ReturnType<typeof vi.fn>;
+
+describe('POST /api/session/refresh', () => {
+  const testAddress = 'GDEMOXABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890XXXX';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.SESSION_PASSWORD = 'test-password-at-least-32-characters-long';
+    process.env.SESSION_MAX_AGE = '604800';
+    delete process.env.SESSION_REFRESH_ENABLED;
+  });
+
+  it('should return 200 with address and expiresAt for a valid session', async () => {
+    const { sealed } = await createSession(testAddress);
+
+    cookies.mockResolvedValue({
+      get: vi.fn().mockReturnValue({ value: sealed }),
+      set: vi.fn(),
+    });
+
+    const response = await postSessionRefresh();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.address).toBe(testAddress);
+    expect(data.data.expiresAt).toBeDefined();
+    expect(typeof data.data.expiresAt).toBe('number');
+  });
+
+  it('should return 401 with Session expired message when no session cookie exists', async () => {
+    cookies.mockResolvedValue({
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+    });
+
+    const response = await postSessionRefresh();
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe('Unauthorized');
+    expect(data.message).toBe('Session expired');
+  });
+
+  it('should return 401 for an expired session', async () => {
+    const now = Date.now();
+    const { sealData } = require('iron-session');
+    const expiredSession = {
+      address: testAddress,
+      createdAt: now - 8 * 24 * 60 * 60 * 1000,
+      expiresAt: now - 24 * 60 * 60 * 1000,
+    };
+
+    const sealed = await sealData(expiredSession, {
+      password: process.env.SESSION_PASSWORD!,
+      ttl: 604800,
+    });
+
+    cookies.mockResolvedValue({
+      get: vi.fn().mockReturnValue({ value: sealed }),
+      set: vi.fn(),
+    });
+
+    const response = await postSessionRefresh();
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe('Unauthorized');
+    expect(data.message).toBe('Session expired');
+
+    const setCookieHeader = response.headers.get('Set-Cookie');
+    expect(setCookieHeader).toContain('Max-Age=0');
+  });
+
+  it('should extend expiresAt when SESSION_REFRESH_ENABLED is true', async () => {
+    process.env.SESSION_REFRESH_ENABLED = 'true';
+
+    const { sealed } = await createSession(testAddress);
+
+    const mockSet = vi.fn();
+    cookies.mockResolvedValue({
+      get: vi.fn().mockReturnValue({ value: sealed }),
+      set: mockSet,
+    });
+
+    const response = await postSessionRefresh();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.address).toBe(testAddress);
+    expect(data.data.expiresAt).toBeGreaterThan(Date.now());
+    expect(mockSet).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1233

## Summary
Add a POST `/api/session/refresh` endpoint in the Next.js app router that extends the current session using the existing sliding-window mechanism.

## Changes
- **New route**: `app/api/session/refresh/route.ts` — POST handler using `getSessionWithRefresh()` from `lib/session.ts`
- **OpenAPI spec**: Added `/session/refresh` path and `SessionRefreshResponse` schema to `openapi.yaml`
- **Tests**: `tests/session/session-refresh-api.test.ts` — 4 tests covering:
  - Happy path: valid session returns 200 with `address` and `expiresAt`
  - Missing session cookie returns 401 with `Session expired` message
  - Expired session returns 401 with `Set-Cookie` clear header
  - Sliding-window refresh extends `expiresAt` when `SESSION_REFRESH_ENABLED=true`

## Design decisions
- Uses `jsonSuccess()` from `lib/api/types.ts` for the 200 response to follow the structured response pattern
- 401 response matches the existing `/api/auth/refresh` format (`{ error, message }`) for backward compatibility with client-side session expiry detection (`sessionHandler.isSessionExpired()`)
- Includes `clearSessionCookie()` on 401 for proper cookie cleanup (consistent with other protected routes)
- Additive-only: does not modify any existing routes or files beyond the OpenAPI spec

## Acceptance criteria
- [x] Change matches the issue summary
- [x] Tests cover happy path + explicit failure mode (missing cookie, expired session)
- [x] Lint passes (no new warnings — pre-existing errors only)
- [x] PR references this issue with Closes #1233