### PR TITLE
feat: add LiveRegion component for centralized aria-live semantics

### DIFF
--- a/components/AsyncSubmissionStatus.tsx
+++ b/components/AsyncSubmissionStatus.tsx
@@ -2,116 +2,113 @@
 
 import { AlertCircle, CheckCircle2, Clock3, Loader2 } from "lucide-react";
 import { useAsyncOperations } from "@/lib/context/AsyncOperationsContext";
+import LiveRegion from "@/components/ui/LiveRegion";
 
 interface AsyncSubmissionStatusProps {
-	pending?: boolean; // Made optional
-	error?: string;
-	success?: string;
-	idleTitle: string;
-	idleDescription: string;
-	pendingTitle: string;
-	pendingDescription: string;
-	successTitle?: string;
-	successDescription?: string;
-	errorTitle?: string;
+        pending?: boolean; // Made optional
+        error?: string;
+        success?: string;
+        idleTitle: string;
+        idleDescription: string;
+        pendingTitle: string;
+        pendingDescription: string;
+        successTitle?: string;
+        successDescription?: string;
+        errorTitle?: string;
 }
 
 const statusStyles = {
-	idle: {
-		Icon: Clock3,
-		cardClass: "border-white/[0.08] bg-black/20",
-		iconClass: "text-gray-300",
-		label: "Ready",
-		spin: false,
-	},
-	pending: {
-		Icon: Loader2,
-		cardClass:
-			"border-red-500/20 bg-[linear-gradient(180deg,rgba(127,29,29,0.18),rgba(16,16,16,0.96))]",
-		iconClass: "text-red-200",
-		label: "In progress",
-		spin: true,
-	},
-	success: {
-		Icon: CheckCircle2,
-		cardClass: "border-emerald-500/20 bg-emerald-500/[0.08]",
-		iconClass: "text-emerald-300",
-		label: "Complete",
-		spin: false,
-	},
-	error: {
-		Icon: AlertCircle,
-		cardClass: "border-amber-500/20 bg-amber-500/[0.08]",
-		iconClass: "text-amber-200",
-		label: "Needs attention",
-		spin: false,
-	},
+        idle: {
+                Icon: Clock3,
+                cardClass: "border-white/[0.08] bg-black/20",
+                iconClass: "text-gray-300",
+                label: "Ready",
+                spin: false,
+        },
+        pending: {
+                Icon: Loader2,
+                cardClass:
+                        "border-red-500/20 bg-[linear-gradient(180deg,rgba(127,29,29,0.18),rgba(16,16,16,0.96))]",
+                iconClass: "text-red-200",
+                label: "In progress",
+                spin: true,
+        },
+        success: {
+                Icon: CheckCircle2,
+                cardClass: "border-emerald-500/20 bg-emerald-500/[0.08]",
+                iconClass: "text-emerald-300",
+                label: "Complete",
+                spin: false,
+        },
+        error: {
+                Icon: AlertCircle,
+                cardClass: "border-amber-500/20 bg-amber-500/[0.08]",
+                iconClass: "text-amber-200",
+                label: "Needs attention",
+                spin: false,
+        },
 } as const;
 
 export default function AsyncSubmissionStatus({
-	pending: propPending,
-	error,
-	success,
-	idleTitle,
-	idleDescription,
-	pendingTitle,
-	pendingDescription,
-	successTitle,
-	successDescription,
-	errorTitle,
+        pending: propPending,
+        error,
+        success,
+        idleTitle,
+        idleDescription,
+        pendingTitle,
+        pendingDescription,
+        successTitle,
+        successDescription,
+        errorTitle,
 }: AsyncSubmissionStatusProps) {
-	const { state } = useAsyncOperations();
-	
-	// Pending if an operation is active
-	const isActive = state.operations.some(op => op.status !== 'confirmed' && op.status !== 'failed');
-	const pending = propPending ?? isActive;
+        const { state } = useAsyncOperations();
 
-	const status = error ? "error" : success ? "success" : pending ? "pending" : "idle";
-	const style = statusStyles[status];
-	const Icon = style.Icon;
+        // Pending if an operation is active
+        const isActive = state.operations.some(op => op.status !== 'confirmed' && op.status !== 'failed');
+        const pending = propPending ?? isActive;
 
-	const title =
-		status === "error"
-			? errorTitle ?? "Submission needs attention"
-			: status === "success"
-				? successTitle ?? "Contract request is ready"
-				: status === "pending"
-					? pendingTitle
-					: idleTitle;
+        const status = error ? "error" : success ? "success" : pending ? "pending" : "idle";
+        const style = statusStyles[status];
+        const Icon = style.Icon;
 
-	const description =
-		status === "error"
-			? error
-			: status === "success"
-				? successDescription ?? success
-				: status === "pending"
-					? pendingDescription
-					: idleDescription;
+        const title =
+                status === "error"
+                        ? errorTitle ?? "Submission needs attention"
+                        : status === "success"
+                                ? successTitle ?? "Contract request is ready"
+                                : status === "pending"
+                                        ? pendingTitle
+                                        : idleTitle;
 
-	return (
-		<div
-			role='status'
-			aria-atomic='true'
-			aria-live='polite'
-			className={`rounded-2xl border p-4 ${style.cardClass}`}>
-			<div className='flex items-start gap-3'>
-				<div className='flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.04]'>
-					<Icon
-						className={`h-4 w-4 ${style.iconClass} ${
-							style.spin ? "animate-spin" : ""
-						}`}
-					/>
-				</div>
-				<div className='min-w-0'>
-					<div className='flex flex-wrap items-center gap-2'>
-						<h3 className='text-sm font-semibold text-white'>{title}</h3>
-						<span className='rounded-full border border-white/10 bg-white/[0.03] px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.18em] text-gray-400'>
-							{style.label}
-						</span>
-					</div>
-					<p className='mt-2 text-sm leading-6 text-gray-300'>{description}</p>
-				</div>
-			</div>
-		</div>
-	);
+        const description =
+                status === "error"
+                        ? error
+                        : status === "success"
+                                ? successDescription ?? success
+                                : status === "pending"
+                                        ? pendingDescription
+                                        : idleDescription;
+
+        return (
+                <LiveRegion className={`rounded-2xl border p-4 ${style.cardClass}`}>
+                        <div className='flex items-start gap-3'>
+                                <div className='flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.04]'>
+                                        <Icon
+                                                className={`h-4 w-4 ${style.iconClass} ${
+                                                        style.spin ? "animate-spin" : ""
+                                                }`}
+                                        />
+                                </div>
+                                <div className='min-w-0'>
+                                        <div className='flex flex-wrap items-center gap-2'>
+                                                <h3 className='text-sm font-semibold text-white'>{title}</h3>
+                                                <span className='rounded-full border border-white/10 bg-white/[0.03] px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.18em] text-gray-400'>
+                                                        {style.label}
+                                                </span>
+                                        </div>
+                                        <p className='mt-2 text-sm leading-6 text-gray-300'>{description}</p>
+                                </div>
+                        </div>
+                </LiveRegion>
+        );
 }

--- a/components/ui/LiveRegion.tsx
+++ b/components/ui/LiveRegion.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+export type LiveRegionPoliteness = "polite" | "assertive";
+
+export interface LiveRegionProps {
+  /**
+   * ARIA live-region politeness.
+   * "polite" (default) waits for the screen reader to finish its current
+   * announcement before reading this update — use for routine status
+   * changes (idle/pending/success).
+   * "assertive" interrupts immediately — reserve for urgent, blocking
+   * conditions the user must know about right away.
+   */
+  politeness?: LiveRegionPoliteness;
+  /**
+   * When true (default), the entire region is re-announced as a unit on
+   * any change, rather than only the specific node that changed. This is
+   * almost always what you want for a status message — omitting it is a
+   * common source of incomplete announcements.
+   */
+  atomic?: boolean;
+  /**
+   * When true, the region is visually hidden (sr-only) but remains in the
+   * accessibility tree — use for announcements that don't need a visible
+   * persistent UI element (e.g. "3 results loaded").
+   * When false (default), the region renders normally and callers are
+   * responsible for its visible presentation.
+   */
+  visuallyHidden?: boolean;
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * LiveRegion
+ *
+ * Central primitive for wrapping ARIA live-region semantics. Ensures
+ * `role`, `aria-live`, and `aria-atomic` are always set together and
+ * consistently, rather than each consumer hand-rolling its own subset
+ * of these attributes (a pattern that previously led to inconsistent —
+ * and in some cases missing — `aria-atomic` across the codebase).
+ *
+ * `role="status"` (polite) or `role="alert"` (assertive) is derived from
+ * `politeness` — matching the app's existing convention in `Notice.tsx`.
+ */
+export default function LiveRegion({
+  politeness = "polite",
+  atomic = true,
+  visuallyHidden = false,
+  className = "",
+  children,
+}: LiveRegionProps) {
+  const role = politeness === "assertive" ? "alert" : "status";
+
+  return (
+    <div
+      role={role}
+      aria-live={politeness}
+      aria-atomic={atomic}
+      className={visuallyHidden ? `sr-only ${className}`.trim() : className}
+    >
+      {children}
+    </div>
+  );
+}

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -445,3 +445,63 @@ Applied to:
 4. **Focus-based:** Shows on both hover and focus to ensure keyboard users discover shortcuts without needing to read documentation.
 
 5. **Escape dismissal:** Allows keyboard users to close tooltips without moving focus away from the trigger.
+
+---
+
+## LiveRegion
+
+Central primitive for wrapping ARIA live-region semantics (`role`, `aria-live`,
+`aria-atomic`). Use as the base for any component that announces status
+changes to assistive technology, instead of hand-rolling these three
+attributes — a pattern that previously led to inconsistent (and in places
+missing) `aria-atomic` across the codebase.
+
+**File:** `components/ui/LiveRegion.tsx`
+
+### Props
+
+| Prop | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `politeness` | `"polite" \| "assertive"` | — | `"polite"` | Maps to `role="status"`/`aria-live="polite"` or `role="alert"`/`aria-live="assertive"`. |
+| `atomic` | `boolean` | — | `true` | Sets `aria-atomic`. Keep `true` unless you have a specific reason to announce only the changed sub-node. |
+| `visuallyHidden` | `boolean` | — | `false` | When `true`, applies `sr-only` — use for announcements with no persistent visible UI. |
+| `className` | `string` | — | `""` | Extra classes on the wrapper. |
+| `children` | `React.ReactNode` | ✓ | — | Content to announce. |
+
+### Accessibility
+
+- `role` is derived from `politeness`: `"status"` (polite) or `"alert"` (assertive) — matching the convention already used in `Notice.tsx`.
+- `aria-atomic` defaults to `true` so the full region is announced as a unit on any change.
+- Does not manage focus — assertive announcements do not steal focus; use a modal/dialog pattern separately if the situation requires interrupting the user's task.
+
+### Usage examples
+
+```tsx
+import LiveRegion from "@/components/ui/LiveRegion";
+
+// Visible status card (polite, atomic — the defaults)
+<LiveRegion className="rounded-2xl border p-4">
+  <p>Transfer submitted.</p>
+</LiveRegion>
+
+// Urgent, interrupting announcement
+<LiveRegion politeness="assertive">
+  <p>Connection lost. Retrying…</p>
+</LiveRegion>
+
+// Invisible announcer (no persistent visible element)
+<LiveRegion visuallyHidden>
+  {resultCount} results loaded.
+</LiveRegion>
+```
+
+### Integration
+
+Import directly — no context provider required.
+
+```tsx
+import LiveRegion from "@/components/ui/LiveRegion";
+```
+
+`components/AsyncSubmissionStatus.tsx` uses this internally as its live-region
+wrapper as of #1149.

--- a/tests/e2e/live-region-a11y.spec.ts
+++ b/tests/e2e/live-region-a11y.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+// ---------------------------------------------------------------------------
+// AsyncSubmissionStatus / LiveRegion — zero-violation axe scan on /split,
+// covering idle, error, and success states.
+// ---------------------------------------------------------------------------
+
+test.describe("LiveRegion (via AsyncSubmissionStatus) on /split", () => {
+  test("idle state has zero axe violations", async ({ page }) => {
+    await page.goto("/split");
+    await page.locator('[role="status"]').first().waitFor({ state: "visible" });
+
+    const results = await new AxeBuilder({ page }).include("main").analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("error state has zero axe violations and is announced via role=status", async ({ page }) => {
+    await page.goto("/split");
+
+    // Push Daily Spending to 60 so the total exceeds 100%, triggering the
+    // validation error branch of AsyncSubmissionStatus.
+    await page.getByLabel("Daily Spending percentage").fill("60");
+
+    const statusRegion = page.locator('[role="status"]').last();
+    await expect(statusRegion).toHaveAttribute("aria-live", "polite");
+    await expect(statusRegion).toHaveAttribute("aria-atomic", "true");
+
+    const results = await new AxeBuilder({ page }).include("main").analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("success state has zero axe violations", async ({ page }) => {
+    await page.goto("/split");
+
+    // Default allocation already sums to 100% (DEFAULT_SPLIT_CONFIG) — submit
+    // directly to trigger the success branch.
+    await page.getByRole("form", { name: "Smart money split configuration" })
+      .getByRole("button", { name: /save allocation/i })
+      .click();
+
+    await page.locator('[role="status"]').last().getByText(/configuration saved/i).waitFor();
+
+    const results = await new AxeBuilder({ page }).include("main").analyze();
+    expect(results.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Closes #1149

### Summary
Adds `components/ui/LiveRegion.tsx`, a shared primitive that wraps `role`, `aria-live`, and `aria-atomic` consistently, so status-announcing components no longer each hand-roll their own subset of these attributes. Auditing the codebase turned up ~20 independent `aria-live` implementations; of the ones inspected closely, two (`NetworkStatusIndicator`, `StaleBanner` — both currently dead/unrendered code) were missing `aria-atomic`, which can cause screen readers to announce only a changed sub-node instead of the full status message.

`AsyncSubmissionStatus.tsx` is migrated to use `LiveRegion` internally as the demonstrated example — it was already correctly implemented (`aria-atomic="true"` present), so this migration is a pure refactor with no behavior change.

### Visible/API changes
- New component: `components/ui/LiveRegion.tsx`, documented in `docs/COMPONENTS.md`.
- No changes to `AsyncSubmissionStatus`'s public props or rendered output.

### Testing
- `components/AsyncSubmissionStatus.test.tsx` — all 20 existing tests pass unmodified, including the dedicated live-region-semantics check and a full `jest-axe` scan across all 4 states.
- `npx tsc --noEmit` — clean for all files touched by this PR.
- New: `tests/e2e/live-region-a11y.spec.ts` — written and reviewed, follows the existing `nav-a11y.spec.ts` convention, targets `/split` across idle/error/success states of `AsyncSubmissionStatus`.
- **Could not be executed locally**: all Playwright e2e specs are currently blocked in this environment by a pre-existing, unrelated crash — `No QueryClient set, use QueryClientProvider to set one` in `ConnectionQualityIndicator` (`lib/hooks/useSwrQuery.ts:22`). Confirmed pre-existing by running the repo's existing `tests/e2e/nav-a11y.spec.ts` against `main`, which hits the identical failure. Requesting a maintainer or CI run to confirm the Axe report is clean, since CI's environment may not have this issue.

### Keyboard-only walkthrough (described, on `/split`)
1. Tab from page load through: nav → **Daily Spending** input → **Savings** → **Bills** → **Insurance** → (Total display — not focusable, correctly so, it's a live readout) → **Save Allocation** → **How it works** → **Cancel**.
2. Each `SplitInput` is a native `<input type="number">` with a real `<label>` — fully keyboard-operable (type or arrow keys), no custom widget code.
3. Adjusting values to an invalid total (≠100%) updates the Total block's validation message and `AsyncSubmissionStatus`'s idle copy without requiring a focus change, via `aria-live="polite"` on both regions.
4. Restoring a valid total and activating **Save Allocation** via keyboard triggers pending → success announcements without unexpected focus loss.

### Flagging for maintainer awareness (not fixed here, out of scope)
- **Local Playwright e2e is broken repo-wide** (see Testing section above) — a `QueryClientProvider` appears to be missing somewhere in the tree that `ConnectionQualityIndicator` depends on. Affects all e2e specs, not just this PR's. Worth a dedicated fix.
- `NetworkStatusIndicator` and `StaleBanner` are both imported but never rendered anywhere in the app (dead code), found while investigating this ticket. Both were also missing `aria-atomic`. Worth a cleanup/removal ticket.
- `WrongNetworkBanner` (live, rendered on every `/dashboard/*` route) claims in its own doc comment to block "all nav actions" via its overlay while visible, but there's no keyboard focus trap — a keyboard user can Tab past it into the nav underneath. Real gap, but focus-management rather than `aria-live`, so out of scope here.
- The "Total" validation block on `/split` has its own separate, correctly-implemented `aria-live`/`aria-atomic` pair, independent of `AsyncSubmissionStatus`. Left as-is per scope — a natural next migration target.
- `docs/toast-pattern.md` states the toast system "replaces `SessionExpiryNotification`," but that component is still actively rendered via `SessionExpiryProvider.tsx`. Appears to be an incomplete migration, unrelated to this ticket.
- `npm run lint` fails locally — `eslint` isn't installed in `node_modules` despite being referenced in the `lint` script. Pre-existing, unrelated.