### PR TITLE
fix: improve mobile navigation accessibility

### DIFF
--- a/components/Nav/MobileNav.test.tsx
+++ b/components/Nav/MobileNav.test.tsx
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import MobileNav from './MobileNav';
+
+expect.extend(toHaveNoViolations);
 
 // Mock next/navigation
 vi.mock('next/navigation', () => ({
@@ -33,6 +36,14 @@ describe('MobileNav', () => {
     const toggleButton = screen.getByRole('button', { name: /open mobile menu/i });
     expect(toggleButton).toBeInTheDocument();
     expect(toggleButton).toHaveAttribute('aria-label', 'Open Mobile Menu');
+  });
+
+  it('has no axe violations when the menu is open', async () => {
+    const { container } = render(<MobileNav />);
+    fireEvent.click(screen.getByRole('button', { name: /open mobile menu/i }));
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 
   it('opens menu on toggle click and closes on X button', () => {
@@ -107,13 +118,23 @@ describe('MobileNav', () => {
     expect(screen.queryByText('Menu')).not.toBeInTheDocument();
   });
 
-  it('closes menu on ESC key', () => {
+  it('exposes dialog semantics and labels the close control for assistive tech', () => {
     render(<MobileNav />);
     fireEvent.click(screen.getByRole('button', { name: /open mobile menu/i }));
-    expect(screen.getByText('Menu')).toBeInTheDocument();
 
+    const dialog = screen.getByRole('dialog', { name: /mobile navigation/i });
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /close mobile menu/i })).toBeInTheDocument();
+  });
+
+  it('restores focus to the toggle button when the menu closes with Escape', () => {
+    render(<MobileNav />);
+    const toggleButton = screen.getByRole('button', { name: /open mobile menu/i });
+    toggleButton.focus();
+
+    fireEvent.click(toggleButton);
     fireEvent.keyDown(document, { key: 'Escape' });
-    // Note: Current MobileNav doesn't implement ESC close; this test documents expected behavior
-    // If implementing ESC handling, this would pass
+
+    expect(toggleButton).toHaveFocus();
   });
 });

--- a/components/Nav/MobileNav.tsx
+++ b/components/Nav/MobileNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { 
     Menu, X, Home, 
     Send, LayoutDashboard, FileText, 
@@ -16,6 +16,8 @@ import ShortcutTooltip from "@/components/ui/ShortcutTooltip";
 const MobileNav = () => {
     const [isOpen, setIsOpen] = useState(false);
     const pathname = usePathname();
+    const dialogRef = useRef<HTMLDivElement | null>(null);
+    const lastFocusedElementRef = useRef<HTMLElement | null>(null);
 
     const sections = [
         {
@@ -53,18 +55,37 @@ const MobileNav = () => {
     ];
 
     useEffect(() => {
-  const handleEsc = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') setIsOpen(false);
-  };
-  if (isOpen) {
-    document.addEventListener('keydown', handleEsc);
-    document.body.style.overflow = 'hidden'; // Prevent background scroll
-  }
-  return () => {
-    document.removeEventListener('keydown', handleEsc);
-    document.body.style.overflow = '';
-  };
-}, [isOpen]);
+        if (!isOpen) return;
+
+        lastFocusedElementRef.current = document.activeElement instanceof HTMLElement
+            ? document.activeElement
+            : null;
+
+        const handleEsc = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                setIsOpen(false);
+            }
+        };
+
+        const handleFocusTrap = (event: FocusEvent) => {
+            if (!dialogRef.current?.contains(event.target as Node)) {
+                event.preventDefault();
+                dialogRef.current?.focus();
+            }
+        };
+
+        document.addEventListener('keydown', handleEsc);
+        document.addEventListener('focusin', handleFocusTrap);
+        document.body.style.overflow = 'hidden';
+
+        return () => {
+            document.removeEventListener('keydown', handleEsc);
+            document.removeEventListener('focusin', handleFocusTrap);
+            document.body.style.overflow = '';
+            lastFocusedElementRef.current?.focus();
+        };
+    }, [isOpen]);
 
     const isActive = (href: string) => {
         if (href === "/" || href === "/dashboard") return pathname === href;
@@ -76,13 +97,45 @@ const MobileNav = () => {
         await logout();
     };
 
+    const handleClose = () => {
+        setIsOpen(false);
+    };
+
+    const handleDialogKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'Tab') {
+            const focusableElements = dialogRef.current?.querySelectorAll<HTMLElement>(
+                'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+            );
+
+            if (!focusableElements || focusableElements.length === 0) {
+                event.preventDefault();
+                return;
+            }
+
+            const firstElement = focusableElements[0];
+            const lastElement = focusableElements[focusableElements.length - 1];
+
+            if (event.shiftKey && document.activeElement === firstElement) {
+                event.preventDefault();
+                lastElement.focus();
+            } else if (!event.shiftKey && document.activeElement === lastElement) {
+                event.preventDefault();
+                firstElement.focus();
+            }
+        }
+    };
+
     return (
         <div className="lg:hidden">
             <ShortcutTooltip label="Open Mobile Menu" shortcut="Esc" side="left">
               <button
+                  type="button"
                   onClick={() => setIsOpen(true)}
                   className="p-2 sm:p-2.5 rounded-xl bg-white/5 border border-white/5 hover:bg-white/10 transition-colors"
                   aria-label="Open Mobile Menu"
+                  aria-expanded={isOpen}
+                  aria-controls="mobile-navigation-dialog"
+                  aria-haspopup="dialog"
               >
                   <Menu className="w-5 h-5 text-white/80" />
               </button>
@@ -90,22 +143,33 @@ const MobileNav = () => {
 
             {/* Menu Overlay */}
             {isOpen && (
-                <div className="fixed inset-0 z-[100] bg-brand-dark overflow-y-auto stars-bg flex flex-col">
+                <div
+                    id="mobile-navigation-dialog"
+                    className="fixed inset-0 z-[100] bg-brand-dark overflow-y-auto stars-bg flex flex-col"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label="Mobile navigation"
+                    ref={dialogRef}
+                    tabIndex={-1}
+                    onKeyDown={handleDialogKeyDown}
+                >
                     {/* Header */}
                     <div className="flex items-center justify-between p-4 sm:p-6 border-b border-white/5">
                         <div className="flex items-center gap-3">
                             <span className="text-xl font-bold text-white tracking-tight">Menu</span>
                         </div>
                         <button
-                            onClick={() => setIsOpen(false)}
+                            type="button"
+                            onClick={handleClose}
                             className="p-2 sm:p-2.5 rounded-xl bg-white/5 border border-white/5 hover:bg-white/10 transition-colors"
+                            aria-label="Close Mobile Menu"
                         >
                             <X className="w-5 h-5 text-white/80" />
                         </button>
                     </div>
 
                     {/* Links */}
-                    <nav aria-label="Mobile navigation" className="flex-1 p-4 sm:p-6 space-y-8 pb-24">
+                    <nav aria-label="Mobile navigation links" className="flex-1 p-4 sm:p-6 space-y-8 pb-24">
                         {sections.map((section, idx) => (
                             <div key={idx} className="space-y-4">
                                 <h3 className="text-xs font-bold text-white/70 uppercase tracking-[0.2rem] px-2">
@@ -117,7 +181,7 @@ const MobileNav = () => {
                                             <Link
                                                 href={link.href}
                                                 aria-current={isActive(link.href) ? "page" : undefined}
-                                                onClick={() => setIsOpen(false)}
+                                                onClick={handleClose}
                                                 className={`flex items-center justify-between p-4 rounded-2xl transition-all group overflow-hidden relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red/50
                                                     ${isActive(link.href)
                                                         ? "bg-brand-red/10 border border-brand-red/20 shadow-[0_0_20px_rgba(215,35,35,0.1)]"


### PR DESCRIPTION
## Summary

Fixes the mobile navigation accessibility issues by making the menu behave like a proper dialog for assistive technology and keyboard users.

## What changed
- Added dialog semantics with , , and an accessible label to the mobile navigation overlay.
- Added explicit close-button labeling and button state relationships so screen readers can identify the controls.
- Implemented Escape-to-close behavior and focus restoration so keyboard users can dismiss the menu cleanly.
- Added regression tests covering keyboard and assistive-technology expectations, including axe assertions.

## Verification
- 
 RUN  v4.1.9 /workspaces/Remitwise-Frontend


 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  12:23:29
   Duration  2.27s (transform 214ms, setup 150ms, import 342ms, tests 791ms, environment 764ms)
- 
- 
> remitwise-frontend@0.1.0 prebuild
> npm run generate:types


> remitwise-frontend@0.1.0 generate:types
> openapi-typescript ./openapi.yaml --output ./src/api/types.ts

✨ openapi-typescript 6.7.6
🚀 ./openapi.yaml → file:///workspaces/Remitwise-Frontend/src/api/types.ts [32ms]

> remitwise-frontend@0.1.0 build
> next build --webpack

▲ Next.js 16.2.9 (webpack)
- Experiments (use with caution):
  · clientTraceMetadata

  Creating an optimized production build ...
[@sentry/nextjs] It seems like you don't have a global error handler set up. It is recommended that you add a 'global-error.js' file with Sentry instrumentation so that React rendering errors are reported to Sentry. Read more: https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#react-render-errors-in-app-router (you can suppress this warning by setting SENTRY_SUPPRESS_GLOBAL_ERROR_HANDLER_FILE_WARNING=1 as environment variable)

## Notes
- Keyboard walkthrough: open the menu with the toggle button, tab through the links, use Escape to close, and confirm focus returns to the trigger.
- Axe scan: the mobile navigation now passes the added regression checks for zero violations.

Closes #1172
Closes #1166
Closes #1165
Closes #1156