### PR TITLE
feat:implement-dynamic-heading-levels

### DIFF
--- a/components/ui/Heading.tsx
+++ b/components/ui/Heading.tsx
@@ -1,0 +1,14 @@
+import React, { useContext } from 'react';
+import { HeadingLevelContext } from './HeadingLevelContext';
+
+export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
+}
+
+export const Heading: React.FC<HeadingProps> = ({ level, children, ...props }) => {
+  const currentLevel = useContext(HeadingLevelContext);
+  const resolvedLevel = level ?? currentLevel;
+  const Component = `h${Math.min(Math.max(resolvedLevel, 1), 6)}` as keyof React.JSX.IntrinsicElements;
+
+  return <Component {...props}>{children}</Component>;
+};

--- a/components/ui/HeadingLevelContext.ts
+++ b/components/ui/HeadingLevelContext.ts
@@ -1,0 +1,3 @@
+import React, { createContext } from 'react';
+
+export const HeadingLevelContext = createContext<number>(1);

--- a/components/ui/Section.tsx
+++ b/components/ui/Section.tsx
@@ -1,0 +1,20 @@
+import React, { useContext } from 'react';
+import { HeadingLevelContext } from './HeadingLevelContext';
+
+export interface SectionProps extends React.HTMLAttributes<HTMLElement> {
+  as?: keyof React.JSX.IntrinsicElements;
+  level?: number;
+}
+
+export const Section: React.FC<SectionProps> = ({ as: Component = 'section', level, children, ...props }) => {
+  const currentLevel = useContext(HeadingLevelContext);
+  const nextLevel = level ?? Math.min(currentLevel + 1, 6);
+
+  return (
+    <HeadingLevelContext.Provider value={nextLevel}>
+      <Component {...props}>
+        {children}
+      </Component>
+    </HeadingLevelContext.Provider>
+  );
+};

--- a/tests/unit/components/Heading.test.tsx
+++ b/tests/unit/components/Heading.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Section } from '../../../components/ui/Section';
+import { Heading } from '../../../components/ui/Heading';
+import '@testing-library/jest-dom';
+
+describe('Heading and Section', () => {
+  it('defaults to h1', () => {
+    render(<Heading>Test Heading</Heading>);
+    const heading = screen.getByRole('heading', { name: 'Test Heading' });
+    expect(heading.tagName.toLowerCase()).toBe('h1');
+  });
+
+  it('increments to h2 when nested in a single Section', () => {
+    render(
+      <Section>
+        <Heading>Test Heading</Heading>
+      </Section>
+    );
+    const heading = screen.getByRole('heading', { name: 'Test Heading' });
+    expect(heading.tagName.toLowerCase()).toBe('h2');
+  });
+
+  it('increments correctly with multiple nested Sections', () => {
+    render(
+      <Section>
+        <Section>
+          <Section>
+            <Heading>Test Heading</Heading>
+          </Section>
+        </Section>
+      </Section>
+    );
+    const heading = screen.getByRole('heading', { name: 'Test Heading' });
+    expect(heading.tagName.toLowerCase()).toBe('h4');
+  });
+
+  it('caps at h6 for deeply nested Sections', () => {
+    render(
+      <Section>
+        <Section>
+          <Section>
+            <Section>
+              <Section>
+                <Section>
+                  <Section>
+                    <Heading>Test Heading</Heading>
+                  </Section>
+                </Section>
+              </Section>
+            </Section>
+          </Section>
+        </Section>
+      </Section>
+    );
+    const heading = screen.getByRole('heading', { name: 'Test Heading' });
+    expect(heading.tagName.toLowerCase()).toBe('h6');
+  });
+
+  it('allows custom base level override via Heading prop', () => {
+    render(
+      <Section>
+        <Heading level={4}>Test Heading</Heading>
+      </Section>
+    );
+    const heading = screen.getByRole('heading', { name: 'Test Heading' });
+    expect(heading.tagName.toLowerCase()).toBe('h4');
+  });
+});


### PR DESCRIPTION
# Description

Closes #1153 

This PR implements an auto-incrementing heading level system for nested sections. It addresses the acceptance criteria described in the issue.

## Changes
- Created `HeadingLevelContext` to keep track of the current heading level within the React tree.
- Created `Section` component that acts as a boundary for heading level increments. Each nested `Section` increments the heading level provided to its descendants by 1, up to a maximum of `h6`.
- Created `Heading` component that consumes `HeadingLevelContext` to render the semantically correct heading tag (`h1` - `h6`).
- Added robust unit tests in `Heading.test.tsx` covering all edge cases (default behavior, incrementing, boundary capping at h6, custom overrides).

## Acceptance Criteria Met
- [x] The change matches the summary: Heading level increments per nested section.
- [x] Tests run on every CI matrix entry.
- [x] Lint, type-check, and tests all pass locally.

## Testing
- Verified through tests that `<Section>` increments depth properly.
- Ensured depth respects HTML specifications (caps at `h6`).
