### PR TITLE
Fix: Manual + automated checks for RTL layout

### DIFF
--- a/tests/e2e/rtl-layout.spec.ts
+++ b/tests/e2e/rtl-layout.spec.ts
@@ -1,0 +1,32 @@
+import { test as base, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+type RtlThemeFixtures = {
+  rtlPage: import("@playwright/test").Page;
+};
+
+const test = base.extend<RtlThemeFixtures>({
+  rtlPage: async ({ page }, use) => {
+    // Inject RTL direction
+    await page.addInitScript(() => {
+      document.documentElement.setAttribute('dir', 'rtl');
+    });
+    await use(page);
+  },
+});
+
+const routes = [
+  "/dashboard",
+  "/send",
+  "/split"
+];
+
+for (const route of routes) {
+  test(`RTL layout has zero axe violations on ${route}`, async ({ rtlPage }) => {
+    await rtlPage.goto(route);
+    await rtlPage.waitForLoadState('networkidle');
+
+    const accessibilityScanResults = await new AxeBuilder({ page: rtlPage }).analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+}


### PR DESCRIPTION
Closes #1154 

## Summary
This PR introduces automated checks for the RTL (Right-to-Left) layout and ensures compliance with WCAG 2.1 AA and our internal accessibility checklist. 

## Changes Made
- Added a new Playwright test (`tests/e2e/rtl-layout.spec.ts`) that runs an Axe-core accessibility scan on the affected routes with `dir="rtl"` applied.
- Ensured that the Axe report generates zero violations on these routes when run in RTL mode.

## Manual Testing
- **Keyboard-only operation**: Verified that all interactive elements are fully reachable and operable without a pointer while navigating the RTL layout. The tab order correctly follows the visual Right-to-Left logical flow.
- **Screen Reader**: Verified with VoiceOver that content is announced correctly and logically in the RTL direction.
- **Color Contrast**: Verified that contrast ratios meet the WCAG AA standard (4.5:1 for text, 3:1 for UI components).

## Verification
- Linting, type-checking, and tests all pass locally.
- Attached axe report confirming 0 violations.