### PR TITLE
Add LiveRegion announcement timing tests

### DIFF
--- a/components/ui/AccessibleCalendarGrid.test.tsx
+++ b/components/ui/AccessibleCalendarGrid.test.tsx
@@ -1,11 +1,15 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe, toHaveNoViolations } from "jest-axe";
 import { AccessibleCalendarGrid, type CalendarDate } from "./AccessibleCalendarGrid";
 
 expect.extend(toHaveNoViolations);
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -100,6 +104,45 @@ describe("AccessibleCalendarGrid — ARIA roles and structure", () => {
     const { container } = renderJuly2026();
     const live = container.querySelector("[aria-live='polite']");
     expect(live).not.toBeNull();
+  });
+
+  it("queues month-change announcements until the timing window elapses", () => {
+    vi.useFakeTimers();
+    const { container } = renderJuly2026();
+    const liveRegion = container.querySelector("[aria-live='polite']") as HTMLElement;
+    const nextButton = screen.getByRole("button", { name: /next month/i });
+
+    act(() => {
+      fireEvent.click(nextButton);
+    });
+
+    expect(liveRegion).toHaveTextContent("");
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(liveRegion).toHaveTextContent("August 2026");
+  });
+
+  it("replaces an earlier pending announcement with the latest month label", () => {
+    vi.useFakeTimers();
+    const { container } = renderJuly2026();
+    const liveRegion = container.querySelector("[aria-live='polite']") as HTMLElement;
+    const nextButton = screen.getByRole("button", { name: /next month/i });
+
+    act(() => {
+      fireEvent.click(nextButton);
+      fireEvent.click(nextButton);
+    });
+
+    expect(liveRegion).toHaveTextContent("");
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(liveRegion).toHaveTextContent("September 2026");
   });
 
   it("navigation buttons have descriptive aria-labels", () => {

--- a/components/ui/AccessibleCalendarGrid.tsx
+++ b/components/ui/AccessibleCalendarGrid.tsx
@@ -176,6 +176,8 @@ export function AccessibleCalendarGrid({
   const [displayMonth, setDisplayMonth] = useState<number>(
     value?.month ?? today.month,
   );
+  const displayYearRef = useRef(displayYear);
+  const displayMonthRef = useRef(displayMonth);
 
   // The date cell that currently holds roving tabindex="0"
   const [focusedDate, setFocusedDate] = useState<CalendarDate>(
@@ -184,6 +186,7 @@ export function AccessibleCalendarGrid({
 
   // Live region announcement for screen readers
   const [announcement, setAnnouncement] = useState("");
+  const announcementTimerRef = useRef<number | null>(null);
 
   const gridRef = useRef<HTMLTableElement>(null);
   const headingId = useId();
@@ -201,6 +204,11 @@ export function AccessibleCalendarGrid({
   // Grid data
   const grid = buildMonthGrid(displayYear, displayMonth, firstDayOfWeek);
 
+  useEffect(() => {
+    displayYearRef.current = displayYear;
+    displayMonthRef.current = displayMonth;
+  }, [displayYear, displayMonth]);
+
   // When focused date changes to a different month, update display month
   useEffect(() => {
     if (
@@ -211,6 +219,14 @@ export function AccessibleCalendarGrid({
       setDisplayMonth(focusedDate.month);
     }
   }, [focusedDate, displayYear, displayMonth]);
+
+  useEffect(() => {
+    return () => {
+      if (announcementTimerRef.current !== null) {
+        window.clearTimeout(announcementTimerRef.current);
+      }
+    };
+  }, []);
 
   // Programmatically move focus to the focused date cell
   const focusCellForDate = useCallback((date: CalendarDate) => {
@@ -226,11 +242,22 @@ export function AccessibleCalendarGrid({
   // Navigate to prev/next month
   const navigateMonth = useCallback(
     (delta: -1 | 1) => {
-      const { year, month } = addMonths(displayYear, displayMonth, delta);
+      const { year, month } = addMonths(displayYearRef.current, displayMonthRef.current, delta);
+      displayYearRef.current = year;
+      displayMonthRef.current = month;
       setDisplayYear(year);
       setDisplayMonth(month);
       const newLabel = getMonthYearLabel(year, month, locale);
-      setAnnouncement(newLabel);
+
+      if (announcementTimerRef.current !== null) {
+        window.clearTimeout(announcementTimerRef.current);
+      }
+
+      announcementTimerRef.current = window.setTimeout(() => {
+        setAnnouncement(newLabel);
+        announcementTimerRef.current = null;
+      }, 50);
+
       // Move focused date into the new month if it's out of range
       setFocusedDate((prev) => {
         if (prev.year !== year || prev.month !== month) {
@@ -239,7 +266,7 @@ export function AccessibleCalendarGrid({
         return prev;
       });
     },
-    [displayYear, displayMonth, locale],
+    [locale],
   );
 
   // Keyboard handler on the grid


### PR DESCRIPTION
closes #1150 
Added deterministic regression tests and a small implementation adjustment for the calendar’s live-region announcements so screen-reader updates are coalesced and only surface after the intended timing window. This locks in the expected behavior for month-change announcements and prevents earlier updates from leaking through.