### PR TITLE
feat: add printable keyboard shortcuts page at /shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ remitwise-frontend/
 └── package.json
 ```
 
-The full keyboard shortcut reference lives at [docs/KEYBOARD_SHORTCUTS.md](docs/KEYBOARD_SHORTCUTS.md) — every registered shortcut, where it's handled, and how to add or change one.
+The full keyboard shortcut reference lives at [docs/KEYBOARD_SHORTCUTS.md](docs/KEYBOARD_SHORTCUTS.md) — every registered shortcut, where it's handled, and how to add or change one. End users can open the printable cheat sheet at [`/shortcuts`](/shortcuts) (also linked from the `?` help modal).
 
 ## API Routes
 

--- a/app/shortcuts/page.tsx
+++ b/app/shortcuts/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import ShortcutsCheatSheet from "@/components/ShortcutsCheatSheet";
+
+export const metadata: Metadata = {
+  title: "Keyboard Shortcuts - RemitWise",
+  description:
+    "Printable cheat sheet of every RemitWise keyboard shortcut for navigation, command palette, and overlays.",
+};
+
+export default function ShortcutsPage() {
+  return <ShortcutsCheatSheet />;
+}

--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { Search, Send, LayoutDashboard, FileText, Shield, Users, Settings, Wallet, X, Command, SearchCheck, Clock } from "lucide-react";
+import { Search, Send, LayoutDashboard, FileText, Shield, Users, Settings, Wallet, X, Command, SearchCheck, Clock, Keyboard } from "lucide-react";
+import { SHORTCUTS_PRINTABLE_PATH } from "@/lib/config/shortcuts";
 import { useClientTranslator } from "@/lib/i18n/client";
 import { useRecentItems } from "@/lib/hooks/useRecentItems";
 import { RECENT_COMMANDS_STORAGE_KEY } from "@/lib/config/recent";
@@ -78,6 +79,14 @@ export default function CommandPalette() {
       description: "Configure your settings",
       icon: <Settings className="w-4 h-4" />,
       action: () => router.push("/settings"),
+      category: "routes",
+    },
+    {
+      id: "shortcuts",
+      label: "Keyboard Shortcuts",
+      description: "View and print the full shortcuts cheat sheet",
+      icon: <Keyboard className="w-4 h-4" />,
+      action: () => router.push(SHORTCUTS_PRINTABLE_PATH),
       category: "routes",
     },
     {

--- a/components/LayoutWrapper.tsx
+++ b/components/LayoutWrapper.tsx
@@ -23,11 +23,15 @@ export default function LayoutWrapper({
 
   return (
     <RootErrorBoundary>
-      <Header />
-      <main className="overflow-x-hidden pt-16 375:pt-20">
+      <div className="print:hidden">
+        <Header />
+      </div>
+      <main className="overflow-x-hidden pt-16 375:pt-20 print:pt-0">
         {children}
-        <FinalCallToAction />
-        <Footer />
+        <div className="print:hidden">
+          <FinalCallToAction />
+          <Footer />
+        </div>
       </main>
     </RootErrorBoundary>
   );

--- a/components/ShortcutHelpModal.tsx
+++ b/components/ShortcutHelpModal.tsx
@@ -1,12 +1,47 @@
 "use client";
 
 import React from "react";
-import { X, Keyboard } from "lucide-react";
+import Link from "next/link";
+import { X, Keyboard, ExternalLink } from "lucide-react";
 import { useShortcutHelp } from "@/lib/context/ShortcutHelpContext";
 import { useFocusTrap } from "@/lib/hooks/useFocusTrap";
+import {
+  SHORTCUTS_PRINTABLE_PATH,
+  getModalShortcuts,
+  type ShortcutEntry,
+} from "@/lib/config/shortcuts";
+
+function ModalShortcutKeys({ entry }: { entry: ShortcutEntry }) {
+  return (
+    <div className="flex items-center gap-1 shrink-0">
+      {entry.keys.map((key, index) => (
+        <React.Fragment key={`mac-${entry.id}-${key}-${index}`}>
+          {index > 0 && <span className="text-gray-500 text-xs">+</span>}
+          <kbd className="px-2 py-1 bg-white/5 rounded border border-white/10 text-xs font-mono text-white">
+            {key}
+          </kbd>
+        </React.Fragment>
+      ))}
+      {entry.keysWin && (
+        <>
+          <span className="text-gray-500 text-xs">/</span>
+          {entry.keysWin.map((key, index) => (
+            <React.Fragment key={`win-${entry.id}-${key}-${index}`}>
+              {index > 0 && <span className="text-gray-500 text-xs">+</span>}
+              <kbd className="px-2 py-1 bg-white/5 rounded border border-white/10 text-xs font-mono text-white">
+                {key}
+              </kbd>
+            </React.Fragment>
+          ))}
+        </>
+      )}
+    </div>
+  );
+}
 
 export default function ShortcutHelpModal() {
   const { isOpen, close } = useShortcutHelp();
+  const shortcuts = getModalShortcuts();
 
   // Traps focus inside the modal, closes on Escape, prevents background scrolling,
   // and restores focus to the previously active element when closed.
@@ -47,26 +82,26 @@ export default function ShortcutHelpModal() {
 
         {/* Shortcuts List */}
         <div className="space-y-3 pt-4">
-          <div className="flex justify-between items-center py-2.5 px-3 bg-white/[0.02] border border-white/5 rounded-xl">
-            <span className="text-sm text-gray-300">Open Keyboard Shortcuts</span>
-            <kbd className="px-2 py-1 bg-white/5 rounded border border-white/10 text-xs font-mono text-white">?</kbd>
-          </div>
-
-          <div className="flex justify-between items-center py-2.5 px-3 bg-white/[0.02] border border-white/5 rounded-xl">
-            <span className="text-sm text-gray-300">Toggle Command Palette</span>
-            <div className="flex items-center gap-1">
-              <kbd className="px-2 py-1 bg-white/5 rounded border border-white/10 text-xs font-mono text-white">⌘</kbd>
-              <span className="text-gray-500 text-xs">/</span>
-              <kbd className="px-2 py-1 bg-white/5 rounded border border-white/10 text-xs font-mono text-white">Ctrl</kbd>
-              <span className="text-gray-500 text-xs">+</span>
-              <kbd className="px-2 py-1 bg-white/5 rounded border border-white/10 text-xs font-mono text-white">K</kbd>
+          {shortcuts.map((entry) => (
+            <div
+              key={entry.id}
+              className="flex justify-between items-center gap-3 py-2.5 px-3 bg-white/[0.02] border border-white/5 rounded-xl"
+            >
+              <span className="text-sm text-gray-300">{entry.label}</span>
+              <ModalShortcutKeys entry={entry} />
             </div>
-          </div>
+          ))}
+        </div>
 
-          <div className="flex justify-between items-center py-2.5 px-3 bg-white/[0.02] border border-white/5 rounded-xl">
-            <span className="text-sm text-gray-300">Close Open Modal / Dialog</span>
-            <kbd className="px-2 py-1 bg-white/5 rounded border border-white/10 text-xs font-mono text-white">Esc</kbd>
-          </div>
+        <div className="pt-4 mt-2 border-t border-white/10">
+          <Link
+            href={SHORTCUTS_PRINTABLE_PATH}
+            onClick={close}
+            className="inline-flex items-center gap-1.5 text-sm text-red-400 hover:text-red-300 transition-colors"
+          >
+            View printable cheat sheet
+            <ExternalLink className="w-3.5 h-3.5" aria-hidden="true" />
+          </Link>
         </div>
       </div>
     </div>

--- a/components/ShortcutsCheatSheet.tsx
+++ b/components/ShortcutsCheatSheet.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import React, { useMemo } from "react";
+import { Keyboard, Printer } from "lucide-react";
+import PageHeadingLink from "@/components/PageHeadingLink";
+import { useSeo } from "@/lib/hooks/useSeo";
+import {
+  KEYBOARD_SHORTCUTS,
+  SHORTCUT_CATEGORY_LABELS,
+  getShortcutsByCategory,
+  type ShortcutCategory,
+  type ShortcutEntry,
+} from "@/lib/config/shortcuts";
+
+const CATEGORY_ORDER: ShortcutCategory[] = [
+  "global",
+  "navigation",
+  "modals",
+  "lists",
+];
+
+function formatKeyChord(keys: string[]): string {
+  return keys.join(" + ");
+}
+
+function ShortcutKeys({ entry }: { entry: ShortcutEntry }) {
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1 justify-end">
+      {entry.keys.map((key, index) => (
+        <React.Fragment key={`${entry.id}-mac-${key}-${index}`}>
+          {index > 0 && <span className="text-gray-500 text-xs">+</span>}
+          <kbd className="px-2 py-1 bg-white/5 rounded border border-white/10 text-xs font-mono text-white">
+            {key}
+          </kbd>
+        </React.Fragment>
+      ))}
+      {entry.keysWin && (
+        <>
+          <span className="text-gray-500 text-xs px-0.5">/</span>
+          {entry.keysWin.map((key, index) => (
+            <React.Fragment key={`${entry.id}-win-${key}-${index}`}>
+              {index > 0 && <span className="text-gray-500 text-xs">+</span>}
+              <kbd className="px-2 py-1 bg-white/5 rounded border border-white/10 text-xs font-mono text-white">
+                {key}
+              </kbd>
+            </React.Fragment>
+          ))}
+        </>
+      )}
+    </span>
+  );
+}
+
+function PrintKeys({ entry }: { entry: ShortcutEntry }) {
+  const mac = formatKeyChord(entry.keys);
+  const win = entry.keysWin ? formatKeyChord(entry.keysWin) : null;
+  return (
+    <span className="font-mono text-sm text-gray-900">
+      {mac}
+      {win ? ` / ${win}` : ""}
+    </span>
+  );
+}
+
+export default function ShortcutsCheatSheet() {
+  useSeo({
+    title: "Keyboard Shortcuts - RemitWise",
+    description:
+      "Printable cheat sheet of every RemitWise keyboard shortcut for navigation, command palette, and overlays.",
+  });
+
+  const grouped = useMemo(() => getShortcutsByCategory(), []);
+
+  return (
+    <>
+      {/* Screen layout */}
+      <div className="min-h-screen bg-slate-950 text-white px-4 py-10 sm:px-6 lg:px-8 print:hidden">
+        <div className="mx-auto max-w-3xl">
+          <header className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-start gap-3">
+              <div className="rounded-2xl bg-white/5 p-3 text-slate-200">
+                <Keyboard className="h-5 w-5" aria-hidden="true" />
+              </div>
+              <div>
+                <p className="text-sm uppercase tracking-[0.24em] text-slate-400">
+                  Reference
+                </p>
+                <PageHeadingLink
+                  headingId="shortcuts-page-heading"
+                  label="Copy link to keyboard shortcuts heading"
+                  headingClassName="text-3xl font-semibold tracking-tight text-white"
+                >
+                  Keyboard Shortcuts
+                </PageHeadingLink>
+                <p className="mt-2 text-slate-300 max-w-xl">
+                  Full shortcut list for RemitWise. Print this page for a clean
+                  desk-side cheat sheet.
+                </p>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={() => window.print()}
+              className="inline-flex items-center justify-center gap-2 rounded-xl bg-red-600 px-4 py-3 text-sm font-semibold text-white hover:bg-red-500 transition-colors shrink-0"
+            >
+              <Printer className="h-4 w-4" aria-hidden="true" />
+              Print
+            </button>
+          </header>
+
+          <div className="space-y-6">
+            {CATEGORY_ORDER.map((category) => {
+              const entries = grouped[category];
+              if (entries.length === 0) return null;
+
+              return (
+                <section
+                  key={category}
+                  aria-labelledby={`shortcuts-${category}`}
+                  className="rounded-2xl border border-white/10 bg-white/[0.03] p-4 sm:p-5"
+                >
+                  <h2
+                    id={`shortcuts-${category}`}
+                    className="text-sm font-semibold uppercase tracking-wider text-slate-400 mb-3"
+                  >
+                    {SHORTCUT_CATEGORY_LABELS[category]}
+                  </h2>
+                  <ul className="space-y-2">
+                    {entries.map((entry) => (
+                      <li
+                        key={entry.id}
+                        className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between py-2.5 px-3 bg-white/[0.02] border border-white/5 rounded-xl"
+                      >
+                        <div>
+                          <p className="text-sm text-gray-200">{entry.label}</p>
+                          <p className="text-xs text-gray-500 mt-0.5">{entry.scope}</p>
+                        </div>
+                        <ShortcutKeys entry={entry} />
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              );
+            })}
+          </div>
+
+          <p className="mt-8 text-sm text-slate-400">
+            Press{" "}
+            <kbd className="px-1.5 py-0.5 bg-white/5 rounded border border-white/10 text-xs font-mono text-white">
+              ?
+            </kbd>{" "}
+            anywhere in the app for the quick help modal. Contributor reference:{" "}
+            <code className="text-slate-300">docs/KEYBOARD_SHORTCUTS.md</code>.
+          </p>
+        </div>
+      </div>
+
+      {/* Print-only layout */}
+      <div className="hidden print:block w-full min-h-screen bg-white text-black p-8 font-sans">
+        <style>{`
+          @page { size: portrait; margin: 12mm; }
+          body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+        `}</style>
+
+        <header className="mb-8 border-b border-gray-300 pb-4">
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+            RemitWise
+          </h1>
+          <p className="text-sm text-gray-500 uppercase tracking-widest font-semibold mt-1">
+            Keyboard Shortcuts
+          </p>
+          <p className="text-sm text-gray-600 mt-2">
+            {KEYBOARD_SHORTCUTS.length} shortcuts · Printable cheat sheet
+          </p>
+        </header>
+
+        {CATEGORY_ORDER.map((category) => {
+          const entries = grouped[category];
+          if (entries.length === 0) return null;
+
+          return (
+            <section key={`print-${category}`} className="mb-6 break-inside-avoid">
+              <h2 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2 border-b border-gray-200 pb-1">
+                {SHORTCUT_CATEGORY_LABELS[category]}
+              </h2>
+              <table className="w-full text-left border-collapse">
+                <thead>
+                  <tr className="text-xs uppercase tracking-wide text-gray-500">
+                    <th className="py-1.5 pr-4 font-semibold w-[42%]">Action</th>
+                    <th className="py-1.5 pr-4 font-semibold w-[28%]">Keys</th>
+                    <th className="py-1.5 font-semibold">Scope</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {entries.map((entry) => (
+                    <tr key={`print-${entry.id}`} className="border-t border-gray-200">
+                      <td className="py-2 pr-4 text-sm text-gray-900">{entry.label}</td>
+                      <td className="py-2 pr-4">
+                        <PrintKeys entry={entry} />
+                      </td>
+                      <td className="py-2 text-sm text-gray-600">{entry.scope}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+          );
+        })}
+
+        <footer className="mt-10 pt-4 border-t border-gray-300 text-xs text-gray-500">
+          Tip: press ? in the app for the quick help overlay · /shortcuts
+        </footer>
+      </div>
+    </>
+  );
+}

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -938,3 +938,30 @@ export default function BillsPage() {
 - Clipboard failure does not leave the button stuck in "copied" state
 - Legacy path resolution (`/insights`, `/financial-insight`)
 - Trailing slash stripping
+
+---
+
+## ShortcutsCheatSheet
+
+Printable keyboard-shortcuts cheat sheet rendered at `/shortcuts`.
+
+**File:** `components/ShortcutsCheatSheet.tsx`  
+**Route:** `app/shortcuts/page.tsx`  
+**Registry:** `lib/config/shortcuts.ts`
+
+### Behaviour
+
+- Lists every entry from `KEYBOARD_SHORTCUTS`, grouped by category.
+- Screen layout matches other utility pages (dark slate surface, brand accent Print button).
+- Print layout (`hidden print:block`) renders a white portrait table; site chrome is `print:hidden` in `LayoutWrapper`.
+- Linked from `ShortcutHelpModal` (“View printable cheat sheet”) and the command palette.
+
+### Tests
+
+- `lib/config/shortcuts.test.ts` — registry shape and modal subset
+- `tests/unit/components/ShortcutsCheatSheet.test.tsx` — render + `window.print`
+- `tests/unit/components/ShortcutHelpModal.test.tsx` — printable link
+
+### Related docs
+
+See [KEYBOARD_SHORTCUTS.md](KEYBOARD_SHORTCUTS.md).

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -5,44 +5,53 @@
 
 ## Overview
 
-RemitWise does **not** have a centralized keybinding system. Every shortcut is registered via an inline `addEventListener("keydown", ...)` or JSX `onKeyDown` prop inside the owning component. This document enumerates every registered shortcut so reviewers can verify behaviour against documented intent and new contributors know where to look.
+RemitWise keeps a **central shortcut registry** at `lib/config/shortcuts.ts`. The in-app `?` help modal and the printable cheat sheet at [`/shortcuts`](/shortcuts) both read from that registry so the documented list stays in sync with what users see.
+
+Handlers themselves still live in owning components (`keydown` listeners / `onKeyDown` props). The registry is the user-facing catalogue; this document maps each shortcut to its implementation.
+
+## Printable cheat sheet
+
+Visit **`/shortcuts`** for the full list with a **Print** button. The page uses a screen layout plus a print-only white table so Chrome / Safari print dialogs produce a clean desk-side reference (header, footer, and marketing CTA are hidden via `print:hidden`).
+
+| Surface | Path / trigger | Source of truth |
+|---------|----------------|-----------------|
+| Printable page | `/shortcuts` | `KEYBOARD_SHORTCUTS` in `lib/config/shortcuts.ts` |
+| Quick help modal | `?` key, Help button, footer | `getModalShortcuts()` (subset of the registry) |
+| Command palette entry | `Cmd`/`Ctrl`+`K` → “Keyboard Shortcuts” | navigates to `/shortcuts` |
 
 ## Shortcut reference
 
 | Key | Scope | Action | Component | File |
 |-----|-------|--------|-----------|------|
-| `Cmd` / `Ctrl` + `K` | Global | Toggle command palette | `CommandPalette` | `components/CommandPalette.tsx:101` |
-| `Escape` | Global (when palette open) | Close command palette | `CommandPalette` | `components/CommandPalette.tsx:106` |
-| `Escape` | Global (when panel open) | Close "What's New" panel | `WhatsNewPanel` | `components/Dashboard/WhatsNewPanel.tsx:24` |
-| `Escape` | Global (when drawer open) | Close mobile nav drawer | `MobileNav` | `components/Nav/MobileNav.tsx:56` |
-| `Escape` | Global (when modal open) | Close session-expiry notification | `SessionExpiryNotification` | `components/SessionExpiryNotification.tsx:42` |
-| `Escape` | Global (when modal open) | Close savings-goal modal | `SavingsGoalModal` | `app/dashboard/goals/components/SavingsGoalModal.tsx:85` |
-| `Escape` | Global (when drawer open) | Close family-member detail drawer | `FamilyMemberDetailDrawer` | `app/family/components/FamilyMemberDetailDrawer.tsx:186` |
-| `Escape` | Global (when dropdown open) | Close export-format dropdown | Transactions page | `app/transactions/page.tsx:421` |
-| `Escape` | Component | Close policy-detail dialog | `PolicyDetail` | `components/insurance/PolicyDetail.tsx:105` |
-| `Escape` | Component | Close tooltip | `Tooltip` | `components/Tooltip.tsx:62` |
-| `Escape` | Focus-trap hook | Trigger `onEscape` callback | `useFocusTrap` | `lib/hooks/useFocusTrap.ts:31`, `src/lib/hooks/useFocusTrap.ts:64` |
-| `ArrowDown` | Command palette | Move selection to next command | `CommandPalette` | `components/CommandPalette.tsx:111` |
-| `ArrowUp` | Command palette | Move selection to previous command | `CommandPalette` | `components/CommandPalette.tsx:115` |
-| `ArrowDown` | Wallet dropdown | Move focus to next menu item | `WalletDropdown` | `components/WalletDropdown.tsx:123` |
-| `ArrowUp` | Wallet dropdown | Move focus to previous menu item | `WalletDropdown` | `components/WalletDropdown.tsx:126` |
-| `Home` | Wallet dropdown | Move focus to first menu item | `WalletDropdown` | `components/WalletDropdown.tsx:129` |
-| `End` | Wallet dropdown | Move focus to last menu item | `WalletDropdown` | `components/WalletDropdown.tsx:133` |
-| `Enter` | Command palette | Execute selected command | `CommandPalette` | `components/CommandPalette.tsx:120` |
-| `Enter` | Settings row | Activate clickable row | `SettingsItem` | `components/SettingsItem.tsx:56,117` |
-| `Enter` / `Space` | Toast disclosure | Toggle diagnostics section | `Toast` | `components/Toast.tsx:89` |
+| `?` | Global (ignored in inputs) | Open keyboard shortcuts help | `ShortcutHelpProvider` | `lib/context/ShortcutHelpContext.tsx` |
+| `Cmd` / `Ctrl` + `K` | Global | Toggle command palette | `CommandPalette` | `components/CommandPalette.tsx` |
+| `Escape` | Global (when palette open) | Close command palette | `CommandPalette` | `components/CommandPalette.tsx` |
+| `Escape` | Global (when panel open) | Close "What's New" panel | `WhatsNewPanel` | `components/Dashboard/WhatsNewPanel.tsx` |
+| `Escape` | Global (when drawer open) | Close mobile nav drawer | `MobileNav` | `components/Nav/MobileNav.tsx` |
+| `Escape` | Global (when modal open) | Close session-expiry notification | `SessionExpiryNotification` | `components/SessionExpiryNotification.tsx` |
+| `Escape` | Global (when modal open) | Close savings-goal modal | `SavingsGoalModal` | `app/dashboard/goals/components/SavingsGoalModal.tsx` |
+| `Escape` | Global (when drawer open) | Close family-member detail drawer | `FamilyMemberDetailDrawer` | `app/family/components/FamilyMemberDetailDrawer.tsx` |
+| `Escape` | Global (when dropdown open) | Close export-format dropdown | Transactions page | `app/transactions/page.tsx` |
+| `Escape` | Component | Close policy-detail dialog | `PolicyDetail` | `components/insurance/PolicyDetail.tsx` |
+| `Escape` | Component | Close tooltip | `Tooltip` | `components/Tooltip.tsx` |
+| `Escape` | Focus-trap hook | Trigger `onEscape` callback | `useFocusTrap` | `lib/hooks/useFocusTrap.ts`, `src/lib/hooks/useFocusTrap.ts` |
+| `ArrowDown` | Command palette | Move selection to next command | `CommandPalette` | `components/CommandPalette.tsx` |
+| `ArrowUp` | Command palette | Move selection to previous command | `CommandPalette` | `components/CommandPalette.tsx` |
+| `ArrowDown` | Wallet dropdown | Move focus to next menu item | `WalletDropdown` | `components/WalletDropdown.tsx` |
+| `ArrowUp` | Wallet dropdown | Move focus to previous menu item | `WalletDropdown` | `components/WalletDropdown.tsx` |
+| `Home` | Wallet dropdown | Move focus to first menu item | `WalletDropdown` | `components/WalletDropdown.tsx` |
+| `End` | Wallet dropdown | Move focus to last menu item | `WalletDropdown` | `components/WalletDropdown.tsx` |
+| `Enter` | Command palette | Execute selected command | `CommandPalette` | `components/CommandPalette.tsx` |
+| `Enter` | Settings row | Activate clickable row | `SettingsItem` | `components/SettingsItem.tsx` |
+| `Enter` / `Space` | Toast disclosure | Toggle diagnostics section | `Toast` | `components/Toast.tsx` |
 | `Tab` | Modal / drawer | Cycle focus forward (focus trap) | `useFocusTrap`, `PolicyDetail`, `WhatsNewPanel`, `FamilyMemberDetailDrawer`, `SavingsGoalModal` | Multiple |
 | `Shift` + `Tab` | Modal / drawer | Cycle focus backward (focus trap) | `useFocusTrap`, `PolicyDetail`, `WhatsNewPanel`, `FamilyMemberDetailDrawer`, `SavingsGoalModal` | Multiple |
 
-> **Note:** `Escape` is the most-used shortcut (11 registrations). It is handled independently by each component — there is no shared "close active overlay" mechanism.
+> **Note:** `Escape` is the most-used shortcut. It is handled independently by each component — there is no shared "close active overlay" mechanism.
 
 ## Command palette
 
-The file `components/CommandPalette.tsx` implements a `Cmd`/`Ctrl`+`K` command palette with route navigation and quick actions.
-
-### Current status
-
-The component is **not wired into the app layout**. It imports correctly and type-checks, but no parent renders `<CommandPalette />`. The shortcuts in the table above will not fire until it is mounted. To activate it, add `<CommandPalette />` to `app/layout.tsx` or `components/Providers.tsx`.
+The file `components/CommandPalette.tsx` implements a `Cmd`/`Ctrl`+`K` command palette with route navigation and quick actions. It is mounted from `components/Providers.tsx`.
 
 ### How to add a command
 
@@ -63,9 +72,25 @@ Import the icon from `lucide-react` (already a dependency).
 
 ## How to add or change a shortcut
 
-Because there is no central registry, you work in the component that owns the shortcut.
+### 1. Update the registry (required for UI surfaces)
 
-### Adding a new shortcut
+Edit `lib/config/shortcuts.ts` and add or change a `ShortcutEntry`:
+
+```ts
+{
+  id: "my-shortcut",
+  keys: ["⌘", "S"],
+  keysWin: ["Ctrl", "S"],
+  label: "Save draft",
+  category: "global",
+  scope: "Send flow",
+  showInModal: true, // omit from ? modal when false
+}
+```
+
+The printable page picks up every entry. The `?` modal only shows entries where `showInModal !== false`.
+
+### 2. Wire the handler in the owning component
 
 1. Locate the component that should own the shortcut.
 2. Add a `useEffect` with a `keydown` listener (for global/trapped shortcuts) or an `onKeyDown` prop on the JSX element (for component-scoped shortcuts).
@@ -98,7 +123,7 @@ Because there is no central registry, you work in the component that owns the sh
 1. Find the owning component via the file-path column in the reference table above.
 2. Change the `e.key` comparison in the handler.
 3. If the shortcut conflicts with a browser default (e.g. `Ctrl+S`), call `e.preventDefault()`.
-4. Update this document.
+4. Update `lib/config/shortcuts.ts` and this document.
 
 ### Testing a shortcut
 
@@ -115,13 +140,17 @@ it("closes on Escape", () => {
 });
 ```
 
+Registry and printable page coverage lives in:
+
+- `lib/config/shortcuts.test.ts`
+- `tests/unit/components/ShortcutsCheatSheet.test.tsx`
+- `tests/unit/components/ShortcutHelpModal.test.tsx`
+
 ## Future improvements
 
 The following are not yet implemented but have been discussed:
 
-1. **Wire `CommandPalette` into the layout** — it exists but is unmounted.
-2. **Centralized shortcut registry** — a single config object that all components read from, so contributors can see every shortcut in one file.
-3. **User-configurable keybindings** — allow power users to remap shortcuts via settings UI.
-4. **Keyboard shortcut cheat-sheet modal** — a `?` overlay showing all active shortcuts, similar to GitHub or VS Code.
+1. **User-configurable keybindings** — allow power users to remap shortcuts via settings UI.
+2. **Shared "close active overlay" mechanism** — reduce duplicated `Escape` handlers.
 
 See [docs/uiux-quick-actions-improvements.md](uiux-quick-actions-improvements.md) for the original feature proposal that mentioned keyboard hotkeys.

--- a/lib/config/shortcuts.test.ts
+++ b/lib/config/shortcuts.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import {
+  KEYBOARD_SHORTCUTS,
+  SHORTCUTS_PRINTABLE_PATH,
+  getModalShortcuts,
+  getShortcutsByCategory,
+} from "@/lib/config/shortcuts";
+
+describe("shortcuts registry", () => {
+  it("exports a non-empty shortcut list", () => {
+    expect(KEYBOARD_SHORTCUTS.length).toBeGreaterThan(0);
+  });
+
+  it("keeps printable path stable", () => {
+    expect(SHORTCUTS_PRINTABLE_PATH).toBe("/shortcuts");
+  });
+
+  it("exposes core help shortcuts in the modal subset", () => {
+    const modalIds = getModalShortcuts().map((entry) => entry.id);
+    expect(modalIds).toEqual(expect.arrayContaining(["help", "palette", "escape"]));
+    expect(modalIds).not.toContain("palette-arrows");
+  });
+
+  it("groups every registry entry into a category bucket", () => {
+    const grouped = getShortcutsByCategory();
+    const total = Object.values(grouped).reduce((sum, list) => sum + list.length, 0);
+    expect(total).toBe(KEYBOARD_SHORTCUTS.length);
+  });
+
+  it("requires id, label, keys, category, and scope on every entry", () => {
+    for (const entry of KEYBOARD_SHORTCUTS) {
+      expect(entry.id).toBeTruthy();
+      expect(entry.label).toBeTruthy();
+      expect(entry.keys.length).toBeGreaterThan(0);
+      expect(entry.category).toBeTruthy();
+      expect(entry.scope).toBeTruthy();
+    }
+  });
+});

--- a/lib/config/shortcuts.ts
+++ b/lib/config/shortcuts.ts
@@ -1,0 +1,138 @@
+/**
+ * Central keyboard-shortcut registry.
+ * Consumed by ShortcutHelpModal, the /shortcuts printable page, and docs.
+ */
+
+export type ShortcutCategory = "global" | "navigation" | "modals" | "lists";
+
+export type ShortcutEntry = {
+  id: string;
+  /** Primary key segments shown on macOS (e.g. ["⌘", "K"] or ["?"]). */
+  keys: string[];
+  /** Optional Windows/Linux segments when they differ from macOS. */
+  keysWin?: string[];
+  label: string;
+  category: ShortcutCategory;
+  /** Short scope note for the printable cheat sheet. */
+  scope: string;
+  /** When false, omit from the compact in-app help modal. Defaults to true. */
+  showInModal?: boolean;
+};
+
+export const SHORTCUT_CATEGORY_LABELS: Record<ShortcutCategory, string> = {
+  global: "Global",
+  navigation: "Navigation",
+  modals: "Modals & overlays",
+  lists: "Lists & menus",
+};
+
+export const KEYBOARD_SHORTCUTS: ShortcutEntry[] = [
+  {
+    id: "help",
+    keys: ["?"],
+    label: "Open keyboard shortcuts help",
+    category: "global",
+    scope: "Global (ignored while typing in inputs)",
+  },
+  {
+    id: "palette",
+    keys: ["⌘", "K"],
+    keysWin: ["Ctrl", "K"],
+    label: "Toggle command palette",
+    category: "global",
+    scope: "Global",
+  },
+  {
+    id: "escape",
+    keys: ["Esc"],
+    label: "Close open modal / dialog / drawer",
+    category: "modals",
+    scope: "When an overlay is open",
+  },
+  {
+    id: "palette-enter",
+    keys: ["Enter"],
+    label: "Execute selected command",
+    category: "navigation",
+    scope: "Command palette",
+    showInModal: false,
+  },
+  {
+    id: "palette-arrows",
+    keys: ["↑ / ↓"],
+    label: "Move command selection",
+    category: "navigation",
+    scope: "Command palette",
+    showInModal: false,
+  },
+  {
+    id: "menu-arrows",
+    keys: ["↑ / ↓"],
+    label: "Move focus between menu items",
+    category: "lists",
+    scope: "Wallet dropdown & similar menus",
+    showInModal: false,
+  },
+  {
+    id: "menu-home-end",
+    keys: ["Home / End"],
+    label: "Jump to first / last menu item",
+    category: "lists",
+    scope: "Wallet dropdown",
+    showInModal: false,
+  },
+  {
+    id: "activate-enter",
+    keys: ["Enter"],
+    label: "Activate focused row or control",
+    category: "lists",
+    scope: "Settings rows and similar controls",
+    showInModal: false,
+  },
+  {
+    id: "activate-space",
+    keys: ["Space"],
+    label: "Toggle disclosure / activate control",
+    category: "lists",
+    scope: "Toasts and focusable controls",
+    showInModal: false,
+  },
+  {
+    id: "tab",
+    keys: ["Tab"],
+    label: "Cycle focus forward",
+    category: "modals",
+    scope: "Modals and drawers (focus trap)",
+    showInModal: false,
+  },
+  {
+    id: "shift-tab",
+    keys: ["⇧", "Tab"],
+    keysWin: ["Shift", "Tab"],
+    label: "Cycle focus backward",
+    category: "modals",
+    scope: "Modals and drawers (focus trap)",
+    showInModal: false,
+  },
+];
+
+export const SHORTCUTS_PRINTABLE_PATH = "/shortcuts";
+
+export function getModalShortcuts(): ShortcutEntry[] {
+  return KEYBOARD_SHORTCUTS.filter((entry) => entry.showInModal !== false);
+}
+
+export function getShortcutsByCategory(): Record<ShortcutCategory, ShortcutEntry[]> {
+  return KEYBOARD_SHORTCUTS.reduce(
+    (groups, entry) => {
+      groups[entry.category].push(entry);
+      return groups;
+    },
+    {
+      global: [],
+      navigation: [],
+      modals: [],
+      lists: [],
+    } as Record<ShortcutCategory, ShortcutEntry[]>,
+  );
+}

--- a/tests/unit/components/ShortcutHelpModal.test.tsx
+++ b/tests/unit/components/ShortcutHelpModal.test.tsx
@@ -106,4 +106,19 @@ describe("ShortcutHelpModal", () => {
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
+
+  it("links to the printable shortcuts page", () => {
+    render(
+      <ShortcutHelpProvider>
+        <TestApp />
+      </ShortcutHelpProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Shortcuts" }));
+
+    const printableLink = screen.getByRole("link", {
+      name: /view printable cheat sheet/i,
+    });
+    expect(printableLink).toHaveAttribute("href", "/shortcuts");
+  });
 });

--- a/tests/unit/components/ShortcutsCheatSheet.test.tsx
+++ b/tests/unit/components/ShortcutsCheatSheet.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import ShortcutsCheatSheet from "@/components/ShortcutsCheatSheet";
+import { KEYBOARD_SHORTCUTS } from "@/lib/config/shortcuts";
+
+vi.mock("@/lib/hooks/useSeo", () => ({
+  useSeo: vi.fn(),
+}));
+
+vi.mock("@/lib/context/ToastContext", () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
+describe("ShortcutsCheatSheet", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the full shortcut list on screen", () => {
+    render(<ShortcutsCheatSheet />);
+
+    expect(
+      screen.getByRole("heading", { name: "Keyboard Shortcuts" }),
+    ).toBeInTheDocument();
+
+    for (const entry of KEYBOARD_SHORTCUTS) {
+      expect(screen.getAllByText(entry.label).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("exposes a Print control that calls window.print", () => {
+    const printSpy = vi.spyOn(window, "print").mockImplementation(() => {});
+    render(<ShortcutsCheatSheet />);
+
+    fireEvent.click(screen.getByRole("button", { name: /print/i }));
+    expect(printSpy).toHaveBeenCalledTimes(1);
+
+    printSpy.mockRestore();
+  });
+
+  it("includes a print-only RemitWise cheat sheet heading", () => {
+    const { container } = render(<ShortcutsCheatSheet />);
+    expect(container.querySelector(".print\\:block")).toBeTruthy();
+    expect(screen.getByText("RemitWise")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Overview

This PR adds a printable **Keyboard Shortcuts** cheat sheet at `/shortcuts`, backed by a shared shortcut registry so the `?` help modal and the printable page stay in sync.

## Related Issue

Closes #1001

## Changes

### ⌨️ Shortcuts registry

* **[ADD]** `lib/config/shortcuts.ts`
  * Central `KEYBOARD_SHORTCUTS` catalogue with categories, macOS/Windows key variants, and modal visibility flags.
  * Helpers: `getModalShortcuts()`, `getShortcutsByCategory()`, `SHORTCUTS_PRINTABLE_PATH`.

* **[ADD]** `lib/config/shortcuts.test.ts`
  * Locks registry shape, printable path, and modal subset.

### 🖨️ Printable `/shortcuts` page

* **[ADD]** `app/shortcuts/page.tsx` + `components/ShortcutsCheatSheet.tsx`
  * Full shortcut list grouped by category.
  * Screen UI with Print button (`window.print()`).
  * Print-only white portrait table (`hidden print:block`) for clean desk-side printing.

* **[MODIFY]** `components/LayoutWrapper.tsx`
  * Hide header / footer / CTA via `print:hidden` so printouts stay clean.

### 🔗 Discovery wiring

* **[MODIFY]** `components/ShortcutHelpModal.tsx` — consume registry + link to printable cheat sheet.
* **[MODIFY]** `components/CommandPalette.tsx` — add “Keyboard Shortcuts” route command.
* **[MODIFY]** docs (`KEYBOARD_SHORTCUTS.md`, `COMPONENTS.md`, `README.md`) and unit tests.

## Verification Results

```
node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner \
  lib/config/shortcuts.test.ts \
  tests/unit/components/ShortcutsCheatSheet.test.tsx \
  tests/unit/components/ShortcutHelpModal.test.tsx
✅ 15/15 passed

npx eslint <changed files>
✅ clean

Route check:
✅ /shortcuts compiles (`app/shortcuts/page.tsx`)
✅ metadata title: "Keyboard Shortcuts - RemitWise"
✅ full shortcut list + Print control covered by unit tests
```

| Acceptance Criteria | Status |
| --- | --- |
| Renders full shortcut list | ✅ Screen + print layouts from shared registry |
| Can be printed cleanly | ✅ Print-only white table; chrome `print:hidden` |
| Documented where observable | ✅ README, KEYBOARD_SHORTCUTS.md, COMPONENTS.md |
| Tests lock behaviour | ✅ 15 unit tests |
| PR references issue | ✅ `Closes #1001` |

## Timeline

- oyetunde140 committed

Made with [Cursor](https://cursor.com)