### PR TITLE
fix: correctly handle multiple ResizeObserver entries in useElementSi…

### DIFF
--- a/lib/hooks/useElementSize.ts
+++ b/lib/hooks/useElementSize.ts
@@ -18,15 +18,14 @@ export function useElementSize<T extends Element = HTMLElement>(
   const [size, setSize] = useState<ElementSize>({ width: 0, height: 0 });
 
   const handleResize = useCallback((entries: ResizeObserverEntry[]) => {
-    const entry = entries[0];
-    if (entry) {
-      const { width, height } = entry.contentRect;
-      setSize((prev) => 
-        prev.width === width && prev.height === height 
-          ? prev 
-          : { width, height }
-      );
-    }
+    if (!entries.length) return;
+    const entry = entries[entries.length - 1];
+    const { width, height } = entry.contentRect;
+    setSize((prev) =>
+      prev.width === width && prev.height === height
+        ? prev
+        : { width, height }
+    );
   }, []);
 
   const ref = useResizeObserver<T>(handleResize, target);

--- a/tests/property/useElementSize.property.test.tsx
+++ b/tests/property/useElementSize.property.test.tsx
@@ -82,4 +82,17 @@ describe("useElementSize update behaviour", () => {
 
     unmount();
   });
+it("handles_multiple_resize_entries", () => {
+  const { result, unmount } = renderHook(() => useElementSize());
+  const sizes = [{ width: 100, height: 200 }, { width: 300, height: 400 }, { width: 500, height: 600 }];
+  act(() => {
+    if (triggerResize) {
+      triggerResize(sizes.map(s => ({ contentRect: s })));
+    }
+  });
+  const last = sizes[sizes.length - 1];
+  expect(result.current.width).toBe(last.width);
+  expect(result.current.height).toBe(last.height);
+  unmount();
+});
 });


### PR DESCRIPTION
Closes #1121 
This PR resolves the issue where the useElementSize hook incorrectly handled multiple ResizeObserver entries by only processing the first entry. The fix ensures the hook now uses the most recent entry and safely handles empty resize events. Additionally, a new property‑based test validates the updated behavior.

What was changed
lib/hooks/useElementSize.ts
Updated the handleResize callback to:
Return early when no entries are provided.
Use the last entry in the entries array (the most recent size).
Simplified size update logic.
tests/property/useElementSize.property.test.tsx
Added a new test case handles_multiple_resize_entries that:
Simulates a series of resize entries.
Verifies that the hook reflects the size from the last entry.
Ensures the hook works correctly after multiple resizes.
Why
When multiple resize events are emitted, the hook previously reported the size from the first entry, leading to stale or incorrect layout calculations. By processing the latest entry, the UI now reflects the correct dimensions, fixing the “Multiple sizes produced from a single source” regression.

Related Issue
Closes # (replace with the actual issue number if known)

Verification
Created a new branch fix/multiple-sizes-issue and pushed the changes.
Ran the existing test suite locally; all tests (including the new one) pass.
Lint and TypeScript checks run cleanly.
The PR can be opened via:
https://github.com/VerifiedFlemzy1/Remitwise-Frontend/pull/new/fix/multiple-sizes-issue