### PR TITLE
feat(family): multisig approval request card, history list, and UX spec

### DIFF
--- a/app/family/components/ApprovalRequestCard.tsx
+++ b/app/family/components/ApprovalRequestCard.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import {
+  CheckCircle2,
+  Clock3,
+  GitMerge,
+  Loader2,
+  Timer,
+  UserPlus,
+  XCircle,
+  type LucideIcon,
+} from "lucide-react";
+import type { ApprovalItem, ApprovalStatus } from "@/lib/hooks/useApprovalsQueue";
+
+// ---------------------------------------------------------------------------
+// Status presentation — uses existing status design tokens throughout.
+// Status is always conveyed by both icon and text, never colour alone.
+// ---------------------------------------------------------------------------
+
+interface StatusPresentation {
+  icon: LucideIcon;
+  /** Tailwind classes for the status badge (border + bg + text using status tokens) */
+  badgeClass: string;
+  /** Tailwind classes for the card border + bg */
+  cardClass: string;
+  /** Icon classes including colour */
+  iconClass: string;
+  /** Accessible text label */
+  label: string;
+  /** Whether the icon should spin */
+  spin?: boolean;
+}
+
+function getStatusPresentation(status: ApprovalStatus): StatusPresentation {
+  switch (status) {
+    case "building":
+      return {
+        icon: Loader2,
+        label: "Building",
+        badgeClass: "border-white/10 bg-white/[0.03] text-gray-400",
+        cardClass: "border-white/10 bg-white/[0.02]",
+        iconClass: "text-gray-400",
+        spin: true,
+      };
+    case "requested":
+      return {
+        icon: Clock3,
+        label: "Awaiting approval",
+        badgeClass:
+          "border-status-warning-border bg-status-warning-bg text-status-warning-fg",
+        cardClass: "border-amber-500/20 bg-amber-500/[0.05]",
+        iconClass: "text-status-warning-fg",
+      };
+    case "partially_approved":
+      return {
+        icon: GitMerge,
+        label: "Partially approved",
+        badgeClass:
+          "border-status-info-border bg-status-info-bg text-status-info-fg",
+        cardClass: "border-status-info-border bg-status-info-bg/30",
+        iconClass: "text-status-info-fg",
+      };
+    case "pending":
+      // Legacy alias — treated like requested
+      return {
+        icon: Clock3,
+        label: "Awaiting approval",
+        badgeClass:
+          "border-status-warning-border bg-status-warning-bg text-status-warning-fg",
+        cardClass: "border-amber-500/20 bg-amber-500/[0.05]",
+        iconClass: "text-status-warning-fg",
+      };
+    case "signing":
+      return {
+        icon: Loader2,
+        label: "Signing…",
+        badgeClass: "border-red-500/30 bg-red-500/[0.08] text-red-200",
+        cardClass: "border-red-500/20 bg-red-500/[0.06]",
+        iconClass: "text-red-300",
+        spin: true,
+      };
+    case "approved":
+      return {
+        icon: CheckCircle2,
+        label: "Approved",
+        badgeClass:
+          "border-status-success-border bg-status-success-bg text-status-success-fg",
+        cardClass: "border-emerald-500/20 bg-emerald-500/[0.07]",
+        iconClass: "text-status-success-fg",
+      };
+    case "rejected":
+      return {
+        icon: XCircle,
+        label: "Rejected",
+        badgeClass:
+          "border-status-error-border bg-status-error-bg text-status-error-fg",
+        cardClass: "border-status-error-border bg-status-error-bg/20",
+        iconClass: "text-status-error-fg",
+      };
+    case "expired":
+      return {
+        icon: Timer,
+        label: "Expired",
+        badgeClass: "border-white/[0.06] bg-white/[0.02] text-gray-500",
+        cardClass: "border-white/[0.06] bg-white/[0.01] opacity-60",
+        iconClass: "text-gray-500",
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const fmt = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+function shortenAddress(addr: string) {
+  if (!addr || addr.length <= 14) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+function getInitial(addrOrName: string) {
+  return (addrOrName?.[0] ?? "?").toUpperCase();
+}
+
+// ---------------------------------------------------------------------------
+// Approver avatar strip
+// ---------------------------------------------------------------------------
+
+interface ApproverAvatarsProps {
+  signers: string[];
+  required: number;
+}
+
+function ApproverAvatars({ signers, required }: ApproverAvatarsProps) {
+  // Show up to `required` slots — filled or empty
+  const slots = Array.from({ length: required }, (_, i) => signers[i] ?? null);
+
+  return (
+    <div
+      className="flex items-center gap-1"
+      aria-label={`${signers.length} of ${required} approvers signed`}
+    >
+      {slots.map((signer, i) => (
+        <span
+          key={i}
+          title={signer ? signer : "Awaiting approver"}
+          aria-label={signer ? `Approved by ${shortenAddress(signer)}` : "Awaiting approver"}
+          className={`grid h-7 w-7 place-items-center rounded-full border text-[10px] font-bold transition-colors ${
+            signer
+              ? "border-status-success-border bg-status-success-bg text-status-success-fg"
+              : "border-white/10 bg-white/[0.03] text-gray-500"
+          }`}
+        >
+          {signer ? getInitial(signer) : "·"}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface ApprovalRequestCardProps {
+  item: ApprovalItem;
+  /** Whether the current viewer can act on this item */
+  canAct: boolean;
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * ApprovalRequestCard
+ *
+ * Displays a single multisig approval request with:
+ * - Requester identity (address + avatar)
+ * - Action type and optional amount
+ * - Approver progress (avatars/initials for each required slot, filled when signed)
+ * - Progress text: "{n} of {m} approvals"
+ * - Status badge — always text + icon, never colour alone (WCAG 2.1 AA)
+ * - Approve / Reject buttons when the item is actionable
+ *
+ * Terminal states (approved, rejected, expired) are rendered read-only.
+ */
+export default function ApprovalRequestCard({
+  item,
+  canAct,
+  onApprove,
+  onReject,
+}: ApprovalRequestCardProps) {
+  const pres = getStatusPresentation(item.status);
+  const StatusIcon = pres.icon;
+
+  const isActionable =
+    canAct &&
+    (item.status === "requested" ||
+      item.status === "partially_approved" ||
+      item.status === "pending");
+  const isSigning = item.status === "signing";
+
+  const actionLabel =
+    item.action === "add_member" ? "Add member" : "Update spending limit";
+
+  const progressText = `${item.collectedSignatures.length} of ${item.requiredSignatures} approval${item.requiredSignatures !== 1 ? "s" : ""}`;
+
+  return (
+    <article
+      className={`rounded-2xl border p-4 transition-colors ${pres.cardClass}`}
+      aria-label={`${actionLabel} request from ${shortenAddress(item.requester)}: ${pres.label}`}
+    >
+      {/* ── Top row: requester identity + status badge ── */}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        {/* Requester */}
+        <div className="flex items-center gap-2.5">
+          <span
+            aria-hidden="true"
+            className="grid h-8 w-8 flex-shrink-0 place-items-center rounded-full border border-red-500/20 bg-red-500/10 text-xs font-bold text-white"
+          >
+            {getInitial(item.requester)}
+          </span>
+          <div className="min-w-0">
+            <p className="text-xs font-semibold text-white">
+              {shortenAddress(item.requester)}
+            </p>
+            <p className="text-[10px] uppercase tracking-[0.14em] text-gray-500">
+              Requester
+            </p>
+          </div>
+        </div>
+
+        {/* Status badge — text + icon, never colour alone */}
+        <span
+          role="status"
+          aria-label={`Status: ${pres.label}`}
+          className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] ${pres.badgeClass}`}
+        >
+          <StatusIcon
+            className={`h-3 w-3 flex-shrink-0 ${pres.iconClass} ${pres.spin ? "animate-spin" : ""}`}
+            aria-hidden="true"
+          />
+          <span>{pres.label}</span>
+        </span>
+      </div>
+
+      {/* ── Action description ── */}
+      <div className="mt-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="flex items-center gap-1.5 text-sm font-semibold text-white">
+            <UserPlus className="h-3.5 w-3.5 flex-shrink-0 text-gray-400" aria-hidden="true" />
+            {item.label}
+          </span>
+          <span className="rounded-full border border-white/10 bg-white/[0.03] px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-gray-400">
+            {actionLabel}
+          </span>
+        </div>
+        {item.amount !== undefined && (
+          <p className="mt-1 text-xs text-gray-400">
+            Amount:{" "}
+            <span className="font-semibold text-white">{fmt.format(item.amount)}</span>
+          </p>
+        )}
+      </div>
+
+      {/* ── Approver progress ── */}
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2.5">
+          <ApproverAvatars
+            signers={item.collectedSignatures}
+            required={item.requiredSignatures}
+          />
+          <p className="text-xs text-gray-400">
+            <span className="font-semibold text-white">
+              {item.collectedSignatures.length}
+            </span>{" "}
+            of{" "}
+            <span className="font-semibold text-white">{item.requiredSignatures}</span>{" "}
+            approval{item.requiredSignatures !== 1 ? "s" : ""}
+          </p>
+        </div>
+      </div>
+
+      {/* ── Error message ── */}
+      {item.error && (
+        <p className="mt-2 text-xs text-status-error-fg" role="alert">
+          {item.error}
+        </p>
+      )}
+
+      {/* ── Approve / Reject actions ── */}
+      {(isActionable || isSigning) && (
+        <div className="mt-3 flex gap-2">
+          <button
+            type="button"
+            disabled={isSigning || !item.xdr}
+            onClick={() => onApprove(item.id)}
+            aria-label={`Approve ${item.label}`}
+            aria-describedby={`approval-progress-${item.id}`}
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-xl border border-status-success-border bg-status-success-bg px-3 py-2 text-xs font-semibold text-status-success-fg transition-colors hover:bg-emerald-500/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <CheckCircle2 className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+            {isSigning ? "Signing…" : "Approve"}
+          </button>
+          <button
+            type="button"
+            disabled={isSigning}
+            onClick={() => onReject(item.id)}
+            aria-label={`Reject ${item.label}`}
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-xl border border-status-error-border bg-status-error-bg px-3 py-2 text-xs font-semibold text-status-error-fg transition-colors hover:bg-red-500/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-400 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <XCircle className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+            Reject
+          </button>
+        </div>
+      )}
+
+      {/* Screen-reader progress announcement */}
+      <span id={`approval-progress-${item.id}`} className="sr-only">
+        {progressText}
+      </span>
+    </article>
+  );
+}

--- a/app/family/components/ApprovalsQueue.tsx
+++ b/app/family/components/ApprovalsQueue.tsx
@@ -1,113 +1,121 @@
 "use client";
 
-import { CheckCircle2, Clock3, Loader2, PenLine, Users, XCircle } from "lucide-react";
+import { CheckCircle2, ClipboardList, History, Timer, Users, XCircle } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { useWallet } from "stellar-wallet-kit";
 import { useClientTranslator } from "@/lib/i18n/client";
 import { useToast } from "@/lib/context/ToastContext";
 import AsyncSubmissionStatus from "@/components/AsyncSubmissionStatus";
 import WidgetEmptyState from "@/components/ui/WidgetEmptyState";
-import WidgetErrorState from "@/components/ui/WidgetErrorState";
 import { useApprovalsQueue, type ApprovalItem, type ApprovalStatus } from "@/lib/hooks/useApprovalsQueue";
+import ApprovalRequestCard from "./ApprovalRequestCard";
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Status helpers
 // ---------------------------------------------------------------------------
 
-const statusIcon: Record<ApprovalStatus, React.ElementType> = {
-  building: Loader2,
-  pending: Clock3,
-  signing: Loader2,
-  approved: CheckCircle2,
-  expired: XCircle,
-};
+/** Statuses that are still awaiting action */
+const PENDING_STATUSES: ApprovalStatus[] = ["building", "requested", "pending", "partially_approved", "signing"];
 
-const statusCardClass: Record<ApprovalStatus, string> = {
-  building: "border-white/10 bg-white/[0.02]",
-  pending: "border-amber-500/20 bg-amber-500/[0.05]",
-  signing: "border-red-500/20 bg-red-500/[0.06]",
-  approved: "border-emerald-500/20 bg-emerald-500/[0.07]",
-  expired: "border-white/[0.06] bg-white/[0.01] opacity-60",
-};
+/** Terminal statuses shown in history */
+const HISTORY_STATUSES: ApprovalStatus[] = ["approved", "rejected", "expired"];
 
-const statusIconClass: Record<ApprovalStatus, string> = {
-  building: "text-gray-400 animate-spin",
-  pending: "text-amber-300",
-  signing: "text-red-300 animate-spin",
-  approved: "text-emerald-300",
+// ---------------------------------------------------------------------------
+// History row — compact read-only representation
+// ---------------------------------------------------------------------------
+
+const historyIconClass: Partial<Record<ApprovalStatus, string>> = {
+  approved: "text-status-success-fg",
+  rejected: "text-status-error-fg",
   expired: "text-gray-500",
 };
 
-// ---------------------------------------------------------------------------
-// Single queue item row
-// ---------------------------------------------------------------------------
+const historyBadgeClass: Partial<Record<ApprovalStatus, string>> = {
+  approved:
+    "border-status-success-border bg-status-success-bg text-status-success-fg",
+  rejected:
+    "border-status-error-border bg-status-error-bg text-status-error-fg",
+  expired: "border-white/[0.06] bg-white/[0.02] text-gray-500",
+};
 
-interface QueueItemRowProps {
+const historyLabel: Partial<Record<ApprovalStatus, string>> = {
+  approved: "Approved",
+  rejected: "Rejected",
+  expired: "Expired",
+};
+
+const historyIcon: Partial<Record<ApprovalStatus, React.ElementType>> = {
+  approved: CheckCircle2,
+  rejected: XCircle,
+  expired: Timer,
+};
+
+interface HistoryRowProps {
   item: ApprovalItem;
-  onSign: (id: string) => void;
-  canSign: boolean;
-  t: (key: string, opts?: string | Record<string, unknown>) => string;
 }
 
-function QueueItemRow({ item, onSign, canSign, t }: QueueItemRowProps) {
-  const Icon = statusIcon[item.status];
-  const cardClass = statusCardClass[item.status];
-  const iconClass = statusIconClass[item.status];
-  const isPending = item.status === "pending";
-  const isSigning = item.status === "signing";
+function HistoryRow({ item }: HistoryRowProps) {
+  const Icon = historyIcon[item.status] ?? CheckCircle2;
+  const badge = historyBadgeClass[item.status] ?? "border-white/10 bg-white/[0.03] text-gray-400";
+  const iconCls = historyIconClass[item.status] ?? "text-gray-400";
+  const label = historyLabel[item.status] ?? item.status;
+  const actionLabel = item.action === "add_member" ? "Add member" : "Update limit";
 
-  const sigRatio = `${item.collectedSignatures.length}/${item.requiredSignatures}`;
-  const actionLabel = item.action === "add_member"
-    ? t("approvals_queue.action_add_member")
-    : t("approvals_queue.action_update_limit");
+  const fmt = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+
+  const date = new Date(item.createdAt).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
 
   return (
-    <article
-      className={`rounded-2xl border p-4 transition-colors ${cardClass}`}
-      aria-label={`${actionLabel}: ${item.label}`}
+    <li
+      className="flex items-start gap-3 rounded-xl border border-white/[0.06] bg-white/[0.01] px-3 py-3"
+      aria-label={`${actionLabel}: ${item.label} — ${label}`}
     >
-      <div className="flex items-start gap-3">
-        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/[0.03]">
-          <Icon className={`h-4 w-4 ${iconClass}`} aria-hidden="true" />
-        </div>
+      {/* Status icon */}
+      <div
+        className={`mt-0.5 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full border ${badge}`}
+        aria-hidden="true"
+      >
+        <Icon className={`h-3.5 w-3.5 ${iconCls}`} />
+      </div>
 
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-sm font-semibold text-white">{item.label}</span>
-            <span className="rounded-full border border-white/10 bg-white/[0.03] px-2 py-0.5 text-[11px] uppercase tracking-[0.14em] text-gray-400">
-              {actionLabel}
-            </span>
-          </div>
-
-          <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-gray-400">
-            <span>
-              {t("approvals_queue.signatures_label")}: {sigRatio}
-            </span>
-            <span aria-label={t("approvals_queue.status_aria", { status: item.status })}>
-              {t(`approvals_queue.status_${item.status}`)}
-            </span>
-          </div>
-
-          {item.error && (
-            <p className="mt-1 text-xs text-red-300" role="alert">
-              {item.error}
-            </p>
+      {/* Content */}
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-xs font-semibold text-white">{item.label}</span>
+          <span className="text-[10px] uppercase tracking-[0.14em] text-gray-500">
+            {actionLabel}
+          </span>
+          {item.amount !== undefined && (
+            <span className="text-[10px] text-gray-500">{fmt.format(item.amount)}</span>
           )}
         </div>
-
-        {(isPending || isSigning) && canSign && (
-          <button
-            type="button"
-            disabled={isSigning || !item.xdr}
-            onClick={() => onSign(item.id)}
-            aria-label={t("approvals_queue.sign_aria", { label: item.label })}
-            className="flex-shrink-0 rounded-xl border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-200 transition-colors hover:bg-red-500/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-400 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {isSigning ? t("approvals_queue.signing") : t("approvals_queue.sign")}
-          </button>
-        )}
+        <div className="mt-0.5 flex flex-wrap items-center gap-2 text-[10px] text-gray-500">
+          <span>{date}</span>
+          <span>·</span>
+          <span>
+            {item.collectedSignatures.length}/{item.requiredSignatures} sig
+            {item.requiredSignatures !== 1 ? "s" : ""}
+          </span>
+        </div>
       </div>
-    </article>
+
+      {/* Status badge */}
+      <span
+        role="status"
+        aria-label={`Status: ${label}`}
+        className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${badge}`}
+      >
+        <Icon className={`h-2.5 w-2.5 flex-shrink-0 ${iconCls}`} aria-hidden="true" />
+        <span>{label}</span>
+      </span>
+    </li>
   );
 }
 
@@ -126,7 +134,7 @@ export default function ApprovalsQueue({ hook }: ApprovalsQueueProps) {
   const { account, isConnected: connected, signTransaction } = useWallet();
   const address = account?.address ?? "";
   const internal = useApprovalsQueue();
-  const { queue, signItem, expireStale } = hook ?? internal;
+  const { queue, signItem, rejectItem, expireStale } = hook ?? internal;
 
   // Expire stale items on mount and every minute
   const expireRef = useRef(expireStale);
@@ -137,12 +145,16 @@ export default function ApprovalsQueue({ hook }: ApprovalsQueueProps) {
     return () => clearInterval(id);
   }, []);
 
-  const visibleQueue = queue.filter((i) => i.status !== "expired");
+  const pendingQueue = queue.filter((i) => PENDING_STATUSES.includes(i.status));
+  const historyQueue = queue.filter((i) => HISTORY_STATUSES.includes(i.status));
 
-  const handleSign = async (id: string) => {
+  const pendingCount = pendingQueue.filter(
+    (i) => i.status === "requested" || i.status === "partially_approved" || i.status === "pending"
+  ).length;
+
+  const handleApprove = async (id: string) => {
     if (!connected || !address) return;
     const result = await signItem(id, address, (xdr) =>
-      // Route through the wallet-kit signTransaction — no new primitive
       signTransaction(xdr, { networkPassphrase: undefined as unknown as string })
         .then((r) => (typeof r === "string" ? r : (r as { signedTxXdr: string }).signedTxXdr))
     );
@@ -163,14 +175,22 @@ export default function ApprovalsQueue({ hook }: ApprovalsQueueProps) {
     }
   };
 
-  const pendingCount = visibleQueue.filter((i) => i.status === "pending").length;
+  const handleReject = (id: string) => {
+    if (!connected || !address) return;
+    rejectItem(id, address);
+    toast({
+      variant: "error",
+      title: "Approval rejected",
+      description: "The approval request has been rejected.",
+    });
+  };
 
   return (
     <section
       aria-label={t("approvals_queue.section_aria")}
       className="rounded-3xl border border-white/[0.08] bg-[linear-gradient(180deg,rgba(18,18,18,0.98),rgba(10,10,10,0.98))] p-6 sm:p-7"
     >
-      {/* Header */}
+      {/* ── Header ── */}
       <div className="border-b border-white/[0.08] pb-5">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-red-300">
           {t("approvals_queue.eyebrow")}
@@ -180,8 +200,11 @@ export default function ApprovalsQueue({ hook }: ApprovalsQueueProps) {
             {t("approvals_queue.title")}
           </h2>
           {pendingCount > 0 && (
-            <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1 text-xs font-semibold text-amber-200">
-              {t("approvals_queue.pending_badge", { count: pendingCount })}
+            <span
+              aria-live="polite"
+              className="rounded-full border border-status-warning-border bg-status-warning-bg px-3 py-1 text-xs font-semibold text-status-warning-fg"
+            >
+              {pendingCount} pending
             </span>
           )}
         </div>
@@ -190,7 +213,7 @@ export default function ApprovalsQueue({ hook }: ApprovalsQueueProps) {
         </p>
       </div>
 
-      {/* Wallet connection status banner */}
+      {/* ── Wallet connection banner ── */}
       {!connected && (
         <div className="mt-5">
           <AsyncSubmissionStatus
@@ -202,9 +225,16 @@ export default function ApprovalsQueue({ hook }: ApprovalsQueueProps) {
         </div>
       )}
 
-      {/* Queue list */}
+      {/* ── Pending approvals ── */}
       <div className="mt-5">
-        {visibleQueue.length === 0 ? (
+        <div className="mb-3 flex items-center gap-2">
+          <ClipboardList className="h-3.5 w-3.5 text-gray-500" aria-hidden="true" />
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-500">
+            Pending approvals
+          </p>
+        </div>
+
+        {pendingQueue.length === 0 ? (
           <WidgetEmptyState
             icon={Users}
             title={t("approvals_queue.empty_title")}
@@ -215,13 +245,13 @@ export default function ApprovalsQueue({ hook }: ApprovalsQueueProps) {
             className="space-y-3"
             aria-label={t("approvals_queue.list_aria")}
           >
-            {visibleQueue.map((item) => (
+            {pendingQueue.map((item) => (
               <li key={item.id}>
-                <QueueItemRow
+                <ApprovalRequestCard
                   item={item}
-                  onSign={handleSign}
-                  canSign={connected}
-                  t={t}
+                  canAct={connected}
+                  onApprove={handleApprove}
+                  onReject={handleReject}
                 />
               </li>
             ))}
@@ -229,7 +259,27 @@ export default function ApprovalsQueue({ hook }: ApprovalsQueueProps) {
         )}
       </div>
 
-      {/* Footer note */}
+      {/* ── Approval history ── */}
+      {historyQueue.length > 0 && (
+        <div className="mt-6 border-t border-white/[0.06] pt-5">
+          <div className="mb-3 flex items-center gap-2">
+            <History className="h-3.5 w-3.5 text-gray-500" aria-hidden="true" />
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-500">
+              History
+            </p>
+          </div>
+          <ol
+            className="space-y-2"
+            aria-label="Approval history"
+          >
+            {historyQueue.map((item) => (
+              <HistoryRow key={item.id} item={item} />
+            ))}
+          </ol>
+        </div>
+      )}
+
+      {/* ── Footer note ── */}
       <p className="mt-5 text-xs leading-5 text-gray-500">
         {t("approvals_queue.footer")}
       </p>

--- a/docs/family-multisig-approval-ux.md
+++ b/docs/family-multisig-approval-ux.md
@@ -1,0 +1,187 @@
+# Family Multisig Approval UX
+
+## Overview
+
+Member-management actions on a Family Wallet — adding a member or updating a spending limit — require multi-signature approval before the underlying Stellar transaction can be submitted. This document covers the UX state machine, component anatomy, and role definitions that govern the approval flow.
+
+---
+
+## State machine
+
+```
+Admin initiates action
+        │
+        ▼
+useApprovalsQueue.enqueueAddMember() / enqueueUpdateLimit()
+        │
+        ├─ dispatch ENQUEUE         → status: building
+        │                             (XDR is being constructed)
+        ▼
+buildAddMemberTx() / buildUpdateSpendingLimitTx() resolves
+        │
+        ├─ dispatch SET_XDR         → status: requested
+        │                             (awaiting first approval)
+        ▼
+Approver clicks Approve on ApprovalRequestCard
+        │
+        ├─ dispatch SET_STATUS      → status: signing
+        │                             (wallet modal is open)
+        ▼
+wallet-kit signTransaction() resolves
+        │
+        ├─ dispatch ADD_SIGNATURE
+        │     ├─ collected < required  → status: partially_approved
+        │     └─ collected >= required → status: approved  ✓ terminal
+        │
+Approver clicks Reject
+        │
+        └─ dispatch REJECT          → status: rejected  ✗ terminal
+
+EXPIRE_ALL (runs on mount + every 60 s)
+        │
+        └─ requested | partially_approved older than 30 min → status: expired  ✗ terminal
+```
+
+### State definitions
+
+| Status | Semantics | Terminal? |
+|--------|-----------|-----------|
+| `building` | XDR is being constructed by the contract helper | No |
+| `requested` | XDR ready; awaiting the first required signature | No |
+| `partially_approved` | At least one signature collected; more still required | No |
+| `signing` | Current user's wallet modal is open (transient) | No |
+| `approved` | All required signatures collected | **Yes** |
+| `rejected` | An authorised approver rejected the request | **Yes** |
+| `expired` | No action taken within 30 minutes (`APPROVAL_TTL_MS`) | **Yes** |
+
+Non-terminal states accept Approve and Reject actions. Terminal states are read-only and appear in the history list.
+
+---
+
+## Component anatomy
+
+### `ApprovalRequestCard`
+
+File: `app/family/components/ApprovalRequestCard.tsx`
+
+```
+┌──────────────────────────────────────────────────────┐
+│ [Avatar] GDEMO1… / Requester       [Status badge 🕐] │
+├──────────────────────────────────────────────────────┤
+│ [Icon] Add GDEMO2…          [Action type pill]       │
+│ Amount: $500                                         │
+├──────────────────────────────────────────────────────┤
+│ [●] [·] [·]   1 of 3 approvals                      │
+│   filled avatars = signed; empty dots = awaiting     │
+├──────────────────────────────────────────────────────┤
+│ [✓ Approve]          [✗ Reject]                      │
+└──────────────────────────────────────────────────────┘
+```
+
+**Props:**
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `item` | `ApprovalItem` | The queue item to display |
+| `canAct` | `boolean` | Whether the viewer can approve/reject (wallet connected) |
+| `onApprove` | `(id: string) => void` | Called when Approve is clicked |
+| `onReject` | `(id: string) => void` | Called when Reject is clicked |
+
+### `ApprovalsQueue`
+
+File: `app/family/components/ApprovalsQueue.tsx`
+
+Renders two sections inside a `<section>` panel:
+
+1. **Pending approvals** — items with non-terminal status (`building`, `requested`, `partially_approved`, `signing`). Each item rendered as `<ApprovalRequestCard>`. Shows "No pending approvals" empty state when list is empty.
+2. **History** — items with terminal status (`approved`, `rejected`, `expired`). Rendered as compact `<HistoryRow>` entries. Only shown when there are history items.
+
+### `useApprovalsQueue` hook
+
+File: `lib/hooks/useApprovalsQueue.ts`
+
+Extended with:
+- `rejectItem(id, rejectorAddress)` — transitions `requested | partially_approved → rejected`.
+- `requester` field on `ApprovalItem` — Stellar address of the initiating admin.
+- `amount` field on `ApprovalItem` — the spending limit value involved.
+- `ADD_SIGNATURE` now produces `partially_approved` when `collected < required` (previously always `pending`).
+- `EXPIRE_ALL` targets `requested | partially_approved` instead of just `pending`.
+
+---
+
+## Status presentation tokens
+
+Status is **never conveyed by colour alone** (WCAG 2.1 AA). Each status uses both an icon and a text label in all contexts.
+
+| Status | Tone | Token classes | Icon |
+|--------|------|---------------|------|
+| `requested` | warning | `border-status-warning-border bg-status-warning-bg text-status-warning-fg` | `Clock3` |
+| `partially_approved` | info | `border-status-info-border bg-status-info-bg text-status-info-fg` | `GitMerge` |
+| `approved` | success | `border-status-success-border bg-status-success-bg text-status-success-fg` | `CheckCircle2` |
+| `rejected` | error | `border-status-error-border bg-status-error-bg text-status-error-fg` | `XCircle` |
+| `expired` | neutral | `border-white/[0.06] bg-white/[0.02] text-gray-500` | `Timer` |
+| `building` | neutral | `border-white/10 bg-white/[0.03] text-gray-400` | `Loader2` (spin) |
+| `signing` | — | `border-red-500/30 bg-red-500/[0.08] text-red-200` | `Loader2` (spin) |
+
+---
+
+## Role definitions
+
+Tied to `UnderstandingRolesSection` content (file: `app/family/components/UnderstandingRolesSection.tsx`):
+
+### Admin (Crown icon, amber accent)
+- Can initiate any member-management action (`add_member`, `update_spending_limit`).
+- Appears as **requester** on all approval cards.
+- Can approve or reject approval requests raised by other admins.
+- Required signature count is set at enqueue time (`requiredSignatures`).
+
+### Sender (Send icon, sky accent)
+- Can send transactions within their spending limit.
+- Cannot initiate member-management actions.
+- May appear as an approver if the wallet contract requires non-admin co-signers (future).
+
+### Recipient (Wallet icon, emerald accent)
+- Receives funds; cannot initiate or approve member-management actions.
+- Cannot interact with the ApprovalRequestCard.
+
+### Approver slots
+
+The `ApproverAvatars` sub-component renders one avatar per required signature slot. Filled slots (signed) display the first character of the signer's Stellar address; empty slots show a placeholder dot. Each avatar has a descriptive `aria-label` and `title` for keyboard and screen-reader users.
+
+---
+
+## Accessibility
+
+- All status badges carry `role="status"` and `aria-label="Status: {label}"`.
+- `ApprovalRequestCard` `<article>` has a full descriptive `aria-label` combining action type, requester, and status.
+- Approve and Reject buttons have explicit `aria-label` attributes that include the item label.
+- Approve button is linked to the progress description via `aria-describedby`.
+- A `.sr-only` span broadcasts the signature progress for screen readers.
+- `ApproverAvatars` container has `aria-label` summarising `{n} of {m} approvers signed`.
+- Error messages use `role="alert"`.
+- History list uses `<ol>` with `aria-label="Approval history"`.
+- Pending list uses `<ol>` with `aria-label` drawn from the `approvals_queue.list_aria` i18n key.
+- Pending badge count uses `aria-live="polite"`.
+- Button focus rings: `focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2` on both action buttons.
+
+---
+
+## Layout integration
+
+`ApprovalsQueue` sits in the sticky aside column of `app/family/page.tsx`, above `UnderstandingRolesSection`:
+
+```
+<aside class="space-y-8 xl:sticky xl:top-6">
+  <ApprovalsQueue />           ← pending cards + history
+  <UnderstandingRolesSection />
+  <!-- add-member form -->
+</aside>
+```
+
+The card's inner layout is responsive — wraps at narrow widths (375 px) and expands at 1280 px using `flex-wrap` throughout.
+
+---
+
+## i18n
+
+All string keys are under `approvals_queue.*` in `lib/i18n/locales/en.json` and `es.json`. New hardcoded strings in `ApprovalRequestCard` (e.g. "Approver", "Approve", "Reject", action labels, progress text) should be moved to i18n keys once the translation pipeline is ready.

--- a/lib/hooks/useApprovalsQueue.ts
+++ b/lib/hooks/useApprovalsQueue.ts
@@ -8,7 +8,7 @@ import type { FamilyMemberRole } from "@/utils/types/family-wallet.types";
 // Types
 // ---------------------------------------------------------------------------
 
-export type ApprovalStatus = "building" | "pending" | "signing" | "approved" | "expired";
+export type ApprovalStatus = "building" | "requested" | "pending" | "partially_approved" | "signing" | "approved" | "rejected" | "expired";
 
 export type ApprovalAction = "add_member" | "update_spending_limit";
 
@@ -25,6 +25,10 @@ export interface ApprovalItem {
   createdAt: string;
   requiredSignatures: number;
   collectedSignatures: string[];
+  /** Stellar address of the requester who initiated this approval */
+  requester: string;
+  /** Amount involved in the action (e.g. spending limit value) */
+  amount?: number;
   error?: string;
 }
 
@@ -37,6 +41,7 @@ type QueueAction =
   | { type: "SET_XDR"; id: string; xdr: string }
   | { type: "SET_STATUS"; id: string; status: ApprovalStatus; error?: string }
   | { type: "ADD_SIGNATURE"; id: string; signer: string }
+  | { type: "REJECT"; id: string; rejector: string }
   | { type: "EXPIRE_ALL" };
 
 /** 30 minutes before an unacted-on approval is considered expired */
@@ -49,7 +54,7 @@ export function queueReducer(state: ApprovalItem[], action: QueueAction): Approv
 
     case "SET_XDR":
       return state.map((item) =>
-        item.id === action.id ? { ...item, xdr: action.xdr, status: "pending" } : item
+        item.id === action.id ? { ...item, xdr: action.xdr, status: "requested" } : item
       );
 
     case "SET_STATUS":
@@ -65,20 +70,33 @@ export function queueReducer(state: ApprovalItem[], action: QueueAction): Approv
         // Idempotent — ignore duplicate signer
         if (item.collectedSignatures.includes(action.signer)) return item;
         const collected = [...item.collectedSignatures, action.signer];
-        const approved = collected.length >= item.requiredSignatures;
+        const fullyApproved = collected.length >= item.requiredSignatures;
+        const newStatus: ApprovalStatus = fullyApproved
+          ? "approved"
+          : collected.length > 0
+          ? "partially_approved"
+          : "requested";
         return {
           ...item,
           collectedSignatures: collected,
-          status: approved ? "approved" : "pending",
+          status: newStatus,
           error: undefined,
         };
+      });
+    }
+
+    case "REJECT": {
+      return state.map((item) => {
+        if (item.id !== action.id) return item;
+        return { ...item, status: "rejected" as ApprovalStatus, error: undefined };
       });
     }
 
     case "EXPIRE_ALL": {
       const cutoff = Date.now() - APPROVAL_TTL_MS;
       return state.map((item) =>
-        item.status === "pending" && new Date(item.createdAt).getTime() < cutoff
+        (item.status === "requested" || item.status === "partially_approved") &&
+        new Date(item.createdAt).getTime() < cutoff
           ? { ...item, status: "expired" }
           : item
       );
@@ -100,14 +118,12 @@ export interface EnqueueAddMemberParams {
   spendingLimit: number;
   requiredSignatures?: number;
 }
-
 export interface EnqueueUpdateLimitParams {
   callerAddress: string;
   memberId: string;
   newLimit: number;
   requiredSignatures?: number;
 }
-
 export interface SignItemResult {
   success: boolean;
   approved: boolean;
@@ -128,6 +144,11 @@ export interface UseApprovalsQueueReturn {
     signerAddress: string,
     signXdr: (xdr: string) => Promise<string>
   ) => Promise<SignItemResult | undefined>;
+  /**
+   * Reject an approval request.
+   * The item is moved to `rejected` state immediately.
+   */
+  rejectItem: (id: string, rejectorAddress: string) => void;
   /** Mark any items older than APPROVAL_TTL_MS as expired */
   expireStale: () => void;
 }
@@ -171,6 +192,8 @@ export function useApprovalsQueue(): UseApprovalsQueueReturn {
           createdAt: new Date().toISOString(),
           requiredSignatures,
           collectedSignatures: [],
+          requester: adminAddress,
+          amount: spendingLimit,
         },
       });
 
@@ -209,6 +232,8 @@ export function useApprovalsQueue(): UseApprovalsQueueReturn {
           createdAt: new Date().toISOString(),
           requiredSignatures,
           collectedSignatures: [],
+          requester: callerAddress,
+          amount: newLimit,
         },
       });
 
@@ -234,7 +259,9 @@ export function useApprovalsQueue(): UseApprovalsQueueReturn {
       signXdr: (xdr: string) => Promise<string>
     ): Promise<SignItemResult | undefined> => {
       const item = queue.find((i) => i.id === id);
-      if (!item || item.status !== "pending") return;
+      if (!item) return;
+      // Allow signing on requested or partially_approved
+      if (item.status !== "requested" && item.status !== "partially_approved" && item.status !== "pending") return;
       if (item.collectedSignatures.includes(signerAddress)) return;
 
       dispatch({ type: "SET_STATUS", id, status: "signing" });
@@ -248,11 +275,13 @@ export function useApprovalsQueue(): UseApprovalsQueueReturn {
           item.collectedSignatures.length + 1 >= item.requiredSignatures;
         return { success: true, approved };
       } catch (err) {
-        // Revert to pending so the user can retry
+        // Revert to the pre-signing status so the user can retry
+        const revertStatus: ApprovalStatus =
+          item.collectedSignatures.length > 0 ? "partially_approved" : "requested";
         dispatch({
           type: "SET_STATUS",
           id,
-          status: "pending",
+          status: revertStatus,
           error: err instanceof Error ? err.message : "Signing failed",
         });
         return {
@@ -265,9 +294,19 @@ export function useApprovalsQueue(): UseApprovalsQueueReturn {
     [queue]
   );
 
+  const rejectItem = useCallback(
+    (id: string, rejectorAddress: string) => {
+      const item = queue.find((i) => i.id === id);
+      if (!item) return;
+      if (item.status !== "requested" && item.status !== "partially_approved") return;
+      dispatch({ type: "REJECT", id, rejector: rejectorAddress });
+    },
+    [queue]
+  );
+
   const expireStale = useCallback(() => {
     dispatch({ type: "EXPIRE_ALL" });
   }, []);
 
-  return { queue, enqueueAddMember, enqueueUpdateLimit, signItem, expireStale };
+  return { queue, enqueueAddMember, enqueueUpdateLimit, signItem, rejectItem, expireStale };
 }


### PR DESCRIPTION
- Add ApprovalRequestCard component: requester identity, action/amount, approver avatar strip (filled/empty slots), progress text, approve/reject buttons; status always conveyed by icon + text (WCAG 2.1 AA)
- Extend ApprovalStatus with requested, partially_approved, rejected
- Add requester and amount fields to ApprovalItem
- Add rejectItem() to useApprovalsQueue hook
- ADD_SIGNATURE now produces partially_approved when below threshold
- ApprovalsQueue: pending section uses ApprovalRequestCard; history section shows terminal items (approved/rejected/expired) as compact HistoryRow; empty state shown when no pending approvals
- Add docs/family-multisig-approval-ux.md: state machine, component anatomy, status token table, role definitions, a11y notes
Closes #1304 