### PR TITLE
feat: honour Save-Data header with lower-fi chart fallbacks

### DIFF
--- a/components/Dashboard/MoneyDistributionWidget.tsx
+++ b/components/Dashboard/MoneyDistributionWidget.tsx
@@ -10,6 +10,7 @@ import { useClientTranslator } from "@/lib/i18n/client";
 import { buildChartImageLabel, buildChartSummary } from "@/lib/a11y/chart";
 import { useWidgetDeepLink } from "@/lib/hooks/useWidgetDeepLink";
 import { WIDGET_IDS } from "@/lib/config/widgets";
+import { useSaveData } from "@/lib/hooks/useSaveData";
 
 const data = [
   { name: "Remittances", value: 58, amount: "$3,240", displayPercent: "57.5%", color: "#dc2626" },
@@ -54,6 +55,7 @@ function MoneyDistributionWidget({
   const [retryKey, setRetryKey] = useState(0);
   const summaryId = useId();
   const { t } = useClientTranslator();
+  const saveData = useSaveData();
 
   // Deep-link: scrolls & highlights this widget when ?widget=money-distribution
   const widgetRef = useWidgetDeepLink(WIDGET_IDS.MONEY_DISTRIBUTION);
@@ -113,17 +115,56 @@ function MoneyDistributionWidget({
         <WidgetEmptyState icon={PieChartIcon} title="No distribution data yet" description="Set up your money split to see how your funds are allocated." ctaLabel="Set up your split" ctaHref="/split" />
       ) : (
         <div className="mt-8 flex flex-col gap-10 items-start">
-          <div className="h-[280px] w-full" role="img" aria-label={ariaLabel} aria-describedby={summaryId}>
-            <ResponsiveContainer width="100%" height="100%">
-              <PieChart aria-hidden="true">
-                <Pie data={distributionData} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={110} innerRadius={0} startAngle={90} endAngle={-270} labelLine={false} label={renderLabel} stroke="rgba(255,255,255,0.35)" strokeWidth={1}>
-                  {distributionData.map((entry) => (
-                    <Cell key={entry.name} fill={entry.color} />
-                  ))}
-                </Pie>
-              </PieChart>
-            </ResponsiveContainer>
-          </div>
+          {saveData ? (
+            /* Save-Data fallback: bar list, no PieChart SVG or animation cost */
+            <ul className="w-full space-y-3" aria-label={ariaLabel}>
+              {distributionData.map((item) => (
+                <li key={item.name}>
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-sm font-medium text-white flex items-center gap-2">
+                      <span
+                        className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
+                        style={{ backgroundColor: item.color }}
+                        aria-hidden="true"
+                      />
+                      {item.name}
+                    </span>
+                    <span className="text-sm font-bold text-white">
+                      {item.amount}{' '}
+                      <span className="text-xs text-white/40 font-normal">
+                        ({item.displayPercent ?? `${item.value}%`})
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="w-full bg-white/5 h-2 rounded-full overflow-hidden"
+                    role="presentation"
+                  >
+                    <div
+                      className="h-full rounded-full"
+                      style={{
+                        width: `${item.value}%`,
+                        backgroundColor: item.color,
+                      }}
+                    />
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            /* Full interactive PieChart */
+            <div className="h-[280px] w-full" role="img" aria-label={ariaLabel} aria-describedby={summaryId}>
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart aria-hidden="true">
+                  <Pie data={distributionData} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={110} innerRadius={0} startAngle={90} endAngle={-270} labelLine={false} label={renderLabel} stroke="rgba(255,255,255,0.35)" strokeWidth={1}>
+                    {distributionData.map((entry) => (
+                      <Cell key={entry.name} fill={entry.color} />
+                    ))}
+                  </Pie>
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+          )}
 
           <p id={summaryId} className="sr-only">{summaryText}</p>
 

--- a/components/Dashboard/SixMonthTrendsWidget.tsx
+++ b/components/Dashboard/SixMonthTrendsWidget.tsx
@@ -10,8 +10,7 @@ import WidgetErrorState from '@/components/ui/WidgetErrorState'
 import { useWidgetDeepLink } from '@/lib/hooks/useWidgetDeepLink'
 import { WIDGET_IDS } from '@/lib/config/widgets'
 import { buildChartImageLabel, buildChartSummary } from '@/lib/a11y/chart'
-import { useWidgetDeepLink } from '@/lib/hooks/useWidgetDeepLink'
-import { WIDGET_IDS } from '@/lib/config/widgets'
+import { useSaveData } from '@/lib/hooks/useSaveData'
 
 // Sample data for the 6-month chart (Jul-Dec)
 function tooltipFormatter(value: any, name: any, item: any, index: any, payload: any) {
@@ -145,6 +144,7 @@ export default memo(function SixMonthTrendsWidget({ isLoading = false, hasError 
     const widgetRef = useWidgetDeepLink(WIDGET_IDS.SIX_MONTH_TRENDS);
     const [retryKey, setRetryKey] = useState(0)
     const handleRetry = useCallback(() => setRetryKey((k) => k + 1), [])
+    const saveData = useSaveData()
 
     const tooltipFormatter = useCallback((value: unknown, name: unknown) => {
         const numeric = typeof value === 'number' ? value : Number(value)
@@ -235,24 +235,56 @@ export default memo(function SixMonthTrendsWidget({ isLoading = false, hasError 
                 </button>
             </div>
 
-            {/* Chart */}
-            <div className="w-full h-[280px] sm:h-[320px]" role="img" aria-label={chartLabel}>
-                <ResponsiveContainer width="100%" height="100%">
-                    <LineChart data={chartData} margin={{ top: 5, right: 5, left: -10, bottom: 5 }} aria-hidden="true">
-                        <CartesianGrid strokeDasharray="3 3" stroke="rgba(255, 255, 255, 0.063)" vertical={true} />
-                        <XAxis dataKey="month" axisLine={{ stroke: 'rgba(255, 255, 255, 0.25)' }} tickLine={{ stroke: 'rgba(255, 255, 255, 0.25)' }} tick={{ fill: 'rgba(255, 255, 255, 0.376)', fontSize: 12, fontWeight: 400 }} />
-                        <YAxis axisLine={{ stroke: 'rgba(255, 255, 255, 0.25)' }} tickLine={{ stroke: 'rgba(255, 255, 255, 0.25)' }} tick={{ fill: 'rgba(255, 255, 255, 0.376)', fontSize: 12, fontWeight: 400 }} tickFormatter={(value) => `$${value}`} domain={[0, 3400]} ticks={[0, 850, 1700, 2550, 3400]} width={45} />
-                        <Tooltip contentStyle={TOOLTIP_CONTENT_STYLE} labelStyle={TOOLTIP_LABEL_STYLE} formatter={tooltipFormatter} />
-                        <Legend content={<CustomLegend />} />
-                        <Line type="monotone" dataKey="remittances" stroke={COLORS.remittances} strokeWidth={3} dot={DOT_REMITTANCES} activeDot={ACTIVE_DOT} />
-                        <Line type="monotone" dataKey="savings"     stroke={COLORS.savings}     strokeWidth={3} dot={DOT_SAVINGS}     activeDot={ACTIVE_DOT} />
-                        <Line type="monotone" dataKey="bills"       stroke={COLORS.bills}       strokeWidth={3} dot={DOT_BILLS}       activeDot={ACTIVE_DOT} />
-                        <Line type="monotone" dataKey="insurance"   stroke={COLORS.insurance}   strokeWidth={3} dot={DOT_INSURANCE}   activeDot={ACTIVE_DOT} />
-                    </LineChart>
-                </ResponsiveContainer>
-            </div>
+            {saveData ? (
+                /* Save-Data fallback: plain table, no Recharts bundle cost */
+                <div className="w-full overflow-x-auto">
+                    <table className="w-full text-sm text-white/80 border-collapse">
+                        <caption className="sr-only">6-Month financial trends</caption>
+                        <thead>
+                            <tr className="border-b border-white/10">
+                                <th scope="col" className="py-2 pr-4 text-left font-semibold text-white/60">Month</th>
+                                <th scope="col" className="py-2 pr-4 text-right font-semibold text-white/60">Remittances</th>
+                                <th scope="col" className="py-2 pr-4 text-right font-semibold text-white/60">Savings</th>
+                                <th scope="col" className="py-2 pr-4 text-right font-semibold text-white/60">Bills</th>
+                                <th scope="col" className="py-2 text-right font-semibold text-white/60">Insurance</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {chartData.map((row) => (
+                                <tr key={row.month} className="border-b border-white/5 last:border-0">
+                                    <td className="py-2 pr-4 font-medium">{row.month}</td>
+                                    <td className="py-2 pr-4 text-right">${row.remittances.toLocaleString()}</td>
+                                    <td className="py-2 pr-4 text-right">${row.savings.toLocaleString()}</td>
+                                    <td className="py-2 pr-4 text-right">${row.bills.toLocaleString()}</td>
+                                    <td className="py-2 text-right">${row.insurance.toLocaleString()}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            ) : (
+                /* Full interactive chart */
+                <>
+                    {/* Chart */}
+                    <div className="w-full h-[280px] sm:h-[320px]" role="img" aria-label={chartLabel}>
+                        <ResponsiveContainer width="100%" height="100%">
+                            <LineChart data={chartData} margin={{ top: 5, right: 5, left: -10, bottom: 5 }} aria-hidden="true">
+                                <CartesianGrid strokeDasharray="3 3" stroke="rgba(255, 255, 255, 0.063)" vertical={true} />
+                                <XAxis dataKey="month" axisLine={{ stroke: 'rgba(255, 255, 255, 0.25)' }} tickLine={{ stroke: 'rgba(255, 255, 255, 0.25)' }} tick={{ fill: 'rgba(255, 255, 255, 0.376)', fontSize: 12, fontWeight: 400 }} />
+                                <YAxis axisLine={{ stroke: 'rgba(255, 255, 255, 0.25)' }} tickLine={{ stroke: 'rgba(255, 255, 255, 0.25)' }} tick={{ fill: 'rgba(255, 255, 255, 0.376)', fontSize: 12, fontWeight: 400 }} tickFormatter={(value) => `$${value}`} domain={[0, 3400]} ticks={[0, 850, 1700, 2550, 3400]} width={45} />
+                                <Tooltip contentStyle={TOOLTIP_CONTENT_STYLE} labelStyle={TOOLTIP_LABEL_STYLE} formatter={tooltipFormatter} />
+                                <Legend content={<CustomLegend />} />
+                                <Line type="monotone" dataKey="remittances" stroke={COLORS.remittances} strokeWidth={3} dot={DOT_REMITTANCES} activeDot={ACTIVE_DOT} />
+                                <Line type="monotone" dataKey="savings"     stroke={COLORS.savings}     strokeWidth={3} dot={DOT_SAVINGS}     activeDot={ACTIVE_DOT} />
+                                <Line type="monotone" dataKey="bills"       stroke={COLORS.bills}       strokeWidth={3} dot={DOT_BILLS}       activeDot={ACTIVE_DOT} />
+                                <Line type="monotone" dataKey="insurance"   stroke={COLORS.insurance}   strokeWidth={3} dot={DOT_INSURANCE}   activeDot={ACTIVE_DOT} />
+                            </LineChart>
+                        </ResponsiveContainer>
+                    </div>
 
-            <p className="sr-only" aria-live="polite">{chartSummary}</p>
+                    <p className="sr-only" aria-live="polite">{chartSummary}</p>
+                </>
+            )}
 
             {/* Summary Cards */}
             <div className="w-full border-t border-[rgba(255,255,255,0.08)] pt-[25px]">

--- a/components/Insights/categoryDonutChart.tsx
+++ b/components/Insights/categoryDonutChart.tsx
@@ -2,6 +2,7 @@
 
 import { useId, useState, useMemo, useCallback, memo } from 'react'
 import { usePrefersReducedMotion } from '@/lib/hooks/usePrefersReducedMotion'
+import { useSaveData } from '@/lib/hooks/useSaveData'
 import {
   PieChart,
   Pie,
@@ -113,6 +114,7 @@ function CategoryDonutChartInner({ data = MOCK_CATEGORY_DATA }: CategoryDonutCha
   const chartSummary = buildChartSummary(summaryItems, t);
   const [activeCategory, setActiveCategory] = useState<CategoryDataPoint | null>(null)
   const reducedMotion = usePrefersReducedMotion()
+  const saveData = useSaveData()
 
   const total = useMemo(() => data.reduce((s, d) => s + d.amount, 0), [data])
   const topCat = useMemo(() => data[0], [data])
@@ -165,87 +167,126 @@ function CategoryDonutChartInner({ data = MOCK_CATEGORY_DATA }: CategoryDonutCha
       {/* Chart + legend layout */}
       <div className="flex flex-col sm:flex-row items-center gap-6">
 
-        {/* Donut */}
-        <div className="w-full sm:w-auto flex-shrink-0" role="img" aria-label={ariaLabel} aria-describedby={summaryId}>
-          <ResponsiveContainer width="100%" height={200}>
-            <PieChart aria-hidden="true">
-              <Pie
-                data={data}
-                cx="50%"
-                cy="50%"
-                innerRadius={60}
-                outerRadius={90}
-                paddingAngle={3}
-                dataKey="amount"
-                stroke="none"
-                isAnimationActive={!reducedMotion}
-                onMouseEnter={handleMouseEnter}
-                onMouseLeave={handleMouseLeave}
-                onClick={handleClick}
-                style={pieStyle}
-              >
-                {cells}
-              </Pie>
-
-              {/* Center label rendered as custom content */}
-              <text>
-                <CenterLabel cx={0} cy={0} active={activeCategory} total={total} />
-              </text>
-
-              <Tooltip content={CustomTooltip} />
-            </PieChart>
-          </ResponsiveContainer>
-        </div>
-
-        {/* Legend rows — interactive */}
-        <div className="w-full space-y-3">
-          {data.map((item, index) => {
-            const color     = SLICE_COLORS[index % SLICE_COLORS.length]
-            const isActive  = activeCategory?.name === item.name
-            const isDimmed  = activeCategory !== null && !isActive
-
-            return (
-              <button
-                key={item.name}
-                type="button"
-                onClick={() =>
-                  setActiveCategory(prev =>
-                    prev?.name === item.name ? null : item
-                  )
-                }
-                className={`w-full text-left space-y-1.5 transition-opacity ${
-                  isDimmed ? 'opacity-40' : 'opacity-100'
-                }`}
-              >
-                <div className="flex justify-between items-center">
-                  <div className="flex items-center gap-2">
-                    <span
-                      className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
-                      style={{ backgroundColor: color }}
+        {saveData ? (
+          /* Save-Data fallback: static progress bars, no PieChart/animation */
+          <div className="w-full space-y-3" aria-label={ariaLabel}>
+            {data.map((item, index) => {
+              const color = SLICE_COLORS[index % SLICE_COLORS.length]
+              return (
+                <div key={item.name} className="space-y-1.5">
+                  <div className="flex justify-between items-center">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
+                        style={{ backgroundColor: color }}
+                        aria-hidden="true"
+                      />
+                      <span className="text-white text-sm font-medium">{item.name}</span>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <span className="text-white font-bold text-sm">
+                        ${item.amount.toLocaleString()}
+                      </span>
+                      <span className="text-gray-500 text-xs w-8 text-right">
+                        {item.percentage}%
+                      </span>
+                    </div>
+                  </div>
+                  <div className="w-full bg-white/5 h-1.5 rounded-full overflow-hidden" role="presentation">
+                    <div
+                      className="h-full rounded-full"
+                      style={{ width: `${item.percentage}%`, backgroundColor: color }}
                     />
-                    <span className="text-white text-sm font-medium">{item.name}</span>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <span className="text-white font-bold text-sm">
-                      ${item.amount.toLocaleString()}
-                    </span>
-                    <span className="text-gray-500 text-xs w-8 text-right">
-                      {item.percentage}%
-                    </span>
                   </div>
                 </div>
+              )
+            })}
+          </div>
+        ) : (
+          <>
+            {/* Donut */}
+            <div className="w-full sm:w-auto flex-shrink-0" role="img" aria-label={ariaLabel} aria-describedby={summaryId}>
+              <ResponsiveContainer width="100%" height={200}>
+                <PieChart aria-hidden="true">
+                  <Pie
+                    data={data}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={60}
+                    outerRadius={90}
+                    paddingAngle={3}
+                    dataKey="amount"
+                    stroke="none"
+                    isAnimationActive={!reducedMotion}
+                    onMouseEnter={handleMouseEnter}
+                    onMouseLeave={handleMouseLeave}
+                    onClick={handleClick}
+                    style={pieStyle}
+                  >
+                    {cells}
+                  </Pie>
 
-                {/* Progress bar */}
-                <div className="w-full bg-white/5 h-1.5 rounded-full overflow-hidden">
-                  <div
-                    className={`h-full rounded-full ${reducedMotion ? '' : 'transition-all duration-700 ease-out'}`}
-                    style={{ width: `${item.percentage}%`, backgroundColor: color }}
-                  />
-                </div>
-              </button>
-            )
-          })}
-        </div>
+                  {/* Center label rendered as custom content */}
+                  <text>
+                    <CenterLabel cx={0} cy={0} active={activeCategory} total={total} />
+                  </text>
+
+                  <Tooltip content={CustomTooltip} />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+
+            {/* Legend rows — interactive */}
+            <div className="w-full space-y-3">
+              {data.map((item, index) => {
+                const color     = SLICE_COLORS[index % SLICE_COLORS.length]
+                const isActive  = activeCategory?.name === item.name
+                const isDimmed  = activeCategory !== null && !isActive
+
+                return (
+                  <button
+                    key={item.name}
+                    type="button"
+                    onClick={() =>
+                      setActiveCategory(prev =>
+                        prev?.name === item.name ? null : item
+                      )
+                    }
+                    className={`w-full text-left space-y-1.5 transition-opacity ${
+                      isDimmed ? 'opacity-40' : 'opacity-100'
+                    }`}
+                  >
+                    <div className="flex justify-between items-center">
+                      <div className="flex items-center gap-2">
+                        <span
+                          className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
+                          style={{ backgroundColor: color }}
+                        />
+                        <span className="text-white text-sm font-medium">{item.name}</span>
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <span className="text-white font-bold text-sm">
+                          ${item.amount.toLocaleString()}
+                        </span>
+                        <span className="text-gray-500 text-xs w-8 text-right">
+                          {item.percentage}%
+                        </span>
+                      </div>
+                    </div>
+
+                    {/* Progress bar */}
+                    <div className="w-full bg-white/5 h-1.5 rounded-full overflow-hidden">
+                      <div
+                        className={`h-full rounded-full ${reducedMotion ? '' : 'transition-all duration-700 ease-out'}`}
+                        style={{ width: `${item.percentage}%`, backgroundColor: color }}
+                      />
+                    </div>
+                  </button>
+                )
+              })}
+            </div>
+          </>
+        )}
       </div>
 
       {/* Insight alert */}

--- a/components/Insights/remittanceTrendChart.tsx
+++ b/components/Insights/remittanceTrendChart.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useCallback, memo } from 'react'
 import { usePrefersReducedMotion } from '@/lib/hooks/usePrefersReducedMotion'
+import { useSaveData } from '@/lib/hooks/useSaveData'
 import { Activity } from 'lucide-react';
 import WidgetEmptyState from '@/components/ui/WidgetEmptyState';
 import {
@@ -100,6 +101,7 @@ function RemittanceTrendChartInner({
 }: RemittanceTrendChartProps) {
   // Use the canonical hook — reactive, SSR-safe, shared across the codebase.
   const reducedMotion = usePrefersReducedMotion()
+  const saveData = useSaveData()
 
   const isEmpty = data.length === 0
   const total   = useMemo(() => data.reduce((s, d) => s + d.amount, 0), [data])
@@ -189,58 +191,70 @@ function RemittanceTrendChartInner({
 
       {/* Chart */}
       <div role="img" aria-label={chartLabel}>
-        <ResponsiveContainer width="100%" height={220}>
-          <AreaChart
-            data={data}
-            margin={margin}
-            aria-hidden="true"
-          >
-            <defs>
-              <linearGradient id="trendGradient" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%"  stopColor={LINE_COLOR} stopOpacity={0.3} />
-                <stop offset="95%" stopColor={LINE_COLOR} stopOpacity={0}   />
-              </linearGradient>
-            </defs>
+        {saveData ? (
+          /* Save-Data fallback: ordered number list, no AreaChart cost */
+          <ol className="space-y-1.5" aria-label="Remittance amounts by date">
+            {data.map((point) => (
+              <li key={point.date} className="flex items-center justify-between text-sm">
+                <span className="text-gray-400">{point.date}</span>
+                <span className="font-bold text-white">${point.amount.toLocaleString()}</span>
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <ResponsiveContainer width="100%" height={220}>
+            <AreaChart
+              data={data}
+              margin={margin}
+              aria-hidden="true"
+            >
+              <defs>
+                <linearGradient id="trendGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%"  stopColor={LINE_COLOR} stopOpacity={0.3} />
+                  <stop offset="95%" stopColor={LINE_COLOR} stopOpacity={0}   />
+                </linearGradient>
+              </defs>
 
-            <CartesianGrid strokeDasharray="3 3" stroke={GRID_COLOR} vertical={false} />
+              <CartesianGrid strokeDasharray="3 3" stroke={GRID_COLOR} vertical={false} />
 
-            <XAxis
-              dataKey="date"
-              tick={xAxisTick}
-              axisLine={false}
-              tickLine={false}
-              interval="preserveStartEnd"
-            />
-            <YAxis
-              tick={yAxisTick}
-              axisLine={false}
-              tickLine={false}
-              tickFormatter={tickFormatter}
-              width={40}
-              className="hidden sm:block"
-            />
+              <XAxis
+                dataKey="date"
+                tick={xAxisTick}
+                axisLine={false}
+                tickLine={false}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                tick={yAxisTick}
+                axisLine={false}
+                tickLine={false}
+                tickFormatter={tickFormatter}
+                width={40}
+                className="hidden sm:block"
+              />
 
-            <Tooltip content={CustomTooltip} cursor={tooltipCursor} />
+              <Tooltip content={CustomTooltip} cursor={tooltipCursor} />
 
-            <ReferenceLine
-              y={average}
-              stroke="rgba(255,255,255,0.15)"
-              strokeDasharray="4 4"
-              label={referenceLabel}
-            />
+              <ReferenceLine
+                y={average}
+                stroke="rgba(255,255,255,0.15)"
+                strokeDasharray="4 4"
+                label={referenceLabel}
+              />
 
-            <Area
-              type="monotone"
-              dataKey="amount"
-              stroke={LINE_COLOR}
-              strokeWidth={2.5}
-              fill="url(#trendGradient)"
-              dot={false}
-              isAnimationActive={!reducedMotion}
-              activeDot={activeDot}
-            />
-          </AreaChart>
-        </ResponsiveContainer>
+              <Area
+                type="monotone"
+                dataKey="amount"
+                stroke={LINE_COLOR}
+                strokeWidth={2.5}
+                fill="url(#trendGradient)"
+                dot={false}
+                isAnimationActive={!reducedMotion}
+                activeDot={activeDot}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
       </div>
 
       {/* Screen‑reader summary */}

--- a/components/Insights/spendingVsSavingChart.tsx
+++ b/components/Insights/spendingVsSavingChart.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useCallback, memo } from 'react'
 import { usePrefersReducedMotion } from '@/lib/hooks/usePrefersReducedMotion'
+import { useSaveData } from '@/lib/hooks/useSaveData'
 import {
     BarChart,
     Bar,
@@ -120,6 +121,7 @@ function SpendingVsSavingsChartInner({
 }: SpendingVsSavingsChartProps) {
     // Use the canonical hook — reactive, SSR-safe, shared across the codebase.
     const reducedMotion = usePrefersReducedMotion()
+    const saveData = useSaveData()
 
     const savingsRate = useMemo(() => {
         const spending = data.reduce((s, d) => s + d.spending, 0)
@@ -161,47 +163,92 @@ function SpendingVsSavingsChartInner({
                 </div>
             </div>
 
-            {/* Chart */}
-            <div role="img" aria-label={chartLabel}>
-                <ResponsiveContainer width="100%" height={220}>
-                    <BarChart
-                        data={data}
-                        barCategoryGap="30%"
-                        barGap={4}
-                        margin={margin}
-                        aria-hidden="true"
-                    >
-                        <CartesianGrid
-                            strokeDasharray="3 3"
-                            stroke={GRID_COLOR}
-                            vertical={false}
-                        />
-                        <XAxis
-                            dataKey="month"
-                            tick={axisTick}
-                            axisLine={false}
-                            tickLine={false}
-                        />
-                        <YAxis
-                            tick={axisTick}
-                            axisLine={false}
-                            tickLine={false}
-                            tickFormatter={tickFormatter}
-                            width={40}
-                            className="hidden sm:block"
-                        />
-                        <Tooltip content={CustomTooltip as any} cursor={tooltipCursor} />
-                        <Bar dataKey="spending" name="spending" fill={SPENDING_COLOR} radius={barRadius} isAnimationActive={!reducedMotion} />
-                        <Bar dataKey="savings"  name="savings"  fill={SAVINGS_COLOR}  radius={barRadius} isAnimationActive={!reducedMotion} />
-                    </BarChart>
-                </ResponsiveContainer>
-            </div>
+            {/* Chart — or plain table when Save-Data is active */}
+            {saveData ? (
+                /* Save-Data fallback: plain data table, no BarChart bundle cost */
+                <div className="overflow-x-auto">
+                    <table className="w-full text-sm text-white/80 border-collapse">
+                        <caption className="sr-only">Monthly spending vs savings</caption>
+                        <thead>
+                            <tr className="border-b border-white/10">
+                                <th scope="col" className="py-2 pr-4 text-left font-semibold text-white/60">Month</th>
+                                <th scope="col" className="py-2 pr-4 text-right font-semibold text-white/60">
+                                    <span className="inline-flex items-center gap-1">
+                                        <span
+                                            className="inline-block w-2.5 h-2.5 rounded-sm"
+                                            style={{ backgroundColor: SPENDING_COLOR }}
+                                            aria-hidden="true"
+                                        />
+                                        Spending
+                                    </span>
+                                </th>
+                                <th scope="col" className="py-2 text-right font-semibold text-white/60">
+                                    <span className="inline-flex items-center gap-1">
+                                        <span
+                                            className="inline-block w-2.5 h-2.5 rounded-sm"
+                                            style={{ backgroundColor: SAVINGS_COLOR }}
+                                            aria-hidden="true"
+                                        />
+                                        Savings
+                                    </span>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {data.map((row) => (
+                                <tr key={row.month} className="border-b border-white/5 last:border-0">
+                                    <td className="py-2 pr-4 font-medium">{row.month}</td>
+                                    <td className="py-2 pr-4 text-right">${row.spending.toLocaleString()}</td>
+                                    <td className="py-2 text-right">${row.savings.toLocaleString()}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            ) : (
+                /* Full interactive BarChart */
+                <div role="img" aria-label={chartLabel}>
+                    <ResponsiveContainer width="100%" height={220}>
+                        <BarChart
+                            data={data}
+                            barCategoryGap="30%"
+                            barGap={4}
+                            margin={margin}
+                            aria-hidden="true"
+                        >
+                            <CartesianGrid
+                                strokeDasharray="3 3"
+                                stroke={GRID_COLOR}
+                                vertical={false}
+                            />
+                            <XAxis
+                                dataKey="month"
+                                tick={axisTick}
+                                axisLine={false}
+                                tickLine={false}
+                            />
+                            <YAxis
+                                tick={axisTick}
+                                axisLine={false}
+                                tickLine={false}
+                                tickFormatter={tickFormatter}
+                                width={40}
+                                className="hidden sm:block"
+                            />
+                            <Tooltip content={CustomTooltip as any} cursor={tooltipCursor} />
+                            <Bar dataKey="spending" name="spending" fill={SPENDING_COLOR} radius={barRadius} isAnimationActive={!reducedMotion} />
+                            <Bar dataKey="savings"  name="savings"  fill={SAVINGS_COLOR}  radius={barRadius} isAnimationActive={!reducedMotion} />
+                        </BarChart>
+                    </ResponsiveContainer>
+                </div>
+            )}
 
             {/* Screen‑reader summary */}
             <p className="sr-only" aria-live="polite">
                 {chartSummary}
             </p>
 
+            {/* Legend shown in both modes */}
             <CustomLegend />
         </div>
     )

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -148,3 +148,47 @@ function ResponsiveWidget() {
 ```
 
 You can also pass an existing React ref or an element directly.
+
+---
+
+## `useSaveData`
+
+**File:** `lib/hooks/useSaveData.ts`
+
+Returns `true` when the browser signals that the user is on a metered or low-bandwidth connection via the `Save-Data: on` client hint (part of the [Network Information API](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/saveData)).
+
+When active, chart components swap their rich Recharts visualisations for lightweight static alternatives (tables, bar lists, progress bars) so that heavy library code, SVG paths, and animation timers are not downloaded or executed unnecessarily.
+
+**Behaviour:**
+- **SSR-safe:** defaults to `false` on the server so hydration never mismatches.
+- **Reactive:** updates immediately when `navigator.connection.saveData` changes at runtime (e.g. user toggles Data Saver mid-session).
+- **Graceful degradation:** returns `false` in environments that do not implement the Network Information API (Safari, Firefox, Node.js).
+
+```tsx
+import { useSaveData } from "@/lib/hooks/useSaveData";
+
+export default function MyChart({ data }) {
+  const saveData = useSaveData();
+
+  if (saveData) {
+    // Lightweight fallback — no Recharts, no animation
+    return <DataTable data={data} />;
+  }
+
+  return <FancyAnimatedChart data={data} />;
+}
+```
+
+**Where it is used:**
+
+| Component | Save-Data fallback |
+|---|---|
+| `SixMonthTrendsWidget` | Plain `<table>` of monthly figures |
+| `MoneyDistributionWidget` | `<ul>` bar list with colored progress bars |
+| `RemittanceTrendChart` | Ordered list of date / amount pairs |
+| `CategoryDonutChart` | Static progress bars (no interactive donut) |
+| `SpendingVsSavingsChart` | Plain `<table>` with spending and savings columns |
+
+**Testing in Chromium:** DevTools → Network panel → tick **"Save-Data"** under custom headers. The chart components will immediately swap to their table / list fallbacks.
+
+**Unit tests:** `tests/unit/hooks/useSaveData.test.ts`

--- a/lib/hooks/useSaveData.ts
+++ b/lib/hooks/useSaveData.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Returns `true` when the browser signals that the user is on a metered /
+ * low-bandwidth connection via the `Save-Data: on` client hint (part of the
+ * Network Information API).
+ *
+ * When active, chart components should swap their rich Recharts visualisations
+ * for lightweight static alternatives (tables, bar lists, etc.) so that
+ * heavy library code, SVG paths, and animation timers are not downloaded or
+ * executed unnecessarily.
+ *
+ * ### Behaviour
+ * - **SSR-safe:** defaults to `false` on the server so hydration never
+ *   produces a mismatch.
+ * - **Reactive:** updates when `navigator.connection.saveData` changes at
+ *   runtime (e.g. the user toggles Data Saver in their browser settings).
+ * - **Graceful degradation:** returns `false` in environments that do not
+ *   implement the Network Information API (Safari, Firefox, Node).
+ *
+ * ### Usage
+ * ```tsx
+ * import { useSaveData } from "@/lib/hooks/useSaveData";
+ *
+ * export default function MyChart({ data }) {
+ *   const saveData = useSaveData();
+ *
+ *   if (saveData) {
+ *     return <DataTable data={data} />;
+ *   }
+ *
+ *   return <FancyAnimatedChart data={data} />;
+ * }
+ * ```
+ *
+ * ### Testing
+ * In Chromium-based browsers: DevTools → Network → "Enable network throttling"
+ * and tick "Save-Data". Alternatively, pass the `Save-Data: on` request
+ * header, or use `navigator.connection` overrides in unit tests.
+ */
+export function useSaveData(): boolean {
+  const [saveData, setSaveData] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    // The Network Information API is not universally supported.
+    const connection =
+      (navigator as Navigator & {
+        connection?: { saveData: boolean; addEventListener: (...args: unknown[]) => void; removeEventListener: (...args: unknown[]) => void };
+        mozConnection?: { saveData: boolean };
+        webkitConnection?: { saveData: boolean };
+      }).connection ??
+      (navigator as any).mozConnection ??
+      (navigator as any).webkitConnection;
+
+    if (!connection) return;
+
+    const update = () => setSaveData(Boolean(connection.saveData));
+
+    // Initialise with the current value.
+    update();
+
+    // Listen for changes (e.g. user toggles Data Saver mid-session).
+    if (typeof connection.addEventListener === 'function') {
+      connection.addEventListener('change', update);
+      return () => connection.removeEventListener('change', update);
+    }
+  }, []);
+
+  return saveData;
+}

--- a/tests/unit/hooks/useSaveData.test.ts
+++ b/tests/unit/hooks/useSaveData.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useSaveData } from '@/lib/hooks/useSaveData'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a minimal mock of `navigator.connection` that supports `saveData`
+ * and emits "change" events via `addEventListener`.
+ */
+function makeConnection(initialSaveData: boolean) {
+  let _saveData = initialSaveData
+  const listeners: Array<() => void> = []
+
+  const connection = {
+    get saveData() {
+      return _saveData
+    },
+    addEventListener(_event: string, cb: () => void) {
+      listeners.push(cb)
+    },
+    removeEventListener(_event: string, cb: () => void) {
+      const idx = listeners.indexOf(cb)
+      if (idx !== -1) listeners.splice(idx, 1)
+    },
+    /** Test-only helper: flip saveData and fire all "change" listeners. */
+    _set(value: boolean) {
+      _saveData = value
+      listeners.forEach((cb) => cb())
+    },
+    get _listenerCount() {
+      return listeners.length
+    },
+  }
+
+  return connection
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useSaveData', () => {
+  let originalConnection: unknown
+
+  beforeEach(() => {
+    originalConnection = (navigator as any).connection
+  })
+
+  afterEach(() => {
+    // Restore to original value (usually undefined in jsdom)
+    Object.defineProperty(navigator, 'connection', {
+      value: originalConnection,
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  it('returns false by default when navigator.connection is not present', () => {
+    Object.defineProperty(navigator, 'connection', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    })
+
+    const { result } = renderHook(() => useSaveData())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false when navigator.connection.saveData is false', () => {
+    const connection = makeConnection(false)
+    Object.defineProperty(navigator, 'connection', {
+      value: connection,
+      writable: true,
+      configurable: true,
+    })
+
+    const { result } = renderHook(() => useSaveData())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns true when navigator.connection.saveData is true', () => {
+    const connection = makeConnection(true)
+    Object.defineProperty(navigator, 'connection', {
+      value: connection,
+      writable: true,
+      configurable: true,
+    })
+
+    const { result } = renderHook(() => useSaveData())
+    expect(result.current).toBe(true)
+  })
+
+  it('updates reactively when saveData changes at runtime', () => {
+    const connection = makeConnection(false)
+    Object.defineProperty(navigator, 'connection', {
+      value: connection,
+      writable: true,
+      configurable: true,
+    })
+
+    const { result } = renderHook(() => useSaveData())
+    expect(result.current).toBe(false)
+
+    act(() => {
+      connection._set(true)
+    })
+    expect(result.current).toBe(true)
+
+    act(() => {
+      connection._set(false)
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it('removes the change listener on unmount', () => {
+    const connection = makeConnection(false)
+    Object.defineProperty(navigator, 'connection', {
+      value: connection,
+      writable: true,
+      configurable: true,
+    })
+
+    const { unmount } = renderHook(() => useSaveData())
+    expect(connection._listenerCount).toBe(1)
+
+    unmount()
+    expect(connection._listenerCount).toBe(0)
+  })
+
+  it('gracefully handles a connection object without addEventListener', () => {
+    Object.defineProperty(navigator, 'connection', {
+      value: { saveData: true },
+      writable: true,
+      configurable: true,
+    })
+
+    // Should not throw; picks up the initial value but cannot subscribe.
+    const { result } = renderHook(() => useSaveData())
+    expect(result.current).toBe(true)
+  })
+})


### PR DESCRIPTION
Adds useSaveData hook and applies it across all five chart widgets. When navigator.connection.saveData is true, each chart renders a lightweight static alternative instead of the Recharts visualisation, avoiding SVG rendering, animation timers, and heavy bundle code on metered connections.

Changes:
- lib/hooks/useSaveData.ts — new SSR-safe, reactive hook (mirrors usePrefersReducedMotion pattern; graceful degradation on browsers without Network Information API support)
- SixMonthTrendsWidget — plain <table> of monthly figures
- MoneyDistributionWidget — <ul> bar list with CSS progress bars
- RemittanceTrendChart — ordered list of date / amount pairs
- CategoryDonutChart — static progress bars (no interactive donut)
- SpendingVsSavingsChart — plain <table> with spending and savings cols
- tests/unit/hooks/useSaveData.test.ts — 6 unit tests covering default, initial value, reactivity, listener cleanup, and missing addEventListener
- docs/HOOKS.md — useSaveData entry with usage, table of consumers, and Chromium DevTools testing instructions

Closes #1013