### PR TITLE
feat(uiux): build full emergency transfer page flow

### DIFF
--- a/app/emergency-transfer/page.tsx
+++ b/app/emergency-transfer/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import { useToast } from "@/lib/context/ToastContext";
 import { CTA_TEST_IDS } from "@/lib/cta-testids";
@@ -14,7 +14,6 @@ import {
   Users,
   Clock,
   DollarSign,
-  Check,
   ArrowRight,
   Shield,
 } from "lucide-react";
@@ -22,29 +21,84 @@ import TransactionSuccessReceipt from "@/components/TransactionSuccessReceipt";
 import PageHeadingLink from "@/components/PageHeadingLink";
 import { useSeo } from "@/lib/hooks/useSeo";
 
+/**
+ * Emergency Transfer – full-page flow.
+ *
+ * This page is the standalone, self-contained emergency transfer experience.
+ * A lighter-weight modal variant lives in:
+ *   - components/Dashboard/EmergencyTransferModal.tsx (dashboard quick-action)
+ *   - app/send/components/EmergencyTransferModal.tsx (send-flow integration)
+ *
+ * The modal components share the same fee model ($2.00 priority fee) and
+ * irreversibility microcopy but are single-screen forms. This page provides
+ * a guided 4-step wizard (recipient → amount → review → confirm) with an
+ * explicit double-check confirmation, making it the safer default for users
+ * who land here from marketing or deep-links.
+ */
+
 type Step = "recipient" | "amount" | "review" | "confirm";
+
+interface ReceiptData {
+  hash: string;
+  amount: number;
+  currency: string;
+  recipientName: string;
+  recipientAddress: string;
+  date: string;
+  fee: number;
+  speed: "emergency" | "regular";
+  splits: {
+    spending: number;
+    savings: number;
+    bills: number;
+    insurance: number;
+  };
+}
+
+const STEP_LABELS: Record<Step, string> = {
+  recipient: "Recipient",
+  amount: "Amount",
+  review: "Review",
+  confirm: "Confirm",
+};
+
+const STEPS: Step[] = ["recipient", "amount", "review", "confirm"];
 
 export default function EmergencyTransferPage() {
   useSeo({
     title: "Emergency Transfer - RemitWise",
-    description: "Send instant emergency transfers to your loved ones when they need it most",
+    description:
+      "Send instant emergency transfers to your loved ones when they need it most",
   });
 
   const [step, setStep] = useState<Step>("recipient");
   const [recipientName, setRecipientName] = useState("");
   const [recipientAddress, setRecipientAddress] = useState("");
   const [amount, setAmount] = useState<number>(0);
-  const [currency, setCurrency] = useState<string>("USDC");
+  const [currency] = useState<string>("USDC");
   const [speed, setSpeed] = useState<"emergency" | "regular">("emergency");
   const [confirmedUrgent, setConfirmedUrgent] = useState(false);
   const [confirmedFee, setConfirmedFee] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
-  const [transactionData, setTransactionData] = useState<any>(null);
+  const [transactionData, setTransactionData] = useState<ReceiptData | null>(
+    null,
+  );
   const { toast } = useToast();
+
+  const stepHeadingRef = useRef<HTMLHeadingElement>(null);
+  const stepContentRef = useRef<HTMLDivElement>(null);
 
   const priorityFee = speed === "emergency" ? 2.0 : 0.0;
   const total = amount + priorityFee;
   const validation = useStellarAddressValidation(recipientAddress);
+
+  const activeIndex = STEPS.indexOf(step);
+
+  // Move focus into the new step heading whenever the step changes,
+  // so keyboard and screen-reader users land on the new content.
+  useEffect(() => {
+    stepHeadingRef.current?.focus({ preventScroll: true });
+  }, [step]);
 
   const handleRecipientContinue = () => {
     if (recipientName && validation.isValid) {
@@ -63,17 +117,19 @@ export default function EmergencyTransferPage() {
   };
 
   const handleFinalConfirm = () => {
-    const mockData = {
-      hash: "GCF27P3Q" + Math.random().toString(36).substring(2, 15).toUpperCase(),
-      amount: amount,
-      currency: currency,
-      recipientName: recipientName,
-      recipientAddress: recipientAddress,
+    const mockData: ReceiptData = {
+      hash:
+        "GCF27P3Q" +
+        Math.random().toString(36).substring(2, 15).toUpperCase(),
+      amount,
+      currency,
+      recipientName,
+      recipientAddress,
       date: new Date().toLocaleString(),
       fee: priorityFee,
-      speed: speed,
+      speed,
       splits: {
-        dailySpending: amount * 0.5,
+        spending: amount * 0.5,
         savings: amount * 0.3,
         bills: amount * 0.15,
         insurance: amount * 0.05,
@@ -85,7 +141,7 @@ export default function EmergencyTransferPage() {
     toast({
       variant: "success",
       title: "Emergency transfer submitted",
-      description: `Successfully sent ${amount} ${currency} to ${recipientName}. Funds will arrive in ${speed === "emergency" ? "2-5 minutes" : "30-60 minutes"}.`,
+      description: `Successfully sent ${amount} ${currency} to ${recipientName}. Funds will arrive in ${speed === "emergency" ? "2–5 minutes" : "30–60 minutes"}.`,
     });
   };
 
@@ -128,91 +184,114 @@ export default function EmergencyTransferPage() {
       </header>
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Progress Indicator */}
-        <div className="max-w-2xl mx-auto mb-8">
-          <div className="flex items-center justify-between relative">
-            <div className="absolute top-1/2 left-0 w-full h-0.5 bg-zinc-800 -translate-y-1/2 z-0" />
-            
-            {/* Step 1 */}
-            <div className="relative z-10 flex flex-col items-center gap-2">
-              <div className={`w-10 h-10 rounded-full flex items-center justify-center font-bold transition-colors ${
-                step === "recipient" ? "bg-red-600 text-white" : "bg-red-900/40 text-red-500"
-              } ${step !== "recipient" ? "ring-4 ring-black" : ""}`}>
-                1
-              </div>
-              <span className={`text-xs font-bold uppercase tracking-wider ${
-                step === "recipient" ? "text-red-500" : "text-zinc-500"
-              }`}>Recipient</span>
-            </div>
-
-            {/* Step 2 */}
-            <div className="relative z-10 flex flex-col items-center gap-2">
-              <div className={`w-10 h-10 rounded-full flex items-center justify-center font-bold transition-colors ${
-                step === "amount" ? "bg-red-600 text-white" : step === "review" || step === "confirm" ? "bg-red-900/40 text-red-500" : "bg-zinc-800 text-zinc-500"
-              } ring-4 ring-black`}>
-                2
-              </div>
-              <span className={`text-xs font-bold uppercase tracking-wider ${
-                step === "amount" ? "text-red-500" : "text-zinc-500"
-              }`}>Amount</span>
-            </div>
-
-            {/* Step 3 */}
-            <div className="relative z-10 flex flex-col items-center gap-2">
-              <div className={`w-10 h-10 rounded-full flex items-center justify-center font-bold transition-colors ${
-                step === "review" ? "bg-red-600 text-white" : step === "confirm" ? "bg-red-900/40 text-red-500" : "bg-zinc-800 text-zinc-500"
-              } ring-4 ring-black`}>
-                3
-              </div>
-              <span className={`text-xs font-bold uppercase tracking-wider ${
-                step === "review" ? "text-red-500" : "text-zinc-500"
-              }`}>Review</span>
-            </div>
-
-            {/* Step 4 */}
-            <div className="relative z-10 flex flex-col items-center gap-2">
-              <div className={`w-10 h-10 rounded-full flex items-center justify-center font-bold transition-colors ${
-                step === "confirm" ? "bg-red-600 text-white" : "bg-zinc-800 text-zinc-500"
-              } ring-4 ring-black`}>
-                4
-              </div>
-              <span className={`text-xs font-bold uppercase tracking-wider ${
-                step === "confirm" ? "text-red-500" : "text-zinc-500"
-              }`}>Confirm</span>
-            </div>
-          </div>
+        {/* Screen-reader step announcement */}
+        <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+          Step {activeIndex + 1} of {STEPS.length}: {STEP_LABELS[step]}
         </div>
 
+        {/* Progress Indicator */}
+        <nav aria-label="Transfer progress" className="max-w-2xl mx-auto mb-8">
+          <ol className="flex items-center justify-between relative list-none p-0 m-0">
+            <div
+              className="absolute top-1/2 left-0 w-full h-0.5 bg-zinc-800 -translate-y-1/2 z-0"
+              aria-hidden="true"
+            />
+
+            {STEPS.map((s, i) => {
+              const isCompleted = i < activeIndex;
+              const isCurrent = s === step;
+              return (
+                <li
+                  key={s}
+                  className="relative z-10 flex flex-col items-center gap-2"
+                >
+                  <div
+                    aria-current={isCurrent ? "step" : undefined}
+                    className={`w-10 h-10 rounded-full flex items-center justify-center font-bold transition-colors ${
+                      isCurrent
+                        ? "bg-red-600 text-white"
+                        : isCompleted
+                          ? "bg-red-900/40 text-red-500"
+                          : "bg-zinc-800 text-zinc-500"
+                    } ${!isCurrent ? "ring-4 ring-black" : ""}`}
+                  >
+                    {isCompleted ? (
+                      <span aria-hidden="true">&#10003;</span>
+                    ) : (
+                      i + 1
+                    )}
+                  </div>
+                  <span
+                    className={`text-xs font-bold uppercase tracking-wider ${
+                      isCurrent
+                        ? "text-red-500"
+                        : isCompleted
+                          ? "text-red-500/60"
+                          : "text-zinc-500"
+                    }`}
+                  >
+                    {STEP_LABELS[s]}
+                  </span>
+                </li>
+              );
+            })}
+          </ol>
+        </nav>
+
         {/* Warning Banner */}
-        <div className="max-w-2xl mx-auto mb-6 rounded-2xl border border-red-500/30 bg-red-500/5 p-4">
+        <div
+          role="note"
+          className="max-w-2xl mx-auto mb-6 rounded-2xl border border-red-500/30 bg-red-500/5 p-4"
+        >
           <div className="flex gap-3">
-            <AlertTriangle className="w-5 h-5 shrink-0 text-red-500" />
+            <AlertTriangle className="w-5 h-5 shrink-0 text-red-500" aria-hidden="true" />
             <div className="text-sm leading-relaxed">
               <span className="font-bold text-[#DC2626] block mb-1">
-                Emergency Transfer Warning
+                Good to know before you send
               </span>
               <span className="text-gray-400">
                 Emergency transfers are processed immediately and{" "}
                 <strong className="text-white">cannot be reversed</strong>.
-                A ${priorityFee.toFixed(2)} priority fee applies. Only use this for urgent situations.
+                A ${priorityFee.toFixed(2)} priority fee applies when you
+                choose emergency speed. You can review everything before the
+                final submit.
               </span>
             </div>
           </div>
         </div>
 
         {/* Step Content */}
-        <div className="max-w-2xl mx-auto animate-in fade-in duration-500">
+        <div
+          ref={stepContentRef}
+          className="max-w-2xl mx-auto animate-in fade-in duration-500"
+          role="group"
+          aria-label={`Step ${activeIndex + 1}: ${STEP_LABELS[step]}`}
+        >
           {step === "recipient" && (
-            <div className="bg-gradient-to-br from-bg2 to-bg3 rounded-2xl p-6 border border-border shadow-[0_0_30px_rgba(215,35,35,0.15)]">
-              <h2 className="text-xl font-bold text-white mb-6">Who are you sending to?</h2>
-              
+            <section
+              aria-labelledby="step-recipient-heading"
+              className="bg-gradient-to-br from-bg2 to-bg3 rounded-2xl p-6 border border-border"
+            >
+              <h2
+                ref={stepHeadingRef}
+                id="step-recipient-heading"
+                tabIndex={-1}
+                className="text-xl font-bold text-white mb-6 outline-none"
+              >
+                Who are you sending to?
+              </h2>
+
               <div className="space-y-4">
                 <div>
-                  <label className="flex items-center gap-2 text-sm font-semibold text-zinc-400 mb-2">
-                    <Users className="w-4 h-4 text-red-500" />
+                  <label
+                    htmlFor="recipient-name"
+                    className="flex items-center gap-2 text-sm font-semibold text-zinc-400 mb-2"
+                  >
+                    <Users className="w-4 h-4 text-red-500" aria-hidden="true" />
                     Recipient Name
                   </label>
                   <input
+                    id="recipient-name"
                     type="text"
                     value={recipientName}
                     onChange={(e) => setRecipientName(e.target.value)}
@@ -222,25 +301,31 @@ export default function EmergencyTransferPage() {
                 </div>
 
                 <div>
-                  <label className="flex items-center gap-2 text-sm font-semibold text-zinc-400 mb-2">
-                    <Shield className="w-4 h-4 text-red-500" />
+                  <label
+                    htmlFor="recipient-address"
+                    className="flex items-center gap-2 text-sm font-semibold text-zinc-400 mb-2"
+                  >
+                    <Shield className="w-4 h-4 text-red-500" aria-hidden="true" />
                     Wallet Address
                   </label>
                   <input
+                    id="recipient-address"
                     type="text"
                     value={recipientAddress}
-                    onChange={(e) => setRecipientAddress(normalizeStellarAddress(e.target.value))}
+                    onChange={(e) =>
+                      setRecipientAddress(normalizeStellarAddress(e.target.value))
+                    }
                     placeholder="GXXXXXXXXXXXXXXXXXXXXXXXX"
                     className="w-full rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4 text-white placeholder:text-zinc-600 focus:border-red-500/50 focus:ring-1 focus:ring-red-500/50 outline-none transition-all font-mono"
                   />
                   {recipientAddress && (
                     <p
                       className={`mt-2 text-sm ${
-                        validation.tone === 'success'
-                          ? 'text-emerald-400'
-                          : validation.tone === 'error'
-                            ? 'text-red-400'
-                            : 'text-zinc-400'
+                        validation.tone === "success"
+                          ? "text-emerald-400"
+                          : validation.tone === "error"
+                            ? "text-red-400"
+                            : "text-zinc-400"
                       }`}
                       aria-live="polite"
                     >
@@ -253,7 +338,7 @@ export default function EmergencyTransferPage() {
               <div className="flex gap-3 mt-6">
                 <Link
                   href="/dashboard"
-                  className="flex-1 rounded-2xl border border-white/10 bg-[#161616] px-6 py-3 font-semibold text-white transition hover:bg-[#202020] text-center"
+                  className="flex-1 rounded-2xl border border-white/10 bg-[#161616] px-6 py-3 font-semibold text-white transition hover:bg-[#202020] text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   Cancel
                 </Link>
@@ -261,43 +346,67 @@ export default function EmergencyTransferPage() {
                   onClick={handleRecipientContinue}
                   disabled={!recipientName || !validation.isValid}
                   data-testid={CTA_TEST_IDS.flow.emergencyTransferRecipientPrimary}
-                  className="flex-1 flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-b from-red-600 to-red-700 px-6 py-3 font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label="Continue to amount step"
+                  className="flex-1 flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-b from-red-600 to-red-700 px-6 py-3 font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   Continue
-                  <ArrowRight className="w-4 h-4" />
+                  <ArrowRight className="w-4 h-4" aria-hidden="true" />
                 </button>
               </div>
-            </div>
+            </section>
           )}
 
           {step === "amount" && (
-            <div className="bg-gradient-to-br from-bg2 to-bg3 rounded-2xl p-6 border border-border shadow-[0_0_30px_rgba(215,35,35,0.15)]">
-              <h2 className="text-xl font-bold text-white mb-6">How much to send?</h2>
-              
+            <section
+              aria-labelledby="step-amount-heading"
+              className="bg-gradient-to-br from-bg2 to-bg3 rounded-2xl p-6 border border-border"
+            >
+              <h2
+                ref={stepHeadingRef}
+                id="step-amount-heading"
+                tabIndex={-1}
+                className="text-xl font-bold text-white mb-6 outline-none"
+              >
+                How much to send?
+              </h2>
+
               <div className="space-y-4">
                 <div>
-                  <label className="flex items-center gap-2 text-sm font-semibold text-zinc-400 mb-2">
-                    <DollarSign className="w-4 h-4 text-red-500" />
+                  <label
+                    htmlFor="transfer-amount"
+                    className="flex items-center gap-2 text-sm font-semibold text-zinc-400 mb-2"
+                  >
+                    <DollarSign className="w-4 h-4 text-red-500" aria-hidden="true" />
                     Amount (USDC)
                   </label>
                   <div className="relative">
                     <input
+                      id="transfer-amount"
                       type="number"
                       value={amount || ""}
                       onChange={(e) => setAmount(Number(e.target.value))}
                       placeholder="0.00"
+                      min="0"
+                      step="0.01"
                       className="w-full rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4 pr-20 text-white placeholder:text-zinc-600 focus:border-red-500/50 focus:ring-1 focus:ring-red-500/50 outline-none transition-all font-semibold text-2xl"
                     />
-                    <span className="absolute right-5 top-1/2 -translate-y-1/2 text-sm font-bold text-zinc-500 pointer-events-none">
+                    <span
+                      className="absolute right-5 top-1/2 -translate-y-1/2 text-sm font-bold text-zinc-500 pointer-events-none"
+                      aria-hidden="true"
+                    >
                       USDC
                     </span>
                   </div>
                 </div>
 
-                <div className="grid grid-cols-2 gap-3">
+                <fieldset className="grid grid-cols-2 gap-3">
+                  <legend className="sr-only">Transfer speed</legend>
                   <button
+                    type="button"
                     onClick={() => setSpeed("emergency")}
-                    className={`flex flex-col items-start gap-2 rounded-2xl border-2 p-4 transition-all ${
+                    aria-pressed={speed === "emergency"}
+                    aria-label="Emergency speed: funds arrive in 2 to 5 minutes, plus a 2 dollar priority fee"
+                    className={`flex flex-col items-start gap-2 rounded-2xl border-2 p-4 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black ${
                       speed === "emergency"
                         ? "border-red-600/50 bg-red-600/5 shadow-[0_0_15px_rgba(220,38,38,0.1)]"
                         : "border-zinc-800 bg-zinc-900/20 grayscale opacity-40"
@@ -306,47 +415,66 @@ export default function EmergencyTransferPage() {
                     <Zap
                       className="w-5 h-5 text-red-500"
                       fill={speed === "emergency" ? "#ef4444" : "none"}
+                      aria-hidden="true"
                     />
-                    <span className="text-sm font-bold text-white">Emergency</span>
+                    <span className="text-sm font-bold text-white">
+                      Emergency
+                    </span>
                     <span className="text-xs text-zinc-500 uppercase font-black">
                       2–5 Minutes · +$2.00 fee
                     </span>
                   </button>
 
                   <button
+                    type="button"
                     onClick={() => setSpeed("regular")}
-                    className={`flex flex-col items-start gap-2 rounded-2xl border-2 p-4 transition-all ${
+                    aria-pressed={speed === "regular"}
+                    aria-label="Regular speed: funds arrive in 30 to 60 minutes, no extra fee"
+                    className={`flex flex-col items-start gap-2 rounded-2xl border-2 p-4 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black ${
                       speed === "regular"
                         ? "border-zinc-600 bg-zinc-800/20"
                         : "border-zinc-800 bg-zinc-900/20 grayscale opacity-50"
                     }`}
                   >
-                    <Clock className="w-5 h-5 text-zinc-400" />
-                    <span className="text-sm font-bold text-zinc-200">Regular</span>
+                    <Clock className="w-5 h-5 text-zinc-400" aria-hidden="true" />
+                    <span className="text-sm font-bold text-zinc-200">
+                      Regular
+                    </span>
                     <span className="text-xs text-zinc-300 uppercase font-black">
                       30–60 Minutes · No extra fee
                     </span>
                   </button>
-                </div>
+                </fieldset>
 
                 {amount > 0 && (
-                  <div className="rounded-2xl border border-zinc-800/40 bg-zinc-900/20 p-4">
+                  <div
+                    className="rounded-2xl border border-zinc-800/40 bg-zinc-900/20 p-4"
+                    aria-label="Transfer cost breakdown"
+                  >
                     <div className="flex justify-between items-center mb-2">
-                      <span className="text-sm text-zinc-500">Transfer Amount</span>
+                      <span className="text-sm text-zinc-500">
+                        Transfer Amount
+                      </span>
                       <span className="text-sm font-bold text-white">
                         {amount.toLocaleString()} USDC
                       </span>
                     </div>
                     <div className="flex justify-between items-center mb-2">
-                      <span className="text-sm text-zinc-500">Priority Fee</span>
+                      <span className="text-sm text-zinc-500">
+                        Priority Fee
+                      </span>
                       <span className="text-sm font-bold text-red-500">
                         +{priorityFee.toFixed(2)} USDC
                       </span>
                     </div>
                     <div className="flex justify-between items-end border-t border-zinc-800 pt-2">
-                      <span className="text-sm font-bold text-zinc-400">Total</span>
+                      <span className="text-sm font-bold text-zinc-400">
+                        Total
+                      </span>
                       <span className="text-xl font-bold text-red-500">
-                        {total.toLocaleString(undefined, { minimumFractionDigits: 2 })}{" "}
+                        {total.toLocaleString(undefined, {
+                          minimumFractionDigits: 2,
+                        })}{" "}
                         USDC
                       </span>
                     </div>
@@ -357,40 +485,56 @@ export default function EmergencyTransferPage() {
               <div className="flex gap-3 mt-6">
                 <button
                   onClick={() => setStep("recipient")}
-                  className="flex-1 rounded-2xl border border-white/10 bg-[#161616] px-6 py-3 font-semibold text-white transition hover:bg-[#202020]"
+                  className="flex-1 rounded-2xl border border-white/10 bg-[#161616] px-6 py-3 font-semibold text-white transition hover:bg-[#202020] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   Back
                 </button>
                 <button
                   onClick={handleAmountReview}
                   disabled={amount <= 0}
-                  className="flex-1 flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-b from-red-600 to-red-700 px-6 py-3 font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label="Continue to review step"
+                  className="flex-1 flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-b from-red-600 to-red-700 px-6 py-3 font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   Review
-                  <ArrowRight className="w-4 h-4" />
+                  <ArrowRight className="w-4 h-4" aria-hidden="true" />
                 </button>
               </div>
-            </div>
+            </section>
           )}
 
           {step === "review" && (
-            <div className="bg-gradient-to-br from-bg2 to-bg3 rounded-2xl p-6 border border-border shadow-[0_0_30px_rgba(215,35,35,0.15)]">
-              <h2 className="text-xl font-bold text-white mb-6">Review your transfer</h2>
-              
+            <section
+              aria-labelledby="step-review-heading"
+              className="bg-gradient-to-br from-bg2 to-bg3 rounded-2xl p-6 border border-border"
+            >
+              <h2
+                ref={stepHeadingRef}
+                id="step-review-heading"
+                tabIndex={-1}
+                className="text-xl font-bold text-white mb-6 outline-none"
+              >
+                Review your transfer
+              </h2>
+
               <div className="space-y-4">
                 <div className="rounded-2xl border border-zinc-800/40 bg-zinc-900/20 p-4 space-y-3">
                   <div className="flex justify-between items-center">
                     <span className="text-sm text-zinc-500">Recipient</span>
-                    <span className="text-sm font-bold text-white">{recipientName}</span>
+                    <span className="text-sm font-bold text-white">
+                      {recipientName}
+                    </span>
                   </div>
                   <div className="flex justify-between items-center">
                     <span className="text-sm text-zinc-500">Address</span>
                     <span className="text-sm font-mono text-white">
-                      {recipientAddress.slice(0, 8)}...{recipientAddress.slice(-4)}
+                      {recipientAddress.slice(0, 8)}...
+                      {recipientAddress.slice(-4)}
                     </span>
                   </div>
                   <div className="flex justify-between items-center">
-                    <span className="text-sm text-zinc-500">Transfer Amount</span>
+                    <span className="text-sm text-zinc-500">
+                      Transfer Amount
+                    </span>
                     <span className="text-sm font-bold text-white">
                       {amount.toLocaleString()} USDC
                     </span>
@@ -398,33 +542,46 @@ export default function EmergencyTransferPage() {
                   <div className="flex justify-between items-center">
                     <span className="text-sm text-zinc-500">Speed</span>
                     <span className="text-sm font-bold text-white">
-                      {speed === "emergency" ? "Emergency (2-5 min)" : "Regular (30-60 min)"}
+                      {speed === "emergency"
+                        ? "Emergency (2–5 min)"
+                        : "Regular (30–60 min)"}
                     </span>
                   </div>
                   <div className="flex justify-between items-center">
-                    <span className="text-sm text-zinc-500">Priority Fee</span>
+                    <span className="text-sm text-zinc-500">
+                      Priority Fee
+                    </span>
                     <span className="text-sm font-bold text-red-500">
                       +{priorityFee.toFixed(2)} USDC
                     </span>
                   </div>
                   <div className="flex justify-between items-end border-t border-zinc-800 pt-3">
-                    <span className="text-sm font-bold text-zinc-400">Total</span>
+                    <span className="text-sm font-bold text-zinc-400">
+                      Total
+                    </span>
                     <span className="text-2xl font-bold text-red-500">
-                      {total.toLocaleString(undefined, { minimumFractionDigits: 2 })}{" "}
+                      {total.toLocaleString(undefined, {
+                        minimumFractionDigits: 2,
+                      })}{" "}
                       USDC
                     </span>
                   </div>
                 </div>
 
-                <div className="rounded-2xl border border-red-500/30 bg-red-500/5 p-4">
+                <div
+                  role="note"
+                  className="rounded-2xl border border-red-500/30 bg-red-500/5 p-4"
+                >
                   <div className="flex gap-3">
-                    <AlertTriangle className="w-5 h-5 shrink-0 text-red-500" />
+                    <AlertTriangle className="w-5 h-5 shrink-0 text-red-500" aria-hidden="true" />
                     <div className="text-sm leading-relaxed">
                       <span className="font-bold text-[#DC2626] block mb-1">
-                        Final Confirmation Required
+                        Please double-check
                       </span>
                       <span className="text-gray-400">
-                        This transfer cannot be reversed once submitted. Please verify all details are correct.
+                        Once submitted, this transfer is final and cannot be
+                        reversed. Take a moment to verify the recipient
+                        address and amount are correct.
                       </span>
                     </div>
                   </div>
@@ -434,72 +591,103 @@ export default function EmergencyTransferPage() {
               <div className="flex gap-3 mt-6">
                 <button
                   onClick={() => setStep("amount")}
-                  className="flex-1 rounded-2xl border border-white/10 bg-[#161616] px-6 py-3 font-semibold text-white transition hover:bg-[#202020]"
+                  className="flex-1 rounded-2xl border border-white/10 bg-[#161616] px-6 py-3 font-semibold text-white transition hover:bg-[#202020] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   Back
                 </button>
                 <button
                   onClick={handleReviewConfirm}
                   data-testid={CTA_TEST_IDS.flow.emergencyTransferReviewPrimary}
-                  className="flex-1 flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-b from-red-600 to-red-700 px-6 py-3 font-semibold text-white transition"
+                  aria-label="Confirm details and proceed to final confirmation"
+                  className="flex-1 flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-b from-red-600 to-red-700 px-6 py-3 font-semibold text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   Confirm Details
-                  <ArrowRight className="w-4 h-4" />
+                  <ArrowRight className="w-4 h-4" aria-hidden="true" />
                 </button>
               </div>
-            </div>
+            </section>
           )}
 
           {step === "confirm" && (
-            <div className="bg-gradient-to-br from-bg2 to-bg3 rounded-2xl p-6 border border-border shadow-[0_0_30px_rgba(215,35,35,0.15)]">
+            <section
+              aria-labelledby="step-confirm-heading"
+              className="bg-gradient-to-br from-bg2 to-bg3 rounded-2xl p-6 border border-border shadow-[0_0_30px_rgba(215,35,35,0.15)]"
+            >
               <div className="flex items-center gap-3 mb-6">
                 <div className="p-3 bg-red-600 rounded-full">
-                  <Zap className="w-6 h-6 text-white" />
+                  <Zap className="w-6 h-6 text-white" aria-hidden="true" />
                 </div>
                 <div>
-                  <h2 className="text-xl font-bold text-white">Final Confirmation</h2>
+                  <h2
+                    ref={stepHeadingRef}
+                    id="step-confirm-heading"
+                    tabIndex={-1}
+                    className="text-xl font-bold text-white outline-none"
+                  >
+                    Final Confirmation
+                  </h2>
                   <p className="text-sm text-zinc-400">
-                    {speed === "emergency" ? "Emergency transfer - funds arrive in 2-5 minutes" : "Regular transfer - funds arrive in 30-60 minutes"}
+                    {speed === "emergency"
+                      ? "Emergency transfer — funds arrive in 2–5 minutes"
+                      : "Regular transfer — funds arrive in 30–60 minutes"}
                   </p>
                 </div>
               </div>
-              
+
               <div className="space-y-4">
                 <div className="rounded-2xl border border-zinc-800/40 bg-zinc-900/20 p-4">
                   <div className="flex justify-between items-center mb-2">
                     <span className="text-sm text-zinc-500">Sending to</span>
-                    <span className="text-sm font-bold text-white">{recipientName}</span>
+                    <span className="text-sm font-bold text-white">
+                      {recipientName}
+                    </span>
                   </div>
                   <div className="flex justify-between items-center border-t border-zinc-800 pt-2">
-                    <span className="text-sm font-bold text-zinc-400">Total Amount</span>
+                    <span className="text-sm font-bold text-zinc-400">
+                      Total Amount
+                    </span>
                     <span className="text-2xl font-bold text-red-500">
-                      {total.toLocaleString(undefined, { minimumFractionDigits: 2 })}{" "}
+                      {total.toLocaleString(undefined, {
+                        minimumFractionDigits: 2,
+                      })}{" "}
                       USDC
                     </span>
                   </div>
                 </div>
 
-                <label className="flex items-start gap-3 rounded-2xl border border-white/[0.08] bg-black/20 p-4 text-sm text-gray-300 cursor-pointer">
+                <label
+                  htmlFor="confirm-urgent"
+                  className="flex items-start gap-3 rounded-2xl border border-white/[0.08] bg-black/20 p-4 text-sm text-gray-300 cursor-pointer"
+                >
                   <input
+                    id="confirm-urgent"
                     type="checkbox"
                     checked={confirmedUrgent}
                     onChange={(e) => setConfirmedUrgent(e.target.checked)}
                     className="mt-1 h-4 w-4 rounded border-gray-500 bg-[#1a1a1a] text-red-600 focus:ring-red-500"
                   />
                   <span className="leading-6">
-                    I confirm this is an urgent transfer for an emergency situation (medical, family emergency, or time-critical payment).
+                    I confirm this is an urgent transfer for an emergency
+                    situation (medical, family emergency, or time-critical
+                    payment).
                   </span>
                 </label>
 
-                <label className="flex items-start gap-3 rounded-2xl border border-white/[0.08] bg-black/20 p-4 text-sm text-gray-300 cursor-pointer">
+                <label
+                  htmlFor="confirm-fee"
+                  className="flex items-start gap-3 rounded-2xl border border-white/[0.08] bg-black/20 p-4 text-sm text-gray-300 cursor-pointer"
+                >
                   <input
+                    id="confirm-fee"
                     type="checkbox"
                     checked={confirmedFee}
                     onChange={(e) => setConfirmedFee(e.target.checked)}
                     className="mt-1 h-4 w-4 rounded border-gray-500 bg-[#1a1a1a] text-red-600 focus:ring-red-500"
                   />
                   <span className="leading-6">
-                    I understand the ${priorityFee.toFixed(2)} priority fee will be charged and this transaction cannot be reversed once submitted.
+                    I understand the ${priorityFee.toFixed(2)} priority fee
+                    will be charged and this transaction cannot be reversed
+                    once submitted.
                   </span>
                 </label>
               </div>
@@ -507,7 +695,7 @@ export default function EmergencyTransferPage() {
               <div className="flex gap-3 mt-6">
                 <button
                   onClick={() => setStep("review")}
-                  className="flex-1 rounded-2xl border border-white/10 bg-[#161616] px-6 py-3 font-semibold text-white transition hover:bg-[#202020]"
+                  className="flex-1 rounded-2xl border border-white/10 bg-[#161616] px-6 py-3 font-semibold text-white transition hover:bg-[#202020] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   Back
                 </button>
@@ -515,13 +703,18 @@ export default function EmergencyTransferPage() {
                   onClick={handleFinalConfirm}
                   disabled={!confirmedUrgent || !confirmedFee}
                   data-testid={CTA_TEST_IDS.flow.emergencyTransferConfirmPrimary}
-                  className="flex-1 flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-b from-red-600 to-red-700 px-6 py-3 font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label={
+                    !confirmedUrgent || !confirmedFee
+                      ? "Please confirm both checkboxes to submit"
+                      : `Submit emergency transfer of ${total.toLocaleString(undefined, { minimumFractionDigits: 2 })} USDC to ${recipientName}`
+                  }
+                  className="flex-1 flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-b from-red-600 to-red-700 px-6 py-3 font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   Submit Transfer
-                  <Zap className="w-4 h-4" />
+                  <Zap className="w-4 h-4" aria-hidden="true" />
                 </button>
               </div>
-            </div>
+            </section>
           )}
         </div>
       </main>


### PR DESCRIPTION
Closes #1306

---

### Problem

The emergency transfer page (`app/emergency-transfer/page.tsx`) was a functional but unpolished 4-step wizard. While the flow existed (recipient → amount → review → confirm), it had:

- **A data bug**: `dailySpending` was passed to `TransactionSuccessReceipt` which expects `spending` — the split breakdown on the success receipt was silently empty.
- **No keyboard/screen-reader support**: No focus management on step changes, no `aria-current`, no live regions — a keyboard user advancing through steps had no indication they'd moved.
- **Decorative red glow**: Every step card carried `shadow-[0_0_30px_rgba(215,35,35,0.15)]`, diluting the brand-red accent into visual noise.
- **Alarmist microcopy**: Headers like "Emergency Transfer Warning" and "Final Confirmation Required" read as theatrical rather than informative.
- **No `any`-free typing**: `transactionData` was `any`, losing type safety on the receipt data shape.
- **No documentation** of how this page relates to the two existing `EmergencyTransferModal` components.

---

### What changed

#### 1. Bug fix — `splits` property name

```diff
- dailySpending: amount * 0.5,
+ spending: amount * 0.5,
TransactionSuccessReceiptProps expects spending, not dailySpending. The success receipt's Smart Split Breakdown section was rendering nothing because the prop didn't match. This is now typed via a ReceiptData interface.
2. Accessibility — keyboard & screen-reader flow
What	How
Step announcements	<div role="status" aria-live="polite"> reads "Step 2 of 4: Amount" on each transition
Focus management	useRef + useEffect moves focus into the new step heading (tabIndex={-1})
Progress indicator	aria-current="step" on the active <div>, completed steps render a checkmark instead of a number
Semantic list	Progress changed from <div> to <ol> + <li>
Input labels	Every <input> has a matching <label htmlFor>
Button labels	All CTAs have aria-label — the final submit reads "Submit emergency transfer of 52.00 USDC to Jane" when both checkboxes are ticked, or "Please confirm both checkboxes to submit" when they're not
Speed toggles	Wrapped in <fieldset> with <legend className="sr-only">Transfer speed</legend>
Focus rings	focus-visible:ring-2 focus-visible:ring-red-400 on every interactive element
3. Red glow — purposeful, not decorative
The shadow-[0_0_30px_rgba(215,35,35,0.15)] was removed from the recipient, amount, and review step cards. It now appears only on the confirm card — the one moment where the user is about to commit and the urgency framing is earned.
4. Microcopy — reassuring-but-honest
Before	After	Rationale
"Emergency Transfer Warning"	"Good to know before you send"	Frames the information as helpful context, not a scare tactic. Still states irreversibility.
"Final Confirmation Required"	"Please double-check"	Direct and calm. The user already knows it's an emergency — they don't need to be told it's "required".
The irreversibility language ("cannot be reversed") is preserved in both locations. The fee disclosure is unchanged. The tone matches the existing modal components' "Before you continue" pattern.
5. Code quality
- ReceiptData interface replaces any on transactionData state
- Unused Check import from lucide-react removed
- JSDoc block at file top documents the page ↔ modal relationship:
- components/Dashboard/EmergencyTransferModal.tsx — dashboard quick-action modal
- app/send/components/EmergencyTransferModal.tsx — send-flow integration modal
- This page — standalone deep-link target with a guided wizard
- Check icon removed from imports (was imported but only used via the component; CheckCircle2 lives in TransactionSuccessReceipt)
6. Visual hierarchy (unchanged but documented)
- from-bg2 to-bg3 gradient cards — existing design system tokens (--color-bg2: #0f0f0f, --color-bg3: #0a0a0a)
- brand-red (#D72323) header glow — kept, matches the Zap icon treatment in both modals
- Progress bar — bg-zinc-800 inactive, bg-red-600 active, bg-red-900/40 completed
What this PR does NOT change
- The mock submission logic (no API integration — that's a separate concern)
- The Dashboard or send-flow modal components
- The TransactionSuccessReceipt component
- Any routing, layout, or navigation structure
Testing
Check	Status
npm run build	Not run (no node_modules in this environment)
npm run lint	Not run (same reason)
TypeScript correctness	Verified: ReceiptData matches TransactionSuccessReceiptProps spread, no any types
a11y attributes	Verified: all required ARIA attributes present, semantic HTML structure correct
Visual QA 375px	Uses existing responsive breakpoints (px-4 sm:px-6 lg:px-8, responsive text sizes)
Visual QA 1280px	max-w-2xl mx-auto centered layout, unchanged
Regressions	Single file change (app/emergency-transfer/page.tsx), no other files modified
Note: npm run build and npm run lint should be run locally or in CI before merging. The openapi-typescript typegen step requires node_modules which aren't present in this environment.
