### PR TITLE
feat: add developer telemetry toggle in settings (#992)

### DIFF
--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -3,6 +3,7 @@
 import { ReactNode, useEffect } from "react";
 import { WalletProvider, useWallet } from "stellar-wallet-kit";
 import { DensityProvider } from "@/lib/context/DensityContext";
+import { TelemetryProvider } from "@/lib/context/TelemetryContext";
 import { ThemeProvider } from "@/lib/context/ThemeContext";
 import { ToastProvider } from "@/lib/context/ToastContext";
 import { NetworkStatusProvider } from "@/lib/context/NetworkStatusContext";
@@ -42,16 +43,18 @@ export default function Providers({ children }: { children: ReactNode }) {
       <ApiClientAuthBridge />
       <ToastProvider>
         <DensityProvider>
-          <AsyncOperationsProvider>
-            <SessionExpiryProvider>
-              <ShortcutHelpProvider>
-                <LayoutWrapper>{children}</LayoutWrapper>
-                <ToastRegion />
-                <CommandPalette />
-                <ShortcutHelpModal />
-              </ShortcutHelpProvider>
-            </SessionExpiryProvider>
-          </AsyncOperationsProvider>
+          <TelemetryProvider>
+            <AsyncOperationsProvider>
+              <SessionExpiryProvider>
+                <ShortcutHelpProvider>
+                  <LayoutWrapper>{children}</LayoutWrapper>
+                  <ToastRegion />
+                  <CommandPalette />
+                  <ShortcutHelpModal />
+                </ShortcutHelpProvider>
+              </SessionExpiryProvider>
+            </AsyncOperationsProvider>
+          </TelemetryProvider>
         </DensityProvider>
       </ToastProvider>
     </WalletProvider>

--- a/components/settings/PreferencesSection.test.tsx
+++ b/components/settings/PreferencesSection.test.tsx
@@ -4,10 +4,11 @@
  */
 
 import React from "react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { screen, fireEvent } from "@testing-library/react";
 import { renderWithProviders } from "@/tests/react/renderWithProviders";
 import { PreferencesSection } from "./PreferencesSection";
+import { DEV_TELEMETRY_STORAGE_KEY } from "@/lib/config/developer";
 
 describe("PreferencesSection", () => {
   it("renders inside a section with the preferences id", () => {
@@ -79,5 +80,46 @@ describe("PreferencesSection", () => {
   it("renders the date-format radios with DD/MM/YYYY default", () => {
     renderWithProviders(<PreferencesSection />);
     expect(screen.getByRole("radio", { name: "DD/MM/YYYY" })).toBeChecked();
+  });
+
+  describe("developer telemetry toggle", () => {
+    beforeEach(() => {
+      // Start each test with a clean localStorage so the toggle is off.
+      if (typeof window !== "undefined") {
+        window.localStorage.removeItem(DEV_TELEMETRY_STORAGE_KEY);
+      }
+    });
+
+    it("renders the developer telemetry toggle as off by default", () => {
+      renderWithProviders(<PreferencesSection />);
+      const toggle = screen.getByRole("switch", {
+        name: "settings.preferences.developer_telemetry_label",
+      });
+      expect(toggle).toBeInTheDocument();
+      expect(toggle).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("turns on the telemetry toggle when clicked and persists to localStorage", () => {
+      renderWithProviders(<PreferencesSection />);
+      const toggle = screen.getByRole("switch", {
+        name: "settings.preferences.developer_telemetry_label",
+      });
+
+      fireEvent.click(toggle);
+      expect(toggle).toHaveAttribute("aria-checked", "true");
+
+      const stored = window.localStorage.getItem(DEV_TELEMETRY_STORAGE_KEY);
+      expect(stored).toBe("true");
+    });
+
+    it("reflects a pre-existing enabled preference from localStorage", () => {
+      window.localStorage.setItem(DEV_TELEMETRY_STORAGE_KEY, "true");
+      renderWithProviders(<PreferencesSection />);
+      const toggle = screen.getByRole("switch", {
+        name: "settings.preferences.developer_telemetry_label",
+      });
+      // The TelemetryProvider hydrates from localStorage on mount.
+      expect(toggle).toHaveAttribute("aria-checked", "true");
+    });
   });
 });

--- a/components/settings/PreferencesSection.tsx
+++ b/components/settings/PreferencesSection.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, type ChangeEvent } from "react";
 import { Globe, Moon, Sun, Smartphone, Sparkles } from "lucide-react";
 import { useDensity } from "@/lib/context/DensityContext";
 import { useTheme } from "@/lib/context/ThemeContext";
+import { useTelemetry } from "@/lib/context/TelemetryContext";
 import { useWhatsNew } from "@/lib/context/WhatsNewContext";
 import { useClientTranslator } from "@/lib/i18n/client";
 import { useAutosave } from "@/lib/hooks/useAutosave";
@@ -12,6 +13,7 @@ import {
   SectionCard,
   SectionHeader,
   FieldRow,
+  Toggle,
   SaveButton,
 } from "./SettingsPrimitives";
 import {
@@ -23,6 +25,7 @@ export function PreferencesSection() {
   const { t } = useClientTranslator();
   const { density, setDensity } = useDensity();
   const { replay } = useWhatsNew();
+  const { telemetryEnabled, setTelemetryEnabled } = useTelemetry();
   const [theme, setTheme] = useState<"system" | "light" | "dark">("system");
   const [language, setLanguage] = useState("en-US");
   const [timezone, setTimezone] = useState("Africa/Lagos");
@@ -225,6 +228,15 @@ export function PreferencesSection() {
             {t("settings.preferences.replay_tour_button")}
           </button>
         </FieldRow>
+        <Toggle
+          labelKey="settings.preferences.developer_telemetry_label"
+          descriptionKey="settings.preferences.developer_telemetry_description"
+          checked={telemetryEnabled}
+          onChange={(next) => {
+            setTelemetryEnabled(next);
+            triggerSave();
+          }}
+        />
       </div>
       <SaveButton labelKey="settings.save_changes" saveState={saveState} />
     </SectionCard>

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -285,6 +285,88 @@ interface WhatsNewContextValue {
 - `tests/unit/components/ReceiptPageContent.test.tsx` covers the receipt page
   content component for valid/invalid hashes and successful/missing transactions.
 
+## TelemetryContext
+
+A context provider that manages the developer telemetry toggle — a settings
+switch that, when enabled, prints structured debug events to the browser
+console as JSON (issue #992).
+
+**File:** `lib/context/TelemetryContext.tsx`
+
+### Behavior
+
+- **Default:** Off (`false`). No console output is emitted unless the user
+  explicitly enables the toggle.
+- **Persistence:** Stores the preference in `localStorage` under the key
+  `developer-telemetry-enabled` so the setting survives page reloads.
+- **Structured output:** Each event is serialised as a JSON string and routed
+  to the matching console method (`console.debug`, `console.info`,
+  `console.warn`, `console.error`) with the prefix `[telemetry]`.
+
+### Log entry shape
+
+```ts
+interface TelemetryEvent {
+  timestamp: string;           // ISO-8601
+  level: "debug" | "info" | "warn" | "error";
+  source: string;              // dot-separated emitting module, e.g. "wallet.send"
+  message: string;
+  payload?: Record<string, unknown>;
+}
+```
+
+### API
+
+```ts
+interface TelemetryContextType {
+  telemetryEnabled: boolean;
+  setTelemetryEnabled: (enabled: boolean) => void;
+  logTelemetry: (
+    source: string,
+    message: string,
+    payload?: Record<string, unknown>,
+    level?: TelemetryEventLevel,   // default: "debug"
+  ) => void;
+}
+```
+
+### Integration
+
+- `TelemetryProvider` is wrapped in `components/Providers.tsx` between
+  `DensityProvider` and `AsyncOperationsProvider`, making it available
+  app-wide.
+- The toggle is exposed in `components/settings/PreferencesSection.tsx` under
+  **Settings → Preferences → Developer Telemetry**.
+- Consuming components call `useTelemetry()` to get `logTelemetry`. Calls are
+  no-ops when the toggle is off, so it is safe to leave them in production
+  code.
+
+### Usage
+
+```tsx
+import { useTelemetry } from "@/lib/context/TelemetryContext";
+
+function TransferForm() {
+  const { logTelemetry } = useTelemetry();
+
+  const handleSubmit = () => {
+    logTelemetry("transfer.submit", "Transfer initiated", {
+      amount: 50,
+      currency: "USDC",
+    });
+  };
+}
+```
+
+### Tests
+
+- `components/settings/PreferencesSection.test.tsx` — three tests covering:
+  - Toggle renders with `aria-checked="false"` by default.
+  - Clicking the toggle sets `aria-checked="true"` and writes `"true"` to
+    `localStorage` under `developer-telemetry-enabled`.
+  - A pre-existing `"true"` value in `localStorage` is correctly reflected as
+    `aria-checked="true"` on mount.
+
 ## ConnectionQualityIndicator
 
 A visual indicator that monitors the `/api/health` endpoint and displays the current connection quality.
@@ -709,8 +791,6 @@ interface WhatsNewContextValue {
   content component for valid/invalid hashes and successful/missing transactions.
 
 ## ConnectionQualityIndicator
-
-A visual indicator that monitors the `/api/health` endpoint and displays the current connection quality.
 
 **File:** `components/ConnectionQualityIndicator.tsx`
 

--- a/docs/settings-page-structure.md
+++ b/docs/settings-page-structure.md
@@ -67,7 +67,11 @@ fixed `id` matching `SECTIONS`:
 - **`FamilySection`** (`#family`) — family member list with role badges and an
   invite button. Does not use autosave (inline actions only).
 - **`PreferencesSection`** (`#preferences`) — theme picker, **density controls
-  wired to `useDensity()`**, language/timezone selects, and date-format radios.
+  wired to `useDensity()`**, language/timezone selects, date-format radios,
+  and a **Developer Telemetry toggle wired to `useTelemetry()`** that persists
+  to `localStorage` under the key `developer-telemetry-enabled`. When on,
+  structured events emitted via `logTelemetry()` are printed to the browser
+  console as JSON (`[telemetry] {...}`).
   Uses `useAutosave` (500ms debounce).
 
 ## Cross-cutting integrations

--- a/docs/tracking-and-opt-out.md
+++ b/docs/tracking-and-opt-out.md
@@ -33,6 +33,7 @@ Local storage persists data across browser sessions and tab closures. It is read
 |---|---|---|---|
 | `theme-preference` | Indefinite | Stores user visual theme choice (`dark` or `light`). | Cleared via developer tools or theme toggle in settings. |
 | `display-density` | Indefinite | Stores user layout density choice (`comfortable` or `compact`). | Cleared via developer tools or layout selector in settings. |
+| `developer-telemetry-enabled` | Indefinite | Stores the developer telemetry toggle state (`true` or `false`). When `true`, structured debug events are printed to the browser console. Defaults to `false` (off). | Toggled off via the **Developer Telemetry** switch in Settings → Preferences, or cleared via developer tools. |
 | `redirect_after_auth` | Temporary | Stores the path the user visited before authentication to redirect them back after logging in. | Deleted automatically upon login redirection. |
 | `session_expiry` | Temporary | Stores session expiry timestamp for client-side warning notifications. | Deleted automatically on logout. |
 | `remitwise_whats_new_last_seen` | Indefinite | Tracks the latest seen feature announcement ID. | Managed automatically by the application. |

--- a/lib/config/developer.ts
+++ b/lib/config/developer.ts
@@ -3,3 +3,6 @@ export const DEV_MODE_ENABLED_VALUE = "1";
 export const DEV_MODE_STORAGE_KEY = "dev-mode-enabled";
 export const DEV_MODE_LATEST_REQUEST_ID_KEY = "dev-latest-request-id";
 export const DEV_WIDGET_PAYLOAD_EVENT = "dev-widget-payload-updated";
+
+/** localStorage key for the developer telemetry toggle (issue #992). */
+export const DEV_TELEMETRY_STORAGE_KEY = "developer-telemetry-enabled";

--- a/lib/context/TelemetryContext.tsx
+++ b/lib/context/TelemetryContext.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+} from "react";
+import { DEV_TELEMETRY_STORAGE_KEY } from "@/lib/config/developer";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type TelemetryEventLevel = "debug" | "info" | "warn" | "error";
+
+export interface TelemetryEvent {
+  /** ISO-8601 timestamp set automatically by logTelemetry(). */
+  timestamp: string;
+  level: TelemetryEventLevel;
+  /** Dot-separated path identifying the emitting module, e.g. "wallet.send". */
+  source: string;
+  message: string;
+  /** Any structured key/value payload relevant to the event. */
+  payload?: Record<string, unknown>;
+}
+
+interface TelemetryContextType {
+  /** Whether the developer telemetry toggle is currently on. */
+  telemetryEnabled: boolean;
+  /** Persist the toggle state to localStorage. */
+  setTelemetryEnabled: (enabled: boolean) => void;
+  /**
+   * Emit a structured telemetry event to the console when the toggle is on.
+   * Safe to call unconditionally — no-ops when telemetry is disabled.
+   */
+  logTelemetry: (
+    source: string,
+    message: string,
+    payload?: Record<string, unknown>,
+    level?: TelemetryEventLevel,
+  ) => void;
+}
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+const TelemetryContext = createContext<TelemetryContextType | undefined>(
+  undefined,
+);
+
+// ─── Provider ─────────────────────────────────────────────────────────────────
+
+export function TelemetryProvider({ children }: { children: React.ReactNode }) {
+  const [telemetryEnabled, setTelemetryState] = useState(false);
+
+  // Hydrate from localStorage after mount (avoids SSR mismatch).
+  useEffect(() => {
+    try {
+      if (typeof window !== "undefined") {
+        const stored = localStorage.getItem(DEV_TELEMETRY_STORAGE_KEY);
+        if (stored !== null) {
+          setTelemetryState(JSON.parse(stored) === true);
+        }
+      }
+    } catch {
+      // Corrupted or restricted storage — stay at default (false).
+    }
+  }, []);
+
+  const setTelemetryEnabled = useCallback((enabled: boolean) => {
+    setTelemetryState(enabled);
+    try {
+      if (typeof window !== "undefined") {
+        localStorage.setItem(
+          DEV_TELEMETRY_STORAGE_KEY,
+          JSON.stringify(enabled),
+        );
+      }
+    } catch {
+      // Silently ignore when localStorage is unavailable.
+    }
+  }, []);
+
+  // Keep a ref so logTelemetry always sees the current flag without stale closures.
+  const enabledRef = useRef(telemetryEnabled);
+  useEffect(() => {
+    enabledRef.current = telemetryEnabled;
+  }, [telemetryEnabled]);
+
+  const logTelemetry = useCallback(
+    (
+      source: string,
+      message: string,
+      payload?: Record<string, unknown>,
+      level: TelemetryEventLevel = "debug",
+    ) => {
+      if (!enabledRef.current) return;
+
+      const event: TelemetryEvent = {
+        timestamp: new Date().toISOString(),
+        level,
+        source,
+        message,
+        ...(payload !== undefined && { payload }),
+      };
+
+      // Mirror the log level to the appropriate console method.
+      switch (level) {
+        case "error":
+          console.error("[telemetry]", JSON.stringify(event));
+          break;
+        case "warn":
+          console.warn("[telemetry]", JSON.stringify(event));
+          break;
+        case "info":
+          console.info("[telemetry]", JSON.stringify(event));
+          break;
+        default:
+          console.debug("[telemetry]", JSON.stringify(event));
+      }
+    },
+    [],
+  );
+
+  return (
+    <TelemetryContext.Provider
+      value={{ telemetryEnabled, setTelemetryEnabled, logTelemetry }}
+    >
+      {children}
+    </TelemetryContext.Provider>
+  );
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Access developer telemetry state and the structured console logger.
+ *
+ * @throws {Error} When called outside of a `<TelemetryProvider>` tree.
+ *
+ * @example
+ * const { logTelemetry } = useTelemetry();
+ * logTelemetry("wallet.send", "Transfer initiated", { amount: 10, currency: "USDC" });
+ */
+export function useTelemetry(): TelemetryContextType {
+  const context = useContext(TelemetryContext);
+  if (context === undefined) {
+    throw new Error(
+      "useTelemetry must be used within a TelemetryProvider. " +
+        "Did you forget to wrap your component in <TelemetryProvider>?",
+    );
+  }
+  return context;
+}

--- a/tests/react/renderWithProviders.tsx
+++ b/tests/react/renderWithProviders.tsx
@@ -3,6 +3,8 @@ import { render } from "@testing-library/react";
 import { DensityProvider, type Density } from "@/lib/context/DensityContext";
 import { ThemeProvider } from "@/lib/context/ThemeContext";
 import { ToastProvider } from "@/lib/context/ToastContext";
+import { TelemetryProvider } from "@/lib/context/TelemetryContext";
+import { WhatsNewProvider } from "@/lib/context/WhatsNewContext";
 
 export function renderWithProviders(
   ui: React.ReactElement,
@@ -22,7 +24,11 @@ export function renderWithProviders(
   return render(
     <ThemeProvider>
       <DensityProvider>
-        <ToastProvider>{ui}</ToastProvider>
+        <TelemetryProvider>
+          <WhatsNewProvider>
+            <ToastProvider>{ui}</ToastProvider>
+          </WhatsNewProvider>
+        </TelemetryProvider>
       </DensityProvider>
     </ThemeProvider>,
   );


### PR DESCRIPTION
Closes #992 
- Add DEV_TELEMETRY_STORAGE_KEY constant to lib/config/developer.ts
- Create lib/context/TelemetryContext.tsx with TelemetryProvider, useTelemetry() hook, and logTelemetry() structured console logger
- Mount TelemetryProvider app-wide in components/Providers.tsx
- Add controlled Toggle row to PreferencesSection (Settings -> Preferences) wired to useTelemetry(); persists to localStorage on change
- Add WhatsNewProvider + TelemetryProvider to renderWithProviders test helper
- Add 3 new tests: default off, click-to-enable + localStorage persistence, hydration from existing localStorage value
- Register developer-telemetry-enabled key in docs/tracking-and-opt-out.md
- Update docs/settings-page-structure.md and docs/COMPONENTS.md

Closes #992