### PR TITLE
test: add lifecycle tests for useVisibilityChange hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:unit": "npm run test:unit:node && npm run test:unit:vitest",
     "typecheck": "tsc --noEmit",
     "test:unit:node": "node --test tests/unit/webhooks-verify.test.cjs tests/unit/middleware.test.cjs tests/unit/contract-cache.test.cjs tests/unit/mock-backend.test.cjs",
-    "test:unit:vitest": "node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/unit/validation/savings-goals.test.ts tests/unit/middleware-gateway.test.ts tests/unit/apiClient.test.ts tests/unit/apiClient.retry-timeout.test.ts tests/unit/apiClient.headers.test.ts",
+    "test:unit:vitest": "node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/unit/validation/savings-goals.test.ts tests/unit/middleware-gateway.test.ts tests/unit/apiClient.test.ts tests/unit/apiClient.retry-timeout.test.ts tests/unit/apiClient.headers.test.ts tests/unit/hooks/useVisibilityChange.test.ts",
     "test:property": "node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/property",
     "test:integration": "node --test tests/integration/auth.test.cjs tests/integration/health.test.cjs tests/integration/validation.test.cjs && node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/integration/api",
     "test:e2e": "playwright test",

--- a/tests/unit/hooks/useVisibilityChange.test.ts
+++ b/tests/unit/hooks/useVisibilityChange.test.ts
@@ -72,11 +72,93 @@ describe("useVisibilityChange", () => {
     expect(onChange).toHaveBeenCalledWith(true);
   });
 
+  // -------------------------------------------------------------------------
+  // Listener lifecycle
+  // -------------------------------------------------------------------------
+
+  it("adds visibilitychange listener on mount", () => {
+    const addEventListenerSpy = vi.spyOn(document, "addEventListener");
+
+    renderHook(() => useVisibilityChange());
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.any(Function),
+    );
+  });
+
   it("cleans up event listener on unmount", () => {
     const removeEventListenerSpy = vi.spyOn(document, "removeEventListener");
     const { unmount } = renderHook(() => useVisibilityChange());
 
     unmount();
-    expect(removeEventListenerSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.any(Function),
+    );
+  });
+
+  it("listener and listener only added once per mount", () => {
+    const addEventListenerSpy = vi.spyOn(document, "addEventListener");
+
+    renderHook(() => useVisibilityChange());
+
+    const visibilityChangeCalls = addEventListenerSpy.mock.calls.filter(
+      ([event]) => event === "visibilitychange",
+    );
+    expect(visibilityChangeCalls).toHaveLength(1);
+  });
+
+  it("does not fire callbacks after unmount (sad path)", () => {
+    setDocumentHidden(false);
+    const onHidden = vi.fn();
+    const onVisible = vi.fn();
+    const onChange = vi.fn();
+
+    const { unmount } = renderHook(() =>
+      useVisibilityChange({ onHidden, onVisible, onChange }),
+    );
+
+    // Clear the initial onChange call fired synchronously in useEffect
+    onChange.mockClear();
+
+    unmount();
+
+    // Dispatch a visibility event after the hook is unmounted
+    act(() => {
+      setDocumentHidden(true);
+    });
+
+    expect(onHidden).not.toHaveBeenCalled();
+    expect(onVisible).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("removes the exact same listener function that was added", () => {
+    const addedListeners: EventListener[] = [];
+    const removedListeners: EventListener[] = [];
+
+    vi.spyOn(document, "addEventListener").mockImplementation(
+      (event: string, listener: EventListenerOrEventListenerObject) => {
+        if (event === "visibilitychange") {
+          addedListeners.push(listener as EventListener);
+        }
+      },
+    );
+    vi.spyOn(document, "removeEventListener").mockImplementation(
+      (event: string, listener: EventListenerOrEventListenerObject) => {
+        if (event === "visibilitychange") {
+          removedListeners.push(listener as EventListener);
+        }
+      },
+    );
+
+    const { unmount } = renderHook(() => useVisibilityChange());
+    unmount();
+
+    expect(addedListeners).toHaveLength(1);
+    expect(removedListeners).toHaveLength(1);
+    expect(removedListeners[0]).toBe(addedListeners[0]);
   });
 });


### PR DESCRIPTION
Closes #1028 
Adds comprehensive tests covering:
- addEventListener is called on mount
- removeEventListener is called on unmount
- listener added exactly once (no duplicates)
- callbacks not fired after unmount (sad path)
- same listener function removed that was added (reference identity)

Also adds test file to test:unit:vitest script in package.json so it runs on every CI matrix entry, not just locally.

Closes #1028