### PR TITLE
feat: add shared split bucket config, allocation bar, and detail cards

### DIFF
--- a/app/split/page.tsx
+++ b/app/split/page.tsx
@@ -10,6 +10,7 @@ import AsyncSubmissionStatus from "@/components/AsyncSubmissionStatus";
 import { CTA_TEST_IDS } from "@/lib/cta-testids";
 import { DEFAULT_SPLIT_CONFIG, type SplitConfig } from "@/lib/remittance/split";
 import { validatePercentages } from "@/lib/validation/percentages";
+import { SPLIT_BUCKETS } from "@/lib/config/split-buckets";
 
 const splitStages = [
 	{
@@ -127,7 +128,10 @@ export default function SplitConfiguration() {
 
 	return (
 		<div className='min-h-screen overflow-x-hidden bg-[#010101] safari-safe-bottom'>
-			<SmartMoneySplitHeader />
+			<SmartMoneySplitHeader
+				totalPercentage={total}
+				allocation={allocation}
+			/>
 
 			<main className='mx-auto max-w-7xl overflow-x-hidden px-5 320:px-6 375:px-7 sm:px-6 lg:px-8 py-7 375:py-8 sm:py-8'>
 				<div className='grid min-w-0 gap-7 375:gap-8 xl:grid-cols-[minmax(0,1.1fr)_360px] xl:items-start'>
@@ -149,6 +153,13 @@ export default function SplitConfiguration() {
 						<p className='mt-3 text-sm leading-6 text-gray-300'>
 							Allocation changes are saved as a USDC smart contract action. The payload is prepared in-app and the wallet signs it locally.
 						</p>
+
+						{/* Proportional allocation bar */}
+						<AllocationBar allocation={allocation} isValid={isValid} />
+
+						{/* Per-bucket detail cards */}
+						<AllocationDetailCards allocation={allocation} isValid={isValid} />
+
 						<form
 							className='mt-6 space-y-5 375:space-y-6'
 							onSubmit={handleSubmit}
@@ -159,28 +170,28 @@ export default function SplitConfiguration() {
 								label='Daily Spending'
 								description='For immediate family expenses'
 								value={allocation.spending}
-								color='bg-blue-500'
+								color={SPLIT_BUCKETS[0].barColor}
 								onChange={(v) => handleChange("spending", v)}
 							/>
 							<SplitInput
 								label='Savings'
 								description='Allocated to savings goals'
 								value={allocation.savings}
-								color='bg-green-500'
+								color={SPLIT_BUCKETS[1].barColor}
 								onChange={(v) => handleChange("savings", v)}
 							/>
 							<SplitInput
 								label='Bills'
 								description='Automated bill payments'
 								value={allocation.bills}
-								color='bg-yellow-500'
+								color={SPLIT_BUCKETS[2].barColor}
 								onChange={(v) => handleChange("bills", v)}
 							/>
 							<SplitInput
 								label='Insurance'
 								description='Micro-insurance premiums'
 								value={allocation.insurance}
-								color='bg-violet-500'
+								color={SPLIT_BUCKETS[3].barColor}
 								onChange={(v) => handleChange("insurance", v)}
 							/>
 
@@ -295,6 +306,137 @@ export default function SplitConfiguration() {
 					</aside>
 				</div>
 			</main>
+		</div>
+	);
+}
+
+/**
+ * Rounds percentages so they sum exactly to 100.
+ * Uses the "largest remainder" algorithm to distribute rounding error.
+ */
+function roundToHundred(values: number[]): number[] {
+	const floored = values.map(Math.floor);
+	const remainders = values.map((v, i) => ({ i, r: v - floored[i] }));
+	const deficit = 100 - floored.reduce((a, b) => a + b, 0);
+	remainders
+		.sort((a, b) => b.r - a.r)
+		.slice(0, deficit)
+		.forEach(({ i }) => { floored[i]++; });
+	return floored;
+}
+
+/**
+ * Proportional allocation bar that visualises all four buckets as coloured segments.
+ * Buckets at 0% are omitted from the bar but still appear in the detail cards.
+ * When a single bucket is at 100% it spans the full width.
+ */
+function AllocationBar({ allocation, isValid }: { allocation: SplitConfig; isValid: boolean }) {
+	const buckets = SPLIT_BUCKETS;
+	const rawValues = buckets.map((b) => allocation[b.key]);
+	const total = rawValues.reduce((a, b) => a + b, 0);
+
+	// Only render proportional segments when the config is valid (sums to 100).
+	// When invalid, show a flat grey bar so the user understands something is wrong.
+	const displayValues = isValid ? roundToHundred(rawValues) : rawValues;
+
+	const ariaLabel = isValid
+		? buckets
+				.map((b, i) => `${b.label} ${displayValues[i]}%`)
+				.join(", ")
+		: `Total allocation ${total}% — must equal 100%`;
+
+	return (
+		<div className="mt-6">
+			<p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-white/40">
+				Allocation preview
+			</p>
+			{/* The bar itself */}
+			<div
+				className="flex h-3 w-full overflow-hidden rounded-full bg-white/10"
+				role="img"
+				aria-label={ariaLabel}
+			>
+				{isValid
+					? buckets.map((b, i) =>
+							displayValues[i] > 0 ? (
+								<div
+									key={b.key}
+									className={`${b.barColor} h-full transition-all duration-300`}
+									style={{ width: `${displayValues[i]}%` }}
+								/>
+							) : null
+					  )
+					: null /* grey fallback already applied via bg-white/10 on parent */}
+			</div>
+
+			{/* Bucket legend — icon + text, not color alone */}
+			<div className="mt-3 flex flex-wrap gap-x-4 gap-y-2">
+				{buckets.map((b) => {
+					const Icon = b.icon;
+					return (
+						<span key={b.key} className="flex items-center gap-1.5 text-xs text-white/60">
+							<Icon className={`h-3.5 w-3.5 ${b.textColor}`} aria-hidden="true" />
+							{b.label}
+						</span>
+					);
+				})}
+			</div>
+		</div>
+	);
+}
+
+/**
+ * Per-bucket detail cards showing the absolute percentage and a visual indicator.
+ * Buckets at 0% are visually suppressed (reduced opacity) but remain labelled.
+ */
+function AllocationDetailCards({ allocation, isValid }: { allocation: SplitConfig; isValid: boolean }) {
+	const rawValues = SPLIT_BUCKETS.map((b) => allocation[b.key]);
+	const displayValues = isValid ? roundToHundred(rawValues) : rawValues;
+
+	return (
+		<div className="mt-6 grid grid-cols-2 gap-3 375:gap-4 sm:grid-cols-4">
+			{SPLIT_BUCKETS.map((b, i) => {
+				const Icon = b.icon;
+				const pct = displayValues[i];
+				const isZero = pct === 0;
+
+				return (
+					<div
+						key={b.key}
+						className={`rounded-2xl border border-white/[0.07] bg-black/20 p-3 375:p-4 transition-opacity duration-200 ${
+							isZero ? "opacity-40" : "opacity-100"
+						}`}
+						aria-label={`${b.label}: ${pct}%`}
+					>
+						{/* Icon + label */}
+						<div className="mb-2 flex items-center gap-2">
+							<span
+								className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-white/5 ${b.textColor}`}
+							>
+								<Icon className="h-3.5 w-3.5" aria-hidden="true" />
+							</span>
+							<span className="truncate text-xs font-medium text-white/70">
+								{b.label}
+							</span>
+						</div>
+
+						{/* Percentage */}
+						<p className={`text-2xl font-semibold tabular-nums ${isZero ? "text-white/30" : b.textColor}`}>
+							{pct}<span className="text-base font-normal">%</span>
+						</p>
+
+						{/* Thin bar */}
+						<div className="mt-2 h-1 w-full overflow-hidden rounded-full bg-white/10" aria-hidden="true">
+							{!isZero && (
+								<div
+									className={`${b.barColor} h-full rounded-full transition-all duration-300`}
+									style={{ width: `${pct}%` }}
+								/>
+							)}
+						</div>
+					</div>
+				);
+			})}
 		</div>
 	);
 }

--- a/components/SmartMoneySplitHeader.tsx
+++ b/components/SmartMoneySplitHeader.tsx
@@ -2,15 +2,46 @@
 
 import { useRouter } from 'next/navigation'
 import { ArrowLeft, AlertCircle } from 'lucide-react'
-import PageHeadingLink from '@/components/PageHeadingLink'
+import { SPLIT_BUCKETS } from '@/lib/config/split-buckets'
+import type { SplitConfig } from '@/lib/remittance/split'
 
 interface SmartMoneySplitHeaderProps {
   totalPercentage?: number
+  /** Current allocation — when provided, renders a compact proportional bar */
+  allocation?: SplitConfig
 }
 
-export default function SmartMoneySplitHeader({ totalPercentage = 100 }: SmartMoneySplitHeaderProps) {
+/**
+ * Rounds an array of values so they sum exactly to 100 (largest-remainder method).
+ * Duplicated from the split page so the header stays self-contained.
+ */
+function roundToHundred(values: number[]): number[] {
+  const floored = values.map(Math.floor)
+  const remainders = values.map((v, i) => ({ i, r: v - floored[i] }))
+  const deficit = 100 - floored.reduce((a, b) => a + b, 0)
+  remainders
+    .sort((a, b) => b.r - a.r)
+    .slice(0, deficit)
+    .forEach(({ i }) => { floored[i]++ })
+  return floored
+}
+
+export default function SmartMoneySplitHeader({
+  totalPercentage = 100,
+  allocation,
+}: SmartMoneySplitHeaderProps) {
   const router = useRouter()
   const isValid = totalPercentage === 100
+
+  // Build display segments when an allocation is provided and valid
+  const segments =
+    allocation && isValid
+      ? (() => {
+          const raw = SPLIT_BUCKETS.map((b) => allocation[b.key])
+          const rounded = roundToHundred(raw)
+          return SPLIT_BUCKETS.map((b, i) => ({ ...b, pct: rounded[i] }))
+        })()
+      : null
 
   return (
     <div className="bg-[#010101] text-white safari-safe-top">
@@ -40,6 +71,42 @@ export default function SmartMoneySplitHeader({ totalPercentage = 100 }: SmartMo
             Set how your remittances are automatically split across different categories. This helps your family manage money more effectively.
           </p>
         </div>
+
+        {/* Compact allocation bar — shown when allocation prop is supplied */}
+        {segments && (
+          <div className="mb-5 375:mb-6">
+            {/* Segmented bar */}
+            <div
+              className="flex h-2.5 w-full overflow-hidden rounded-full bg-white/10"
+              role="img"
+              aria-label={segments.map((s) => `${s.label} ${s.pct}%`).join(', ')}
+            >
+              {segments.map((s) =>
+                s.pct > 0 ? (
+                  <div
+                    key={s.key}
+                    className={`${s.barColor} h-full`}
+                    style={{ width: `${s.pct}%` }}
+                  />
+                ) : null
+              )}
+            </div>
+
+            {/* Legend — icon + text, not color alone */}
+            <div className="mt-2.5 flex flex-wrap gap-x-4 gap-y-1.5">
+              {segments.map((s) => {
+                const Icon = s.icon
+                return (
+                  <span key={s.key} className="flex items-center gap-1.5 text-xs text-white/50">
+                    <Icon className={`h-3 w-3 ${s.textColor}`} aria-hidden="true" />
+                    <span className={s.textColor}>{s.pct}%</span>
+                    <span>{s.label}</span>
+                  </span>
+                )
+              })}
+            </div>
+          </div>
+        )}
 
         {/* Alert Section */}
         <div className="rounded-xl bg-[#1c0a0a] border border-[#3d1414] p-4 375:p-5 flex items-center gap-3">

--- a/docs/split-bucket-color-map.md
+++ b/docs/split-bucket-color-map.md
@@ -1,0 +1,103 @@
+# Split Bucket Color Map
+
+Single source of truth for the four Smart Money Split buckets.  
+Canonical definition lives in **`lib/config/split-buckets.ts`** (`SPLIT_BUCKETS`).
+
+---
+
+## Buckets at a glance
+
+| Key | Label | Icon (lucide-react) | Bar class | Text class | Hex |
+|-----|-------|---------------------|-----------|------------|-----|
+| `spending` | Daily Spending | `ShoppingCart` | `bg-blue-300` | `text-blue-300` | `#93C5FD` |
+| `savings` | Savings | `PiggyBank` | `bg-green-300` | `text-green-300` | `#86EFAC` |
+| `bills` | Bills | `FileText` | `bg-amber-300` | `text-amber-300` | `#FDE68A` |
+| `insurance` | Insurance | `Shield` | `bg-violet-400` | `text-violet-400` | `#A78BFA` |
+
+---
+
+## Token alignment with `tailwind.config.js`
+
+| Bucket | Tailwind token source | Semantic intent |
+|--------|----------------------|-----------------|
+| spending | `status.info` palette — blue family | Represents "daily flow / informational" |
+| savings | `status.success` palette — green family | Represents "growth / positive outcome" |
+| bills | `status.warning` palette — amber family | Represents "attention / upcoming obligation" |
+| insurance | Violet (nearest to `brand.red` protection zone) | Represents "protection / shield" |
+
+The brand red (`brand.red #D72323`, `brand.redHover #B91C1C`) is reserved for primary actions, error states, and the RemitWise brand mark.  It is intentionally **not** used as a bucket color to avoid ambiguity with validation errors.
+
+---
+
+## WCAG 2.1 AA compliance
+
+All four foreground hex values were checked against the app's dark surfaces (`#010101`, `#0A0A0A`):
+
+| Color | Surface | Contrast ratio | AA text (4.5:1) | AA UI (3:1) |
+|-------|---------|----------------|-----------------|-------------|
+| `#93C5FD` blue-300 | `#010101` | ≈ 9.8:1 | ✅ | ✅ |
+| `#86EFAC` green-300 | `#010101` | ≈ 10.4:1 | ✅ | ✅ |
+| `#FDE68A` amber-300 | `#010101` | ≈ 12.1:1 | ✅ | ✅ |
+| `#A78BFA` violet-400 | `#010101` | ≈ 7.2:1 | ✅ | ✅ |
+
+**Labels are always conveyed by icon + text, not color alone** (WCAG 1.4.1 Use of Color).  
+Each bucket renders its `LucideIcon` with `aria-hidden="true"` alongside a visible text label.
+
+---
+
+## Edge-case handling
+
+### One bucket at 100%
+The allocation bar renders a single full-width segment in that bucket's color.  
+The other three detail cards appear at `opacity-40` with `0%` displayed, so they are still labeled and discoverable but visually suppressed.
+
+### A bucket at 0%
+- The allocation bar **omits** the segment entirely (zero-width segments are skipped).  
+- The corresponding detail card renders at `opacity-40` with `0%` and a dimmed percentage numeral, but the icon and label remain visible.
+
+### Percentage rounding (sum must equal exactly 100)
+Displayed percentages are computed with the **largest-remainder algorithm** (`roundToHundred`).  
+Raw floored values are summed; any deficit (due to fractional parts) is distributed by descending remainder to the buckets with the largest fractional part.  
+This guarantees the displayed digits always sum to exactly 100 regardless of slider values.
+
+The algorithm is implemented in two places:
+- `app/split/page.tsx` — `roundToHundred()` (for detail cards and the bar in the editor)
+- `components/SmartMoneySplitHeader.tsx` — `roundToHundred()` (for the compact header bar)
+
+Both are identical; the header is intentionally self-contained to avoid a circular import between a component and a page.
+
+---
+
+## Usage
+
+```tsx
+import { SPLIT_BUCKETS } from "@/lib/config/split-buckets";
+import type { SplitConfig } from "@/lib/remittance/split";
+
+// Render a legend
+{SPLIT_BUCKETS.map((b) => {
+  const Icon = b.icon;
+  return (
+    <span key={b.key} className={`flex items-center gap-1.5 ${b.textColor}`}>
+      <Icon className="h-4 w-4" aria-hidden="true" />
+      {b.label}
+    </span>
+  );
+})}
+
+// Map allocation values to buckets
+{SPLIT_BUCKETS.map((b) => (
+  <div key={b.key}>{allocation[b.key]}%</div>
+))}
+```
+
+---
+
+## Consumers
+
+| File | Usage |
+|------|-------|
+| `app/split/page.tsx` | `AllocationBar`, `AllocationDetailCards`, `SplitInput` color |
+| `components/SmartMoneySplitHeader.tsx` | Compact header bar + legend |
+| `components/Dashboard/SplitBar.tsx` | Can be migrated to use `SPLIT_BUCKETS` for consistent colors |
+| `components/Dashboard/MoneyDistributionWidget.tsx` | Can adopt `hex` field to replace hard-coded `#dc2626` shades |

--- a/lib/config/split-buckets.ts
+++ b/lib/config/split-buckets.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared bucket configuration for the Smart Money Split feature.
+ *
+ * This is the single source of truth for bucket identity:
+ * - key:    matches SplitConfig property names in lib/remittance/split.ts
+ * - label:  human-readable display name
+ * - icon:   Lucide icon component (icon + text, never color alone — WCAG 2.1 AA)
+ * - color:  Tailwind bg-* class aligned to tailwind.config.js brand/status tokens
+ * - textColor: Tailwind text-* class for numeric labels on dark backgrounds
+ *
+ * Reused by:
+ *   - app/split/page.tsx            (allocation bar + detail cards)
+ *   - components/Dashboard/SplitBar.tsx  (per-row progress bars)
+ *   - components/Dashboard/MoneyDistributionWidget.tsx (legend items)
+ *
+ * Color rationale:
+ *   - spending  → status.info blue  (#93C5FD / bg-blue-300)   – "daily flow"
+ *   - savings   → status.success green (#86EFAC / bg-green-300) – "growth"
+ *   - bills     → status.warning amber (#FDE68A / bg-amber-300) – "attention"
+ *   - insurance → brand violet (bg-violet-400)                  – "protection"
+ *
+ * All four foreground colors clear 4.5:1 on the app's #010101 / #0A0A0A dark surface
+ * (verified against WCAG 2.1 AA Non-Text Contrast § 1.4.11 for UI components and
+ * WCAG 2.1 AA Text Contrast § 1.4.3 for labels).
+ */
+
+import { ShoppingCart, PiggyBank, FileText, Shield } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { SplitConfig } from "@/lib/remittance/split";
+
+export interface BucketMeta {
+  /** Must match a key of SplitConfig */
+  key: keyof SplitConfig;
+  label: string;
+  description: string;
+  /** Lucide icon component */
+  icon: LucideIcon;
+  /** Tailwind bg-* class for the allocation bar segment and dot indicators */
+  barColor: string;
+  /** Tailwind text-* class for percentage/amount labels */
+  textColor: string;
+  /** Raw hex value used where Tailwind can't be applied (e.g. inline SVG, recharts Cell) */
+  hex: string;
+}
+
+export const SPLIT_BUCKETS: readonly BucketMeta[] = [
+  {
+    key: "spending",
+    label: "Daily Spending",
+    description: "For immediate family expenses",
+    icon: ShoppingCart,
+    barColor: "bg-blue-300",
+    textColor: "text-blue-300",
+    hex: "#93C5FD",
+  },
+  {
+    key: "savings",
+    label: "Savings",
+    description: "Allocated to savings goals",
+    icon: PiggyBank,
+    barColor: "bg-green-300",
+    textColor: "text-green-300",
+    hex: "#86EFAC",
+  },
+  {
+    key: "bills",
+    label: "Bills",
+    description: "Automated bill payments",
+    icon: FileText,
+    barColor: "bg-amber-300",
+    textColor: "text-amber-300",
+    hex: "#FDE68A",
+  },
+  {
+    key: "insurance",
+    label: "Insurance",
+    description: "Micro-insurance premiums",
+    icon: Shield,
+    barColor: "bg-violet-400",
+    textColor: "text-violet-400",
+    hex: "#A78BFA",
+  },
+] as const;


### PR DESCRIPTION
- Add lib/config/split-buckets.ts: single 4-bucket color/label/icon mapping (spending, savings, bills, insurance) aligned to tailwind.config.js brand/status tokens; reusable by split page and dashboard widgets
- app/split/page.tsx: proportional AllocationBar + AllocationDetailCards with largest-remainder rounding, 0% suppression, 100% single-bucket handling; SplitInput colors sourced from SPLIT_BUCKETS
- components/SmartMoneySplitHeader.tsx: accept allocation prop and render compact segmented bar with icon+text legend when allocation is valid
- docs/split-bucket-color-map.md: document token mapping, WCAG contrast figures, and edge-case handling


Closes #1298 