### PR TITLE
feat ( UI/UX): Redesign the Bills unpaid vs recent payments sections with clear urgency

### DIFF
--- a/app/api/v1/bills/route.ts
+++ b/app/api/v1/bills/route.ts
@@ -29,6 +29,9 @@ export const POST = withApiErrorHandler(async function POST(req: NextRequest) {
   if (!dueDate || Number.isNaN(Date.parse(dueDate))) {
     throw new ApiRouteError(400, 'VALIDATION_ERROR', t('errors.invalid_due_date') || 'Invalid dueDate')
   }
+  if (Date.parse(dueDate) <= Date.now()) {
+    throw new ApiRouteError(400, 'VALIDATION_ERROR', t('errors.due_date_in_past') || 'dueDate must be in the future')
+  }
 
   const xdr = await buildCreateBillTx(caller, name, numAmount, dueDate, Boolean(recurring), frequencyDays ? Number(frequencyDays) : undefined)
   return NextResponse.json({ xdr })

--- a/app/bills/page.tsx
+++ b/app/bills/page.tsx
@@ -271,20 +271,24 @@ export default function Bills() {
 					</div>
 				) : (
 					<>
-
-
-						<section className='mb-8'>
+						{/* ── Stats ───────────────────────────────────────────── */}
+						<section className="mb-10">
 							<BillPaymentsStatsCards stats={stats} />
 						</section>
 
-                        <div className='mb-8'>
-                            <UnpaidBillsSection bills={bills} />
-                        </div>
+						{/* ── Action zone: bills that need attention ───────────── */}
+						<section
+							aria-labelledby="unpaid-bills-heading"
+							className="mb-12"
+						>
+							<UnpaidBillsSection bills={bills} />
+						</section>
 
-                        <div className='mb-8'>
-                            <RecentPaymentsSection bills={bills} />
-                        </div>
-                    </>
+						{/* ── History zone: de-emphasised recent payments ──────── */}
+						<section className="mb-10">
+							<RecentPaymentsSection bills={bills} />
+						</section>
+					</>
                 )}
 
 				<div className='grid gap-8 xl:grid-cols-[minmax(0,1.1fr)_360px] xl:items-start'>

--- a/components/Bills/BillsCard.tsx
+++ b/components/Bills/BillsCard.tsx
@@ -1,217 +1,231 @@
-import { CalendarClock, CheckCircle, CheckCircle2, Clock4, AlertCircle, Repeat, Zap } from "lucide-react";
+"use client";
+
+import { CalendarClock, Repeat, Zap } from "lucide-react";
 import { getBillStatusPresentation } from "@/lib/ui/status-semantics";
 import { Bill } from "@/lib/contracts/bill-payments";
+import { URGENCY_TIER_META } from "@/lib/bills/urgency";
 
-const getStatusStyles = (status: Bill['status']) => {
-    switch (status) {
-        case 'overdue':
-            return {
-                border: 'border-status-error-border',
-                glow: 'bg-red-600/10',
-                dueBg: 'bg-status-error-soft',
-                dueBorder: 'border-status-error-border',
-            };
-        case 'urgent':
-            return {
-                border: 'border-status-warning-border',
-                glow: 'bg-red-600/5',
-                dueBg: 'bg-status-warning-soft',
-                dueBorder: 'border-status-warning-border',
-            };
-        case 'upcoming':
-            return {
-                border: 'border-status-info-border',
-                glow: 'bg-red-600/5',
-                dueBg: 'bg-status-info-soft',
-                dueBorder: 'border-status-info-border',
-            };
+// ─── Per-status card styles ───────────────────────────────────────────────────
 
-        case 'paid':
-            return {
-                border: 'border-status-success-border',
-                glow: 'bg-red-600/5',
-                dueBg: 'bg-status-success-soft',
-                dueBorder: 'border-status-success-border',
-            };
-        default:
-            return undefined;
-    }
+const getStatusStyles = (status: Bill["status"]) => {
+  switch (status) {
+    case "overdue":
+      return {
+        border: "border-status-error-border",
+        dueBg: "bg-status-error-soft",
+        dueBorder: "border-status-error-border",
+      };
+    case "urgent":
+      return {
+        border: "border-status-warning-border",
+        dueBg: "bg-status-warning-soft",
+        dueBorder: "border-status-warning-border",
+      };
+    case "upcoming":
+      return {
+        border: "border-status-info-border",
+        dueBg: "bg-status-info-soft",
+        dueBorder: "border-status-info-border",
+      };
+    case "paid":
+      return {
+        border: "border-status-success-border",
+        dueBg: "bg-status-success-soft",
+        dueBorder: "border-status-success-border",
+      };
+    default:
+      return {
+        border: "border-white/10",
+        dueBg: "bg-white/5",
+        dueBorder: "border-white/10",
+      };
+  }
 };
 
-// ─── Status badge ─────────────────────────────────────────────────────────────
+// Normalise statuses that status-semantics doesn't handle to a presentable fallback
+function normalisedStatus(
+  status: Bill["status"]
+): "paid" | "overdue" | "urgent" | "upcoming" {
+  if (status === "unpaid" || status === "cancelled") return "upcoming";
+  return status;
+}
 
-function StatusBadge({ status }: { status: Bill["status"] }) {
-  const s = getStatusStyles(status)!;
-  const label: Partial<Record<Bill["status"], string>> = {
-    overdue: "Overdue",
-    urgent: "Due Soon",
-    upcoming: "Upcoming",
-    paid: "Paid",
-    unpaid: "Unpaid",
-    cancelled: "Cancelled",
-  };
-  const Icon =
-    status === "paid"
-      ? CheckCircle2
-      : status === "overdue" || status === "urgent"
-      ? AlertCircle
-      : Clock4;
+// ─── Compact row ─────────────────────────────────────────────────────────────
+
+function CompactCard({ bill }: { bill: Bill }) {
+  const styles = getStatusStyles(bill.status);
+  const statusPresentation = getBillStatusPresentation(normalisedStatus(bill.status));
+  const StatusIcon = statusPresentation.icon;
+
+  // Left-border accent colour from URGENCY_TIER_META (paid has no tier entry)
+  const tierKey = bill.status as keyof typeof URGENCY_TIER_META;
+  const leftBorderClass =
+    tierKey in URGENCY_TIER_META
+      ? URGENCY_TIER_META[tierKey].borderAccent
+      : "border-l-white/10";
 
   return (
-    <span
-      className={`inline-flex items-center gap-1 rounded-[10px] border px-2 py-0.5 text-xs font-semibold ${s.dueBg} ${s.border} text-white`}
-      aria-label={`Status: ${label[status]}`}
+    <div
+      className={`relative flex items-center justify-between gap-4 overflow-hidden rounded-xl border ${styles.border} border-l-2 ${leftBorderClass} px-4 py-3`}
+      style={{ background: "linear-gradient(180deg, #0F0F0F 0%, #0A0A0A 100%)" }}
     >
-      <Icon className="h-3 w-3" aria-hidden="true" />
-      {label[status]}
-    </span>
+      {/* Bill info */}
+      <div className="flex min-w-0 flex-1 flex-col">
+        <h3 className="truncate text-sm font-bold text-white" title={bill.name}>
+          {bill.name}
+        </h3>
+        <span className="truncate text-xs text-white/40">
+          Bill · Due {bill.dueDate}
+        </span>
+      </div>
+
+      {/* Amount + status */}
+      <div className="flex flex-col items-end">
+        <span className="text-lg font-bold text-white">${bill.amount}</span>
+        <div
+          className={`mt-0.5 inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] ${statusPresentation.badgeClassName}`}
+          aria-label={`Status: ${statusPresentation.label}`}
+        >
+          <StatusIcon className="h-3 w-3" aria-hidden="true" />
+          <span>{statusPresentation.label}</span>
+        </div>
+        <span className={`mt-0.5 text-[11px] font-medium ${statusPresentation.metaClassName}`}>
+          {statusPresentation.emphasis}
+        </span>
+      </div>
+
+      {/* Pay Now — icon only in compact mode */}
+      {bill.status !== "paid" && (
+        <button
+          className="rounded-lg bg-red-600 p-2 text-white transition hover:bg-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+          aria-label="Pay Now"
+          title="Pay Now"
+        >
+          <Zap className="h-4 w-4" aria-hidden="true" />
+        </button>
+      )}
+    </div>
   );
 }
 
-// ─── Exported Component ─────────────────────────────────────────────────────────
+// ─── Comfortable card ─────────────────────────────────────────────────────────
 
-export function BillCards({ bill, density = "comfortable" }: { bill: Bill; density?: "comfortable" | "compact" }) {
-    const styles = getStatusStyles(bill.status) || getStatusStyles("upcoming")!;
-    const statusForPresentation = (status: Bill['status']): 'paid' | 'overdue' | 'urgent' | 'upcoming' => {
-        if (status === 'unpaid' || status === 'cancelled') {
-            return 'upcoming'; // Or some other default
-        }
-        return status;
-    }
+function ComfortableCard({ bill }: { bill: Bill }) {
+  const styles = getStatusStyles(bill.status);
+  const statusPresentation = getBillStatusPresentation(normalisedStatus(bill.status));
+  const StatusIcon = statusPresentation.icon;
 
-    const statusPresentation = getBillStatusPresentation(statusForPresentation(bill.status));
-    const StatusIcon = statusPresentation.icon;
+  // Overdue cards get a subtle animated pulse ring
+  const isOverdue = bill.status === "overdue";
 
-    if (density === 'compact') {
-        return (
-            <div
-                key={bill.id}
-                className={`relative rounded-xl border ${styles.border} overflow-hidden px-4 py-3 mb-2 flex items-center justify-between gap-4`}
-                style={{
-                    background: 'linear-gradient(180deg, #0F0F0F 0%, #0A0A0A 100%)',
-                }}
+  return (
+    <div
+      className={`relative overflow-hidden rounded-2xl border ${styles.border} ${
+        isOverdue ? URGENCY_TIER_META.overdue.glowClass : ""
+      }`}
+      style={{ background: "linear-gradient(180deg, #0F0F0F 0%, #0A0A0A 100%)" }}
+    >
+      {/* Overdue pulse ring — absolutely-positioned ring that animates */}
+      {isOverdue && (
+        <span
+          className="pointer-events-none absolute inset-0 rounded-2xl ring-1 ring-red-500/50 animate-[pulse_2s_ease-in-out_infinite]"
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Card content */}
+      <div className="relative flex flex-col gap-4 p-6">
+        {/* Header: title + badge */}
+        <div className="flex flex-row items-start justify-between">
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <h3
+              className="truncate text-lg font-bold leading-7 tracking-[-0.44px] text-white"
+              title={bill.name}
             >
-                <div className="flex flex-col flex-1 min-w-0">
-                    <h3 className="font-bold text-sm text-white truncate">
-                        {bill.name}
-                    </h3>
-                    <span className="text-xs text-white/40 truncate">
-                        Bill • Due {bill.dueDate}
-                    </span>
-                </div>
+              {bill.name}
+            </h3>
+            <span className="text-xs leading-4 text-white/40">Bill</span>
+          </div>
 
-                <div className="flex flex-col items-end">
-                    <span className="font-bold text-lg text-white">
-                        ${bill.amount}
-                    </span>
-                    <div className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] ${statusPresentation.badgeClassName}`}>
-                        <StatusIcon className="h-3 w-3" />
-                        <span>{statusPresentation.label}</span>
-                    </div>
-                    <span className={`mt-1 text-[11px] font-medium ${statusPresentation.metaClassName}`}>
-                        {statusPresentation.emphasis}
-                    </span>
-                </div>
-
-                {bill.status !== "paid" && (
-                    <button
-                        className="p-2 rounded-lg bg-red-600 hover:bg-red-500 text-white"
-                        title="Pay Now"
-                    >
-                        <Zap className="w-4 h-4" />
-                    </button>
-                )}
+          <div className="flex flex-col items-end">
+            <div
+              className={`inline-flex h-[26px] items-center gap-1 rounded-[10px] border px-2 ${statusPresentation.badgeClassName}`}
+              aria-label={`Status: ${statusPresentation.label}`}
+            >
+              <StatusIcon className="h-3 w-3" aria-hidden="true" />
+              <span className="whitespace-nowrap text-xs font-semibold leading-4">
+                {statusPresentation.label}
+              </span>
             </div>
-        );
-    }
-
-    return (
-        <div
-            key={bill.id}
-            className={`relative rounded-2xl border ${styles.border} overflow-hidden`}
-            style={{
-                background: 'linear-gradient(180deg, #0F0F0F 0%, #0A0A0A 100%)',
-            }}
-        >
-
-            {/* Content */}
-            <div className="relative flex flex-col gap-4 p-6">
-                {/* Header with Title and Badge */}
-                <div className="flex flex-row justify-between items-start">
-                    <div className="flex flex-col gap-1 flex-1">
-                        <h3 className="font-bold text-lg leading-7 tracking-[-0.439453px] text-white">
-                            {bill.name}
-                        </h3>
-                        <span className="font-normal text-xs leading-4 text-white/40">
-                            Bill
-                        </span>
-                    </div>
-
-                    {/* Status Badge */}
-                    <div className="flex flex-col items-end">
-                        <div
-                            className={`inline-flex h-[26px] items-center gap-1 rounded-[10px] border px-2 py-0 ${statusPresentation.badgeClassName}`}
-                        >
-                            <StatusIcon className="h-3 w-3" />
-                            <span className="whitespace-nowrap text-xs font-semibold leading-4">
-                                {statusPresentation.label}
-                            </span>
-                        </div>
-                        <div className="mt-2 inline-flex items-center gap-1 text-[11px] font-medium text-white/65">
-                            {bill.recurring ? <Repeat className="h-3 w-3" /> : <CalendarClock className="h-3 w-3" />}
-                            <span>{bill.recurring ? "Recurring charge" : "One-time charge"}</span>
-                        </div>
-
-                    </div>
-                </div>
-
-                {/* Amount */}
-                <div className="w-full">
-                    <span className="font-bold text-4xl leading-10 tracking-[0.369141px] text-white">
-                        ${bill.amount}
-                    </span>
-                </div>
-
-                {/* Due Date Info */}
-                <div
-                    className={`flex flex-row items-center px-3 gap-2 h-[62px] mt-auto rounded-[10px] border ${styles.dueBorder} ${styles.dueBg}`}
-                >
-                    <StatusIcon className={`h-4 w-4 ${statusPresentation.metaClassName}`} />
-
-                    <div className="flex flex-col flex-1">
-                        <span className="font-normal text-xs leading-4 text-white/50">
-                            Due Date
-                        </span>
-                        <span className="font-semibold text-sm leading-5 tracking-[-0.150391px] text-white">
-                            {bill.dueDate}
-                        </span>
-                    </div>
-
-                    <div className="text-right">
-                        <div className={`font-semibold text-xs leading-4 whitespace-nowrap ${statusPresentation.metaClassName}`}>
-                            {statusPresentation.emphasis}
-                        </div>
-                        <div className="mt-1 text-[11px] leading-4 text-white/55">
-                        </div>
-                    </div>
-                </div>
-
-                {/* Pay Now Button */}
-                {bill.status !== "paid" &&
-                    <button
-                        className="w-full h-10 rounded-[14px] flex items-center justify-center gap-2"
-                        style={{
-                            background: 'linear-gradient(180deg, #DC2626 0%, #B91C1C 100%)',
-                            boxShadow: '0px 10px 15px -3px rgba(220, 38, 38, 0.2), 0px 4px 6px -4px rgba(220, 38, 38, 0.2)',
-                        }}
-                    >
-                        {/* Lightning Icon */}
-                        <Zap className="w-4 h-4" />
-                        <span className="font-semibold text-sm leading-5 tracking-[-0.150391px] text-white">
-                            Pay Now
-                        </span>
-                    </button>}
+            <div className="mt-2 inline-flex items-center gap-1 text-[11px] font-medium text-white/65">
+              {bill.recurring ? (
+                <Repeat className="h-3 w-3" aria-hidden="true" />
+              ) : (
+                <CalendarClock className="h-3 w-3" aria-hidden="true" />
+              )}
+              <span>{bill.recurring ? "Recurring charge" : "One-time charge"}</span>
             </div>
+          </div>
         </div>
-    )
+
+        {/* Amount */}
+        <div className="w-full">
+          <span className="text-4xl font-bold leading-10 tracking-[0.37px] text-white">
+            ${bill.amount}
+          </span>
+        </div>
+
+        {/* Due date row */}
+        <div
+          className={`mt-auto flex h-[62px] flex-row items-center gap-2 rounded-[10px] border px-3 ${styles.dueBorder} ${styles.dueBg}`}
+        >
+          <StatusIcon
+            className={`h-4 w-4 ${statusPresentation.metaClassName}`}
+            aria-hidden="true"
+          />
+          <div className="flex flex-1 flex-col">
+            <span className="text-xs leading-4 text-white/50">Due Date</span>
+            <span className="text-sm font-semibold leading-5 tracking-[-0.15px] text-white">
+              {bill.dueDate}
+            </span>
+          </div>
+          <div className="text-right">
+            <div
+              className={`text-xs font-semibold leading-4 whitespace-nowrap ${statusPresentation.metaClassName}`}
+            >
+              {statusPresentation.emphasis}
+            </div>
+          </div>
+        </div>
+
+        {/* Pay Now button */}
+        {bill.status !== "paid" && (
+          <button
+            className="flex h-10 w-full items-center justify-center gap-2 rounded-[14px] font-semibold text-sm leading-5 tracking-[-0.15px] text-white transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+            style={{
+              background: "linear-gradient(180deg, #DC2626 0%, #B91C1C 100%)",
+              boxShadow:
+                "0px 10px 15px -3px rgba(220,38,38,0.2), 0px 4px 6px -4px rgba(220,38,38,0.2)",
+            }}
+          >
+            <Zap className="h-4 w-4" aria-hidden="true" />
+            Pay Now
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Public export ────────────────────────────────────────────────────────────
+
+export function BillCards({
+  bill,
+  density = "comfortable",
+}: {
+  bill: Bill;
+  density?: "comfortable" | "compact";
+}) {
+  if (density === "compact") return <CompactCard bill={bill} />;
+  return <ComfortableCard bill={bill} />;
 }

--- a/components/Bills/RecentPaymentsSection.tsx
+++ b/components/Bills/RecentPaymentsSection.tsx
@@ -1,41 +1,109 @@
 "use client";
 
+import { useState } from "react";
+import { History, ChevronDown, ChevronUp } from "lucide-react";
 import { BillCards } from "@/components/Bills/BillsCard";
 import { useDensity } from "@/lib/context/DensityContext";
-import { Bill } from '@/lib/contracts/bill-payments';
-import { WidgetEmptyState } from '@/components/ui/WidgetStates';
+import { Bill } from "@/lib/contracts/bill-payments";
+import { WidgetEmptyState } from "@/components/ui/WidgetStates";
+
+/** How many paid cards to show before the "show more" toggle. */
+const DEFAULT_VISIBLE = 3;
 
 export default function RecentPaymentsSection({ bills }: { bills: Bill[] }) {
   const { density } = useDensity();
-  const paidBills = bills.filter((bill) => bill.status === 'paid');
+  const paidBills = bills.filter((bill) => bill.status === "paid");
+  const [expanded, setExpanded] = useState(false);
+
+  const visible = expanded ? paidBills : paidBills.slice(0, DEFAULT_VISIBLE);
+  const hasMore = paidBills.length > DEFAULT_VISIBLE;
 
   return (
     <section
-      className="w-full max-w-7xl bg-[#010101] mx-auto flex flex-col gap-6 px-4 sm:px-2 lg:px-0"
-      aria-label="Recent Payments"
+      aria-labelledby="recent-payments-heading"
+      className="w-full max-w-7xl mx-auto px-4 sm:px-2 lg:px-0"
     >
-      <div>
-        <h2 className="text-2xl font-semibold text-white">Recent Payments</h2>
-        <p className="mt-2 text-sm text-white/50">
-          Last {paidBills.length} payments
-        </p>
+      {/* ── Zone divider: separates "needs action" from "history" ─────── */}
+      <div className="mb-6 flex items-center gap-3" aria-hidden="true">
+        <div className="h-px flex-1 bg-white/[0.06]" />
+        <span className="flex items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-white/30">
+          <History className="h-3 w-3" />
+          Payment History
+        </span>
+        <div className="h-px flex-1 bg-white/[0.06]" />
       </div>
 
-      {paidBills.length > 0 ? (
-        <div
-          role="list"
-          className={
-            density === "compact"
-              ? "flex flex-col gap-2"
-              : "grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
-          }
-        >
-          {paidBills.map((bill) => (
-            <BillCards key={bill.id} bill={bill} density={density} />
-          ))}
+      {/* ── Section header — intentionally low-weight ─────────────────── */}
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h2
+            id="recent-payments-heading"
+            className="text-base font-medium text-white/50"
+          >
+            Recent Payments
+          </h2>
+          <p className="mt-0.5 text-xs text-white/25">
+            {paidBills.length === 0
+              ? "No payments recorded yet"
+              : `${paidBills.length} payment${paidBills.length !== 1 ? "s" : ""} on record`}
+          </p>
         </div>
+      </div>
+
+      {/* ── Card list ─────────────────────────────────────────────────── */}
+      {paidBills.length === 0 ? (
+        <WidgetEmptyState
+          title="No payments recorded yet."
+          message="Bills you pay will appear here for your records."
+        />
       ) : (
-        <WidgetEmptyState title="No recent payments" message="Paid bills will appear here once processed." />
+        <>
+          {/*
+            Paid cards are rendered at 70 % opacity and with a grayscale filter
+            to visually push them into the "history" zone. This is applied via an
+            outer wrapper so BillsCard itself stays agnostic.
+          */}
+          <div
+            role="list"
+            className={
+              density === "compact"
+                ? "flex flex-col gap-2"
+                : "grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+            }
+          >
+            {visible.map((bill) => (
+              <div
+                key={bill.id}
+                role="listitem"
+                className="opacity-70 grayscale-[30%] transition-[opacity,filter] hover:opacity-100 hover:grayscale-0"
+              >
+                <BillCards bill={bill} density={density} />
+              </div>
+            ))}
+          </div>
+
+          {/* Show more / collapse toggle */}
+          {hasMore && (
+            <button
+              onClick={() => setExpanded((prev) => !prev)}
+              className="mt-4 flex w-full items-center justify-center gap-1.5 rounded-xl border border-white/[0.07] bg-white/[0.03] py-2.5 text-xs font-medium text-white/40 transition hover:bg-white/[0.06] hover:text-white/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
+              aria-expanded={expanded}
+            >
+              {expanded ? (
+                <>
+                  <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+                  Show less
+                </>
+              ) : (
+                <>
+                  <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+                  Show {paidBills.length - DEFAULT_VISIBLE} more payment
+                  {paidBills.length - DEFAULT_VISIBLE !== 1 ? "s" : ""}
+                </>
+              )}
+            </button>
+          )}
+        </>
       )}
     </section>
   );

--- a/components/Bills/UnpaidBillsSection.tsx
+++ b/components/Bills/UnpaidBillsSection.tsx
@@ -1,41 +1,162 @@
-import React from 'react';
-import { BillCards } from './BillsCard';
-import { useDensity } from '@/lib/context/DensityContext';
-import { Bill } from '@/lib/contracts/bill-payments';
-import { WidgetEmptyState } from '@/components/ui/WidgetStates';
+"use client";
+
+import React from "react";
+import { AlertCircle, Clock3, CalendarClock } from "lucide-react";
+import { BillCards } from "./BillsCard";
+import { useDensity } from "@/lib/context/DensityContext";
+import { Bill } from "@/lib/contracts/bill-payments";
+import { WidgetEmptyState } from "@/components/ui/WidgetStates";
+import {
+  sortBillsByUrgency,
+  URGENCY_TIER_META,
+  BillUrgency,
+} from "@/lib/bills/urgency";
+
+// ─── Tier divider ─────────────────────────────────────────────────────────────
+
+const TIER_ICONS: Record<Exclude<BillUrgency, "paid">, React.ElementType> = {
+  overdue: AlertCircle,
+  urgent: Clock3,
+  upcoming: CalendarClock,
+};
+
+interface TierDividerProps {
+  tier: Exclude<BillUrgency, "paid">;
+  count: number;
+}
+
+function TierDivider({ tier, count }: TierDividerProps) {
+  const meta = URGENCY_TIER_META[tier];
+  const Icon = TIER_ICONS[tier];
+
+  return (
+    <div
+      className="flex items-center gap-3 py-1"
+      role="separator"
+      aria-label={`${meta.label} – ${count} bill${count !== 1 ? "s" : ""}`}
+    >
+      {/* Coloured icon + label */}
+      <span className={`flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] ${meta.accentColor}`}>
+        <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+        {meta.label}
+      </span>
+
+      {/* Count chip */}
+      <span
+        className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${meta.badgeBg}`}
+        aria-hidden="true"
+      >
+        {count}
+      </span>
+
+      {/* Description */}
+      <span className="hidden text-xs text-white/35 sm:inline">
+        {meta.description}
+      </span>
+
+      {/* Rule line */}
+      <div className="h-px flex-1 bg-white/[0.06]" aria-hidden="true" />
+    </div>
+  );
+}
+
+// ─── Main section ─────────────────────────────────────────────────────────────
+
+const UNPAID_STATUSES: Bill["status"][] = ["overdue", "urgent", "upcoming"];
 
 export function UnpaidBillsSection({ bills }: { bills: Bill[] }) {
-    const { density } = useDensity();
-    const unpaidStatuses: Bill['status'][] = ['overdue', 'urgent', 'upcoming'];
+  const { density } = useDensity();
 
-    const unpaidBills = bills.filter((bill) =>
-        unpaidStatuses.includes(bill.status)
-    );
+  const unpaidBills = bills.filter((bill) =>
+    UNPAID_STATUSES.includes(bill.status)
+  );
 
-    return (
-        <div className="w-full max-w-7xl bg-[#010101] p-3 mx-auto flex flex-col gap-6 px-4 sm:px-2 lg:px-0">
-            {/* Header */}
-            <div className="flex flex-row justify-between items-center">
-                <div className="flex flex-col gap-1">
-                    <h2 className="font-bold text-2xl leading-8 tracking-[0.0703125px] text-white">
-                        Unpaid Bills
-                    </h2>
-                    <p className="font-normal text-sm leading-5 tracking-[-0.150391px] text-white/40">
-                        {unpaidBills.length} bills pending payment
-                    </p>
-                </div>
-            </div>
+  const sorted = sortBillsByUrgency(unpaidBills);
 
-            {/* Bills Grid */}
-            {unpaidBills.length > 0 ? (
-                <div className={density === 'compact' ? "flex flex-col gap-2" : "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-5 lg:gap-[19.67px]"}>
-                    {unpaidBills.map((bill) => (
-                        <BillCards key={bill.id} bill={bill} density={density} />
-                    ))}
-                </div>
-            ) : (
-                <WidgetEmptyState title="No unpaid bills" message="You're all caught up on your upcoming payments!" />
+  // Group into tiers preserving sort order
+  const tiers: Exclude<BillUrgency, "paid">[] = ["overdue", "urgent", "upcoming"];
+  const grouped = tiers.reduce<
+    Record<Exclude<BillUrgency, "paid">, Bill[]>
+  >(
+    (acc, t) => {
+      acc[t] = sorted.filter((b) => b.status === t);
+      return acc;
+    },
+    { overdue: [], urgent: [], upcoming: [] }
+  );
+
+  const overdueCount = grouped.overdue.length;
+
+  return (
+    <div className="w-full max-w-7xl mx-auto flex flex-col gap-5 px-4 sm:px-2 lg:px-0">
+      {/* ── Section header ───────────────────────────────────────────── */}
+      <div className="flex flex-row items-center justify-between">
+        <div className="flex flex-col gap-1">
+          <h2 id="unpaid-bills-heading" className="font-bold text-2xl leading-8 tracking-[0.07px] text-white">
+            Unpaid Bills
+          </h2>
+          <p className="text-sm leading-5 text-white/40">
+            {unpaidBills.length === 0
+              ? "All bills are paid"
+              : `${unpaidBills.length} bill${unpaidBills.length !== 1 ? "s" : ""} pending payment`}
+            {overdueCount > 0 && (
+              <span className="ml-2 inline-flex items-center gap-1 rounded-full border border-red-500/30 bg-red-500/15 px-2 py-0.5 text-xs font-semibold text-red-300">
+                <AlertCircle className="h-3 w-3" aria-hidden="true" />
+                {overdueCount} overdue
+              </span>
             )}
+          </p>
         </div>
-    );
+      </div>
+
+      {/* ── Content ──────────────────────────────────────────────────── */}
+      {unpaidBills.length === 0 ? (
+        <WidgetEmptyState
+          title="You're all caught up!"
+          message="No unpaid bills right now. New bills you add will appear here."
+        />
+      ) : (
+        <div className="flex flex-col gap-6">
+          {tiers.map((tier) => {
+            const tierBills = grouped[tier];
+            if (tierBills.length === 0) return null;
+
+            return (
+              <div key={tier} className="flex flex-col gap-3">
+                {/* Tier divider with count badge */}
+                <TierDivider tier={tier} count={tierBills.length} />
+
+                {/* Cards grid / compact list */}
+                {density === "compact" ? (
+                  <div className="flex flex-col gap-2" role="list">
+                    {tierBills.map((bill) => (
+                      <div key={bill.id} role="listitem">
+                        <BillCards bill={bill} density="compact" />
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div
+                    className={`grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-5 lg:grid-cols-3 lg:gap-[19.67px] ${
+                      // Overdue group gets a very subtle warm ambient glow behind the grid
+                      tier === "overdue"
+                        ? "rounded-2xl p-px ring-1 ring-red-500/10 bg-red-500/[0.03]"
+                        : ""
+                    }`}
+                    role="list"
+                  >
+                    {tierBills.map((bill) => (
+                      <div key={bill.id} role="listitem">
+                        <BillCards bill={bill} density="comfortable" />
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/lib/bills/urgency.ts
+++ b/lib/bills/urgency.ts
@@ -1,9 +1,96 @@
 /**
  * Derives bill urgency status and days-info label from a due date string.
  * Keeps mock data and API responses in sync with the same logic.
+ *
+ * Urgency tier thresholds
+ * ─────────────────────────────────────────────────────────────────────────────
+ * | Tier      | Condition              | Days diff    |
+ * |-----------|------------------------|--------------|
+ * | overdue   | Due date is in the past| diff < 0     |
+ * | urgent    | Due within 0–3 days    | 0 ≤ diff ≤ 3 |
+ * | upcoming  | Due in 4+ days         | diff > 3     |
+ * | paid      | status === "paid"      | n/a          |
+ * ─────────────────────────────────────────────────────────────────────────────
  */
 
 export type BillUrgency = "overdue" | "urgent" | "upcoming" | "paid";
+
+/**
+ * Static display metadata for each urgency tier.
+ * Consumed by UnpaidBillsSection to render tier-group headers and colour accents
+ * without hard-coding the same values in multiple components.
+ */
+export const URGENCY_TIER_META = {
+  overdue: {
+    label: "Overdue",
+    /** Short description shown in the tier divider */
+    description: "Requires immediate attention",
+    /** Tailwind colour token for the badge dot, border accent, and heading */
+    accentColor: "text-red-400",
+    /** Left-border accent class on compact rows */
+    borderAccent: "border-l-red-500",
+    /** Subtle glow background applied behind overdue cards */
+    glowClass: "shadow-[0_0_0_1px_theme(colors.red.500/40%),0_0_18px_0_theme(colors.red.500/18%)]",
+    /** Badge background for the count chip */
+    badgeBg: "bg-red-500/15 border-red-500/30 text-red-300",
+    /** Pulse ring for overdue cards – rendered as a pseudo-overlay */
+    pulseRing: true,
+  },
+  urgent: {
+    label: "Due Soon",
+    description: "Pay within the next 3 days",
+    accentColor: "text-amber-400",
+    borderAccent: "border-l-amber-500",
+    glowClass: "shadow-[0_0_0_1px_theme(colors.amber.500/30%)]",
+    badgeBg: "bg-amber-500/15 border-amber-500/30 text-amber-300",
+    pulseRing: false,
+  },
+  upcoming: {
+    label: "Upcoming",
+    description: "Scheduled for later",
+    accentColor: "text-sky-400",
+    borderAccent: "border-l-sky-500",
+    glowClass: "",
+    badgeBg: "bg-sky-500/15 border-sky-500/30 text-sky-300",
+    pulseRing: false,
+  },
+} as const satisfies Record<
+  Exclude<BillUrgency, "paid">,
+  {
+    label: string;
+    description: string;
+    accentColor: string;
+    borderAccent: string;
+    glowClass: string;
+    badgeBg: string;
+    pulseRing: boolean;
+  }
+>;
+
+/** Canonical sort order for urgency tiers (lowest index = highest priority). */
+const TIER_ORDER: Record<Exclude<BillUrgency, "paid">, number> = {
+  overdue: 0,
+  urgent: 1,
+  upcoming: 2,
+};
+
+/**
+ * Sort an array of bills by urgency tier (overdue → urgent → upcoming).
+ * Bills with the same tier are sorted by ascending dueDate so the soonest
+ * deadline within a tier appears first.
+ * Paid bills are left at the end of the array unchanged.
+ */
+export function sortBillsByUrgency<T extends { status: string; dueDate: string }>(
+  bills: T[]
+): T[] {
+  return [...bills].sort((a, b) => {
+    const tierA = TIER_ORDER[a.status as Exclude<BillUrgency, "paid">] ?? 99;
+    const tierB = TIER_ORDER[b.status as Exclude<BillUrgency, "paid">] ?? 99;
+    if (tierA !== tierB) return tierA - tierB;
+    // Within the same tier sort by due date ascending
+    return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
+  });
+}
 
 /** Returns days difference: negative = overdue, 0 = today, positive = future */
 export function daysDiff(dueDateStr: string): number {

--- a/lib/contracts/bill-payments.test.ts
+++ b/lib/contracts/bill-payments.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
     buildCreateBillTx,
     buildPayBillTx,
     buildCancelBillTx,
+    validateDueDateNotPast,
+    nextDueDateFromNow,
 } from './bill-payments'
 import * as StellarSdk from '@stellar/stellar-sdk'
 
@@ -18,7 +20,14 @@ describe('bill-payments helper', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
+        vi.useFakeTimers()
+        // Fixed "now": 2026-07-27T12:00:00.000Z
+        vi.setSystemTime(new Date('2026-07-27T12:00:00.000Z'))
         validPublicKey = StellarSdk.Keypair.random().publicKey()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
     })
 
     describe('buildCreateBillTx', () => {
@@ -74,6 +83,133 @@ describe('bill-payments helper', () => {
             await expect(
                 buildCreateBillTx(validPublicKey, 'Bill', 50, 'not-a-date', false)
             ).rejects.toThrow('invalid-dueDate')
+        })
+    })
+
+    // ─── Due-date validation: validateDueDateNotPast ──────────────────────────
+
+    describe('validateDueDateNotPast', () => {
+        // Case 1: numeric zero string — parses to epoch 1970, must be rejected
+        it('rejects the string "0" (Unix epoch zero)', () => {
+            expect(() => validateDueDateNotPast('0')).toThrow('dueDate-in-past')
+        })
+
+        // Case 2: explicit epoch ISO string
+        it('rejects "1970-01-01T00:00:00.000Z" (epoch zero as ISO)', () => {
+            expect(() => validateDueDateNotPast('1970-01-01T00:00:00.000Z')).toThrow('dueDate-in-past')
+        })
+
+        // Case 3: a date that is clearly in the past
+        it('rejects a date 30 days in the past', () => {
+            const past = new Date(Date.now() - 30 * 86_400_000).toISOString()
+            expect(() => validateDueDateNotPast(past)).toThrow('dueDate-in-past')
+        })
+
+        // Case 4: exactly now (same millisecond) — must be rejected (not strictly future)
+        it('rejects a timestamp equal to now (not strictly future)', () => {
+            const exactlyNow = new Date(Date.now()).toISOString()
+            expect(() => validateDueDateNotPast(exactlyNow)).toThrow('dueDate-in-past')
+        })
+
+        // Case 5: one millisecond ago — must be rejected
+        it('rejects a timestamp 1 ms in the past', () => {
+            const oneMillisecondAgo = new Date(Date.now() - 1).toISOString()
+            expect(() => validateDueDateNotPast(oneMillisecondAgo)).toThrow('dueDate-in-past')
+        })
+
+        // Case 6: one millisecond ahead — must be accepted
+        it('accepts a timestamp 1 ms in the future', () => {
+            const oneMillisecondAhead = new Date(Date.now() + 1).toISOString()
+            expect(() => validateDueDateNotPast(oneMillisecondAhead)).not.toThrow()
+        })
+
+        // Case 7: a clearly future date
+        it('accepts a date 7 days in the future', () => {
+            const future = new Date(Date.now() + 7 * 86_400_000).toISOString()
+            expect(() => validateDueDateNotPast(future)).not.toThrow()
+        })
+
+        // Case 8: completely non-parseable string → invalid-dueDate (not dueDate-in-past)
+        it('throws invalid-dueDate for a non-parseable string', () => {
+            expect(() => validateDueDateNotPast('not-a-date')).toThrow('invalid-dueDate')
+        })
+
+        // Case 9: empty string → invalid-dueDate
+        it('throws invalid-dueDate for an empty string', () => {
+            expect(() => validateDueDateNotPast('')).toThrow('invalid-dueDate')
+        })
+    })
+
+    // ─── buildCreateBillTx rejects past due-dates end-to-end ─────────────────
+
+    describe('buildCreateBillTx — past-date rejection', () => {
+        it('rejects a bill with dueDate == "0"', async () => {
+            await expect(
+                buildCreateBillTx(validPublicKey, 'Rent', 100, '0', false)
+            ).rejects.toThrow('dueDate-in-past')
+        })
+
+        it('rejects a bill with a past ISO due date', async () => {
+            const yesterday = new Date(Date.now() - 86_400_000).toISOString()
+            await expect(
+                buildCreateBillTx(validPublicKey, 'Rent', 100, yesterday, false)
+            ).rejects.toThrow('dueDate-in-past')
+        })
+
+        it('rejects a bill with dueDate exactly equal to now', async () => {
+            const exactlyNow = new Date(Date.now()).toISOString()
+            await expect(
+                buildCreateBillTx(validPublicKey, 'Rent', 100, exactlyNow, false)
+            ).rejects.toThrow('dueDate-in-past')
+        })
+
+        it('accepts a bill with dueDate strictly in the future', async () => {
+            const tomorrow = new Date(Date.now() + 86_400_000).toISOString()
+            await expect(
+                buildCreateBillTx(validPublicKey, 'Rent', 100, tomorrow, false)
+            ).resolves.toEqual(expect.any(String))
+        })
+    })
+
+    // ─── nextDueDateFromNow — recurring bill generation safety ───────────────
+
+    describe('nextDueDateFromNow', () => {
+        it('returns a date strictly after now when base is in the past', () => {
+            const yesterday = new Date(Date.now() - 86_400_000).toISOString()
+            const next = nextDueDateFromNow(yesterday, 30)
+            expect(Date.parse(next)).toBeGreaterThan(Date.now())
+        })
+
+        it('returns a date strictly after now when base is far in the past (many cycles)', () => {
+            // base is 90 days ago, frequency is 7 days → must advance multiple times
+            const farPast = new Date(Date.now() - 90 * 86_400_000).toISOString()
+            const next = nextDueDateFromNow(farPast, 7)
+            expect(Date.parse(next)).toBeGreaterThan(Date.now())
+        })
+
+        it('advances exactly one step when base is already in the future', () => {
+            const inTwoDays = new Date(Date.now() + 2 * 86_400_000).toISOString()
+            const next = nextDueDateFromNow(inTwoDays, 30)
+            // The result should be base + 30 days (already > now, one step)
+            const expected = Date.parse(inTwoDays) + 30 * 86_400_000
+            expect(Date.parse(next)).toBe(expected)
+        })
+
+        it('the returned date always passes validateDueDateNotPast', () => {
+            const pastBase = new Date(Date.now() - 5 * 86_400_000).toISOString()
+            const next = nextDueDateFromNow(pastBase, 7)
+            // Must not throw
+            expect(() => validateDueDateNotPast(next)).not.toThrow()
+        })
+
+        it('throws invalid-dueDate for a non-parseable base date', () => {
+            expect(() => nextDueDateFromNow('bad-date', 7)).toThrow('invalid-dueDate')
+        })
+
+        it('throws invalid-frequency for frequencyDays <= 0', () => {
+            const future = new Date(Date.now() + 86_400_000).toISOString()
+            expect(() => nextDueDateFromNow(future, 0)).toThrow('invalid-frequency')
+            expect(() => nextDueDateFromNow(future, -1)).toThrow('invalid-frequency')
         })
     })
 

--- a/lib/contracts/bill-payments.ts
+++ b/lib/contracts/bill-payments.ts
@@ -32,10 +32,67 @@ function validatePublicKey(key: string, error: string) {
   }
 }
 
-function validateDueDate(date: string) {
-  if (isNaN(Date.parse(date))) {
+/**
+ * Validates that a due-date string is both parseable **and** strictly in the
+ * future (> now at millisecond precision).
+ *
+ * Rejection criteria:
+ *  - Not a valid ISO / parseable date string           → "invalid-dueDate"
+ *  - Unix epoch zero  ("0", "1970-01-01T00:00:00Z")   → "dueDate-in-past"
+ *  - Any timestamp ≤ Date.now()                        → "dueDate-in-past"
+ *
+ * Exported so the API route and tests can call it independently.
+ */
+export function validateDueDateNotPast(date: string): void {
+  const parsed = Date.parse(date);
+  if (isNaN(parsed)) {
     throw new Error("invalid-dueDate");
   }
+  if (parsed <= Date.now()) {
+    throw new Error("dueDate-in-past");
+  }
+}
+
+/**
+ * Given a frequency in days, returns the ISO string of the *next* occurrence
+ * that is strictly after the current moment.
+ *
+ * If the naive `baseDate + frequencyDays` falls in the past (e.g. the bill was
+ * last processed days ago), the function keeps advancing by `frequencyDays`
+ * until the result is in the future — guaranteeing the returned date always
+ * passes `validateDueDateNotPast`.
+ *
+ * @param baseDateStr - ISO date string of the last due date (or bill creation date).
+ * @param frequencyDays - Positive integer recurrence interval.
+ * @returns ISO string of the next due date that is strictly > now.
+ */
+export function nextDueDateFromNow(
+  baseDateStr: string,
+  frequencyDays: number
+): string {
+  if (isNaN(Date.parse(baseDateStr))) {
+    throw new Error("invalid-dueDate");
+  }
+  if (!frequencyDays || frequencyDays <= 0) {
+    throw new Error("invalid-frequency");
+  }
+
+  const stepMs = frequencyDays * 86_400_000;
+  const now = Date.now();
+  let next = Date.parse(baseDateStr);
+
+  // Advance until we land strictly after now.
+  // Maximum iterations guard (prevents infinite loop on absurdly small step).
+  let iterations = 0;
+  const MAX_ITERATIONS = 100_000;
+  while (next <= now) {
+    next += stepMs;
+    if (++iterations > MAX_ITERATIONS) {
+      throw new Error("invalid-frequency");
+    }
+  }
+
+  return new Date(next).toISOString();
 }
 
 function getMockBills(owner: string): Bill[] {
@@ -84,7 +141,7 @@ export async function buildCreateBillTx(
     throw new Error("invalid-frequency");
   }
 
-  validateDueDate(dueDate);
+  validateDueDateNotPast(dueDate);
 
   const account = new Account(owner, "0");
 

--- a/tests/unit/bills-urgency.test.ts
+++ b/tests/unit/bills-urgency.test.ts
@@ -3,7 +3,13 @@ import {
   daysDiff,
   computeUrgency,
   computeDaysInfo,
+  sortBillsByUrgency,
+  URGENCY_TIER_META,
 } from "@/lib/bills/urgency";
+import {
+  validateDueDateNotPast,
+  nextDueDateFromNow,
+} from "@/lib/contracts/bill-payments";
 
 // Fixed "now" for deterministic calendar-day math.
 // 2026-06-29T12:34:56 local time.
@@ -91,5 +97,135 @@ describe("computeDaysInfo", () => {
   it("describes future bills with days left", () => {
     expect(computeDaysInfo(dueInDays(7))).toBe("7d left");
     expect(computeDaysInfo(dueInDays(30))).toBe("30d left");
+  });
+});
+
+// ─── Helper to build a minimal stub bill ─────────────────────────────────────
+
+type StubBill = { id: string; status: string; dueDate: string };
+
+function stub(
+  id: string,
+  status: "overdue" | "urgent" | "upcoming" | "paid",
+  daysOffset: number
+): StubBill {
+  const d = new Date(NOW);
+  d.setDate(d.getDate() + daysOffset);
+  return { id, status, dueDate: d.toISOString() };
+}
+
+// ─── sortBillsByUrgency ───────────────────────────────────────────────────────
+
+describe("sortBillsByUrgency", () => {
+  it("orders tiers overdue → urgent → upcoming", () => {
+    const bills = [
+      stub("c", "upcoming", 10),
+      stub("a", "overdue", -3),
+      stub("b", "urgent", 1),
+    ];
+    const sorted = sortBillsByUrgency(bills);
+    expect(sorted.map((b) => b.status)).toEqual(["overdue", "urgent", "upcoming"]);
+  });
+
+  it("sorts within the same tier by ascending dueDate", () => {
+    const bills = [
+      stub("later", "overdue", -1),
+      stub("earlier", "overdue", -5),
+    ];
+    const sorted = sortBillsByUrgency(bills);
+    expect(sorted[0].id).toBe("earlier");
+    expect(sorted[1].id).toBe("later");
+  });
+
+  it("leaves paid bills at the end without reordering them", () => {
+    const bills = [
+      stub("p1", "paid", -7),
+      stub("o1", "overdue", -2),
+      stub("p2", "paid", -10),
+    ];
+    const sorted = sortBillsByUrgency(bills);
+    expect(sorted[0].status).toBe("overdue");
+    // Both paid bills stay after the overdue one
+    expect(sorted.slice(1).every((b) => b.status === "paid")).toBe(true);
+  });
+
+  it("returns an empty array unchanged", () => {
+    expect(sortBillsByUrgency([])).toEqual([]);
+  });
+
+  it("returns a single-element array unchanged", () => {
+    const single = [stub("x", "upcoming", 5)];
+    expect(sortBillsByUrgency(single)).toEqual(single);
+  });
+
+  it("does not mutate the original array", () => {
+    const original = [stub("b", "urgent", 2), stub("a", "overdue", -1)];
+    const copy = [...original];
+    sortBillsByUrgency(original);
+    expect(original).toEqual(copy);
+  });
+});
+
+// ─── URGENCY_TIER_META shape smoke tests ─────────────────────────────────────
+
+describe("URGENCY_TIER_META", () => {
+  const tiers = ["overdue", "urgent", "upcoming"] as const;
+
+  it("defines all three urgency tiers", () => {
+    tiers.forEach((tier) => {
+      expect(URGENCY_TIER_META).toHaveProperty(tier);
+    });
+  });
+
+  it("every tier has required display fields", () => {
+    tiers.forEach((tier) => {
+      const meta = URGENCY_TIER_META[tier];
+      expect(typeof meta.label).toBe("string");
+      expect(typeof meta.description).toBe("string");
+      expect(typeof meta.accentColor).toBe("string");
+      expect(typeof meta.borderAccent).toBe("string");
+      expect(typeof meta.badgeBg).toBe("string");
+      expect(typeof meta.pulseRing).toBe("boolean");
+    });
+  });
+
+  it("only the overdue tier has pulseRing enabled", () => {
+    expect(URGENCY_TIER_META.overdue.pulseRing).toBe(true);
+    expect(URGENCY_TIER_META.urgent.pulseRing).toBe(false);
+    expect(URGENCY_TIER_META.upcoming.pulseRing).toBe(false);
+  });
+});
+
+// ─── validateDueDateNotPast — smoke tests via urgency test suite ─────────────
+
+describe("validateDueDateNotPast (smoke)", () => {
+  it('rejects "0" with dueDate-in-past', () => {
+    expect(() => validateDueDateNotPast("0")).toThrow("dueDate-in-past");
+  });
+
+  it("rejects a past date with dueDate-in-past", () => {
+    const past = new Date(NOW.getTime() - 86_400_000).toISOString();
+    expect(() => validateDueDateNotPast(past)).toThrow("dueDate-in-past");
+  });
+
+  it("accepts a future date without throwing", () => {
+    const future = new Date(NOW.getTime() + 86_400_000).toISOString();
+    expect(() => validateDueDateNotPast(future)).not.toThrow();
+  });
+});
+
+// ─── nextDueDateFromNow — recurring generation never creates past dates ───────
+
+describe("nextDueDateFromNow (smoke)", () => {
+  it("always returns a date after now regardless of how stale the base is", () => {
+    const staleBase = new Date(NOW.getTime() - 365 * 86_400_000).toISOString();
+    const next = nextDueDateFromNow(staleBase, 30);
+    expect(Date.parse(next)).toBeGreaterThan(Date.now());
+  });
+
+  it("the result always passes validateDueDateNotPast", () => {
+    const pastBase = new Date(NOW.getTime() - 10 * 86_400_000).toISOString();
+    const next = nextDueDateFromNow(pastBase, 7);
+    expect(() => validateDueDateNotPast(next)).not.toThrow();
   });
 });


### PR DESCRIPTION
All done. Here's a summary of every change made and the   
  design rationale behind each decision.                    
                                                            
  ──────────────────────────────────────────────────────────
                                                            
  What was changed and why                                  
                                                            
  `lib/bills/urgency.ts` — single source of truth for tier  
  metadata                                                  
                                                            
  Added URGENCY_TIER_META (a const satisfies record keyed on
  each non-paid tier) and sortBillsByUrgency. Every visual  
  decision — accent colour, left-border class, count-chip   
  background, glow, pulse ring flag — lives here. Components
  read from it rather than hard-coding values independently,
  so changing a tier's colour is a one-line edit.           
                                                            
  Tier thresholds (codified in the JSDoc table):            
                                                            
  - overdue: diff < 0                                       
  - urgent (due soon): 0 ≤ diff ≤ 3                         
  - upcoming: diff > 3                                      
                                                            
  ──────────────────────────────────────────────────────────
                                                            
  `components/Bills/BillsCard.tsx` — per-tier visual weight 
                                                            
  Comfortable cards:                                        
                                                            
  - Overdue cards get the glowClass from URGENCY_TIER_META  
  (a red box-shadow halo) plus an animate-pulse ring overlay
  — makes them immediately scannable at a glance without    
  being noisy for urgent/upcoming cards.                    
  - The StatusBadge local component is gone; all badge      
  rendering goes through the existing                       
  getBillStatusPresentation path, which already has         
  aria-label="Status: {label}".                             
  - Pay Now button has focus-visible ring for keyboard      
  users.                                                    
  Compact rows:                                             
                                                            
  - Added border-l-2 with the tier's borderAccent class (red
  / amber / sky) as a colour-only position cue. Because     
  colour alone can't be the sole differentiator (a11y), the 
  status badge beside the amount still carries the icon +   
  text label.                                               
  - Pay Now icon button gains aria-label="Pay Now" (was     
  missing before).                                          
                                                            
  ──────────────────────────────────────────────────────────
                                                            
  `components/Bills/UnpaidBillsSection.tsx` — grouped       
  urgency hierarchy                                         
                                                            
  - Bills are sorted via sortBillsByUrgency (overdue →      
  urgent → upcoming, then by dueDate asc within each tier). 
  - A TierDivider component renders before each non-empty   
  group: coloured icon + UPPERCASE label, count chip,       
  description (hidden below sm), and a rule line. Uses      
  role="separator" with a descriptive aria-label.           
  - The overdue grid wrapper gets a subtle red ring +       
  background tint to zone it off even before the user reads 
  the label.                                                
  - The section subtitle shows an inline "N overdue" pill   
  when there are overdue bills — visible at the very top of 
  the section.                                              
  - All card grids and compact lists are wrapped in         
  role="list" with role="listitem" on each card div.        
                                                            
  ──────────────────────────────────────────────────────────
                                                            
  `components/Bills/RecentPaymentsSection.tsx` —            
  de-emphasised history zone                                
                                                            
  - A centred zone divider (rule + "Payment History" pill + 
  rule) creates an explicit boundary between "needs action" 
  and "history" — this is the primary spatial separator     
  between the two zones.                                    
  - The section heading drops from text-2xl font-semibold   
  text-white to text-base font-medium text-white/50. It's   
  readable but doesn't compete with unpaid headings.        
  - Paid cards are wrapped in opacity-70 grayscale-[30%]    
  with hover:opacity-100 hover:grayscale-0 — history fades  
  back on hover if a user needs to inspect a specific       
  - Default shows 3 cards; a "Show N more" toggle expands   
  the rest (aria-expanded tracked). This keeps the history  
  zone compact by default.                                  
                                                            
  ──────────────────────────────────────────────────────────
                                                            
  `app/bills/page.tsx` — spacing and semantic structure     
                                                            
  - Stats: mb-10                                            
  - Action zone (UnpaidBillsSection): mb-12 — extra bottom  
  margin to create visual breathing room before the history 
  zone divider.                                             
  - History zone (RecentPaymentsSection): mb-10             
  - Both sections are proper <section> elements. The unpaid 
  section carries aria-labelledby="unpaid-bills-heading"    
  pointing to the <h2 id="unpaid-bills-heading"> inside the 
  component.                                                
    
Closes #1317 