### PR TITLE
feat(uiux): redesign async contract operations progress ui

### DIFF
--- a/components/AsyncOperationsPanel.tsx
+++ b/components/AsyncOperationsPanel.tsx
@@ -1,18 +1,9 @@
 "use client";
 
-import {
-	ArrowUpRight,
-	CheckCircle2,
-	ChevronDown,
-	ChevronUp,
-	Clock3,
-	Loader2,
-	ShieldCheck,
-	Wallet,
-	type LucideIcon,
-} from "lucide-react";
+import { ChevronDown, ChevronUp, ShieldCheck, Wallet, type LucideIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useAsyncOperations, OperationStatus } from "@/lib/context/AsyncOperationsContext";
+import { ASYNC_STATUS_VISUALS, type AsyncStatusToken } from "@/lib/asyncStatusTokens";
 
 type AsyncStage = {
 	label: string;
@@ -26,7 +17,7 @@ type QueueItem = {
 	title: string;
 	duration: string;
 	detail: string;
-	status: "active" | "queued" | "complete" | "failed";
+	status: AsyncStatusToken;
 };
 
 interface AsyncOperationsPanelProps {
@@ -40,39 +31,7 @@ interface AsyncOperationsPanelProps {
 	footer?: string;
 }
 
-const queueStatusStyles = {
-	active: {
-		badge: "Live now",
-		cardClass:
-			"border-red-500/20 bg-[linear-gradient(180deg,rgba(127,29,29,0.22),rgba(18,18,18,0.96))]",
-		iconClass: "text-red-300",
-		Icon: Loader2,
-		spin: true,
-	},
-	queued: {
-		badge: "Queued",
-		cardClass: "border-white/10 bg-[#111111]",
-		iconClass: "text-amber-200",
-		Icon: Clock3,
-		spin: false,
-	},
-	complete: {
-		badge: "Confirmed",
-		cardClass: "border-emerald-500/20 bg-emerald-500/[0.08]",
-		iconClass: "text-emerald-300",
-		Icon: CheckCircle2,
-		spin: false,
-	},
-	failed: {
-		badge: "Failed",
-		cardClass: "border-amber-500/20 bg-amber-500/[0.06]",
-		iconClass: "text-amber-200",
-		Icon: Clock3,
-		spin: false,
-	},
-} as const;
-
-const mapStatus = (status: OperationStatus): QueueItem['status'] => {
+const mapStatus = (status: OperationStatus): AsyncStatusToken => {
 	switch (status) {
 		case 'building':
 		case 'awaiting-signature':
@@ -85,6 +44,12 @@ const mapStatus = (status: OperationStatus): QueueItem['status'] => {
 		default:
 			return 'queued';
 	}
+};
+
+const STATUS_COUNT_LABEL: Record<Exclude<AsyncStatusToken, "active">, string> = {
+	queued: "queued",
+	complete: "confirmed",
+	failed: "failed",
 };
 
 export default function AsyncOperationsPanel({
@@ -121,7 +86,7 @@ export default function AsyncOperationsPanel({
 		if (state.operations.length > 0) {
 			return state.operations.map(op => ({
 				title: op.title,
-				duration: 'Just now', 
+				duration: 'Just now',
 				detail: op.detail,
 				status: mapStatus(op.status),
 			}));
@@ -129,19 +94,42 @@ export default function AsyncOperationsPanel({
 		return propQueueItems;
 	}, [state.operations, propQueueItems]);
 
+	// The active operation is the most prominent item: it always renders in
+	// full, outside the collapsible rest-of-queue section.
 	const activeIndex = useMemo(() => queueItems.findIndex((i) => i.status === "active"), [queueItems]);
+	const activeItem = activeIndex >= 0 ? queueItems[activeIndex] : null;
+	const restItems = useMemo(
+		() => queueItems.filter((_, index) => index !== activeIndex),
+		[queueItems, activeIndex]
+	);
 
 	useEffect(() => {
 		// Close open detail if item list changes and index no longer valid
-		if (openIndex !== null && openIndex >= queueItems.length) setOpenIndex(null);
-	}, [queueItems, openIndex]);
+		if (openIndex !== null && openIndex >= restItems.length) setOpenIndex(null);
+	}, [restItems, openIndex]);
 
-	// Live announcement for major state: active started/completed/failed
+	const restSummary = useMemo(() => {
+		const counts: Record<string, number> = {};
+		restItems.forEach((item) => {
+			counts[item.status] = (counts[item.status] ?? 0) + 1;
+		});
+		return (Object.keys(counts) as Array<keyof typeof STATUS_COUNT_LABEL>)
+			.filter((status) => counts[status] > 0)
+			.map((status) => `${counts[status]} ${STATUS_COUNT_LABEL[status]}`)
+			.join(" · ");
+	}, [restItems]);
+
+	// Live announcement for the operation the user cares about most right now.
 	const [liveText, setLiveText] = useState("");
 	useEffect(() => {
-		const active = queueItems[activeIndex];
-		if (active) setLiveText(`${active.title} ${active.status}`);
-	}, [queueItems, activeIndex]);
+		const headline = activeItem ?? queueItems[0];
+		if (headline) {
+			setLiveText(`${headline.title}: ${ASYNC_STATUS_VISUALS[headline.status].badge}`);
+		} else {
+			setLiveText("");
+		}
+	}, [queueItems, activeItem]);
+
 	return (
 		<section className='min-w-0 max-w-full overflow-hidden rounded-3xl border border-white/[0.08] bg-[linear-gradient(180deg,rgba(18,18,18,0.98),rgba(10,10,10,0.98))] p-6 sm:p-7'>
 			<div className='border-b border-white/[0.08] pb-5'>
@@ -152,17 +140,17 @@ export default function AsyncOperationsPanel({
 				<p className='mt-2 break-words text-sm leading-6 text-gray-300'>{description}</p>
 			</div>
 
-			<div className='mt-6 space-y-3'>
+			<div className='mt-6 space-y-2.5'>
 				{stages.map((stage, index) => {
 					const StageIcon = stage.icon ?? (index < 2 ? ShieldCheck : Wallet);
 
 					return (
 						<article
 							key={stage.label}
-							className='min-w-0 rounded-2xl border border-white/[0.08] bg-black/20 p-4'>
+							className='min-w-0 rounded-2xl border border-white/[0.08] bg-black/20 p-3.5'>
 							<div className='flex min-w-0 items-start justify-between gap-4'>
 								<div className='flex min-w-0 items-start gap-3'>
-									<div className='flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.04] text-red-300'>
+									<div className='flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/[0.04] text-red-300'>
 										<StageIcon className='h-4 w-4' />
 									</div>
 									<div className='min-w-0'>
@@ -174,7 +162,7 @@ export default function AsyncOperationsPanel({
 												{stage.duration}
 											</span>
 										</div>
-										<p className='mt-2 break-words text-sm leading-6 text-gray-300'>
+										<p className='mt-1.5 break-words text-sm leading-6 text-gray-300'>
 											{stage.detail}
 										</p>
 									</div>
@@ -183,7 +171,7 @@ export default function AsyncOperationsPanel({
 									{stage.placement}
 								</span>
 							</div>
-							<p className='mt-3 break-words text-xs uppercase tracking-[0.16em] text-gray-500 sm:hidden'>
+							<p className='mt-2 break-words text-xs uppercase tracking-[0.16em] text-gray-500 sm:hidden'>
 								{stage.placement}
 							</p>
 						</article>
@@ -191,7 +179,10 @@ export default function AsyncOperationsPanel({
 				})}
 			</div>
 
-			{/* Queue: compact rail on desktop, inline on mobile */}
+			{/* Queue: active operation stays fully visible; queued/complete/failed
+			    items collapse behind a single toggle so the rail doesn't dominate
+			    the screen. Desktop places this panel in a top-right sticky rail;
+			    mobile stacks it inline below the initiating form (see caller). */}
 			<div className='mt-6 min-w-0'>
 				<div className='flex min-w-0 items-start justify-between gap-3'>
 					<div className='min-w-0'>
@@ -200,78 +191,57 @@ export default function AsyncOperationsPanel({
 							{queueDescription}
 						</p>
 					</div>
-					<div className='flex items-center gap-2'>
-						<span className='hidden sm:inline-flex text-xs text-gray-400'>{queueItems.length} total</span>
-						<button
-							aria-expanded={expanded}
-							aria-controls='ops-panel'
-							onClick={() => setExpanded((s) => !s)}
-							className='inline-flex items-center gap-2 rounded-md bg-white/[0.02] px-2 py-1 text-xs text-gray-300 hover:bg-white/[0.04]'>
-							{expanded ? (
-								<ChevronUp className='h-4 w-4' />
-							) : (
-								<ChevronDown className='h-4 w-4' />
-							)}
-							<span className='sr-only'>Toggle operations panel</span>
-						</button>
-					</div>
+					<button
+						aria-expanded={expanded}
+						aria-controls='ops-panel'
+						onClick={() => setExpanded((s) => !s)}
+						className='inline-flex flex-shrink-0 items-center gap-2 rounded-md bg-white/[0.02] px-2 py-1 text-xs text-gray-300 hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400'>
+						{expanded ? (
+							<ChevronUp className='h-4 w-4' />
+						) : (
+							<ChevronDown className='h-4 w-4' />
+						)}
+						<span className='sr-only'>Toggle operations panel</span>
+					</button>
 				</div>
 
-				<div id='ops-panel' className={`mt-4 space-y-3 ${expanded ? "" : "max-h-[220px] overflow-hidden"}`}>
-					{queueItems.map((item, index) => {
-						const statusConfig = queueStatusStyles[item.status] ?? queueStatusStyles.queued;
-						const StatusIcon = statusConfig.Icon;
-						const isActive = item.status === "active";
-						const isOpen = openIndex === index;
+				<div className='mt-4 space-y-3'>
+					{activeItem ? (
+						<ActiveOperationCard item={activeItem} />
+					) : queueItems.length === 0 ? (
+						<p className='rounded-2xl border border-dashed border-white/10 bg-black/10 p-4 text-sm leading-6 text-gray-400'>
+							No operations yet. This panel populates automatically once a contract action starts.
+						</p>
+					) : null}
 
-						return (
-							<article
-								key={`${item.title}-${item.status}-${index}`}
-								className={`group relative flex flex-col rounded-2xl border p-3 ${statusConfig.cardClass} ${isActive ? "ring-2 ring-blue-400/20 shadow-md" : ""}`}>
-								<div className='flex items-center justify-between gap-3'>
-									<div className='flex items-center gap-3 min-w-0'>
-										<div className={`flex h-8 w-8 items-center justify-center rounded-md border border-white/8 bg-white/[0.03] ${isActive ? "animate-pulse" : ""}`}>
-											<StatusIcon className={`h-4 w-4 ${statusConfig.iconClass}`} />
-										</div>
-										<div className='min-w-0'>
-											<div className='flex items-center gap-2'>
-												<h4 className='truncate text-sm font-semibold text-white'>
-													{item.title}
-												</h4>
-												<span className='hidden md:inline-flex rounded-full border border-white/10 bg-white/[0.03] px-2 py-0.5 text-[11px] font-medium uppercase tracking-[0.12em] text-gray-400'>
-													{statusConfig.badge}
-												</span>
-											</div>
-											<p className='mt-1 truncate text-xs text-gray-300'>{item.detail}</p>
-										</div>
-									</div>
-
-									<div className='flex items-center gap-2'>
-										<span className='text-xs text-gray-300'>{item.duration}</span>
-										<button
-											aria-expanded={isOpen}
-											aria-controls={`op-${index}`}
-											onClick={() => setOpenIndex(isOpen ? null : index)}
-											className='ml-2 inline-flex items-center justify-center rounded-md p-2 text-gray-300 hover:bg-white/[0.02]'>
-											{isOpen ? <ChevronUp className='h-4 w-4' /> : <ChevronDown className='h-4 w-4' />}
-										</button>
-									</div>
+					{restItems.length > 0 ? (
+						<div id='ops-panel'>
+							{!expanded ? (
+								<button
+									onClick={() => setExpanded(true)}
+									aria-expanded={false}
+									className='flex w-full items-center justify-between rounded-2xl border border-white/[0.08] bg-black/10 px-4 py-2.5 text-left text-xs text-gray-300 hover:bg-white/[0.03] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400'>
+									<span>
+										{restItems.length} more {restItems.length === 1 ? "item" : "items"}
+										{restSummary ? ` · ${restSummary}` : ""}
+									</span>
+									<ChevronDown className='h-4 w-4 flex-shrink-0' />
+								</button>
+							) : (
+								<div className='space-y-2'>
+									{restItems.map((item, index) => (
+										<CompactOperationRow
+											key={`${item.title}-${item.status}-${index}`}
+											item={item}
+											isOpen={openIndex === index}
+											onToggle={() => setOpenIndex(openIndex === index ? null : index)}
+											controlsId={`op-${index}`}
+										/>
+									))}
 								</div>
-
-								{isOpen ? (
-									<div id={`op-${index}`} className='mt-3 border-t border-white/[0.04] pt-3 text-sm text-gray-300'>
-										<p>{item.detail}</p>
-										<div className='mt-2 flex gap-2'>
-											{item.status === 'failed' ? (
-												<button className='rounded-md bg-amber-500/10 px-3 py-1 text-amber-200'>Retry</button>
-											) : null}
-											<a className='text-sm text-blue-400 hover:underline' href='#'>View details</a>
-										</div>
-									</div>
-								) : null}
-							</article>
-						);
-					})}
+							)}
+						</div>
+					) : null}
 				</div>
 				<div aria-hidden className='sr-only' aria-live='polite'>{liveText}</div>
 			</div>
@@ -280,5 +250,86 @@ export default function AsyncOperationsPanel({
 				<p className='mt-4 break-words text-xs leading-5 text-gray-500'>{footer}</p>
 			) : null}
 		</section>
+	);
+}
+
+function ActiveOperationCard({ item }: { item: QueueItem }) {
+	const visual = ASYNC_STATUS_VISUALS.active;
+	const StatusIcon = visual.Icon;
+
+	return (
+		<article className={`relative rounded-2xl border p-4 shadow-lg shadow-red-950/20 ring-2 ring-red-400/20 ${visual.cardClass}`}>
+			<div className='flex items-start gap-3'>
+				<div className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-2xl border ${visual.iconWrapClass}`}>
+					<StatusIcon className={`h-5 w-5 ${visual.iconClass} ${visual.spin ? "animate-spin" : ""}`} />
+				</div>
+				<div className='min-w-0 flex-1'>
+					<div className='flex flex-wrap items-center gap-2'>
+						<h4 className='break-words text-sm font-semibold text-white'>{item.title}</h4>
+						<span className='inline-flex items-center gap-1.5 rounded-full border border-red-400/30 bg-red-500/10 px-2.5 py-0.5 text-[11px] font-medium uppercase tracking-[0.12em] text-red-200'>
+							<span className={`h-1.5 w-1.5 rounded-full ${visual.dotClass} animate-pulse`} aria-hidden />
+							{visual.badge}
+						</span>
+					</div>
+					<p className='mt-1.5 break-words text-sm leading-6 text-gray-300'>{item.detail}</p>
+					<p className='mt-2 text-xs text-gray-400'>{item.duration}</p>
+				</div>
+			</div>
+		</article>
+	);
+}
+
+function CompactOperationRow({
+	item,
+	isOpen,
+	onToggle,
+	controlsId,
+}: {
+	item: QueueItem;
+	isOpen: boolean;
+	onToggle: () => void;
+	controlsId: string;
+}) {
+	const visual = ASYNC_STATUS_VISUALS[item.status];
+	const StatusIcon = visual.Icon;
+
+	return (
+		<article className={`flex flex-col rounded-xl border p-2.5 ${visual.cardClass}`}>
+			<div className='flex items-center justify-between gap-3'>
+				<div className='flex min-w-0 items-center gap-2.5'>
+					<div className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg border ${visual.iconWrapClass}`}>
+						<StatusIcon className={`h-3.5 w-3.5 ${visual.iconClass} ${visual.spin ? "animate-spin" : ""}`} />
+					</div>
+					<div className='min-w-0'>
+						<div className='flex items-center gap-2'>
+							<h4 className='truncate text-xs font-semibold text-white'>{item.title}</h4>
+							<span className='hidden text-[10px] font-medium uppercase tracking-[0.12em] text-gray-400 md:inline'>
+								{visual.badge}
+							</span>
+						</div>
+					</div>
+				</div>
+				<div className='flex flex-shrink-0 items-center gap-2'>
+					<span className='text-[11px] text-gray-400'>{item.duration}</span>
+					<button
+						aria-expanded={isOpen}
+						aria-controls={controlsId}
+						aria-label={isOpen ? `Hide details for ${item.title}` : `Show details for ${item.title}`}
+						onClick={onToggle}
+						className='inline-flex items-center justify-center rounded-md p-1.5 text-gray-300 hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400'>
+						{isOpen ? <ChevronUp className='h-3.5 w-3.5' /> : <ChevronDown className='h-3.5 w-3.5' />}
+					</button>
+				</div>
+			</div>
+
+			{isOpen ? (
+				<div id={controlsId} className='mt-2.5 border-t border-white/[0.06] pt-2.5 text-xs leading-5 text-gray-300'>
+					<p>{item.detail}</p>
+					{item.status === "failed" ? (
+						<button className='mt-2 rounded-md bg-amber-500/10 px-3 py-1 text-amber-200'>Retry</button>
+					) : null}
+				</div>
+			) : null}
+		</article>
 	);
 }

--- a/components/AsyncSubmissionStatus.test.tsx
+++ b/components/AsyncSubmissionStatus.test.tsx
@@ -291,4 +291,31 @@ describe("AsyncSubmissionStatus", () => {
 			expect(screen.getByText("Ready")).toBeInTheDocument();
 		});
 	});
+
+	describe("Shared status tokens with AsyncOperationsPanel", () => {
+		it("colors pending the same as the queue's active token (both mean 'in flight')", () => {
+			const { container: pendingContainer } = render(
+				<AsyncSubmissionStatus {...defaultProps} pending={true} />
+			);
+			const pendingIcon = pendingContainer.querySelector("svg");
+			expect(pendingIcon).toHaveClass("text-red-300");
+			expect(pendingIcon).toHaveClass("animate-spin");
+		});
+
+		it("colors error the same as the queue's failed token (both mean 'needs attention')", () => {
+			const { container } = render(
+				<AsyncSubmissionStatus {...defaultProps} error="Timeout" />
+			);
+			const icon = container.querySelector("svg");
+			expect(icon).toHaveClass("text-amber-200");
+		});
+
+		it("colors success the same as the queue's complete token", () => {
+			const { container } = render(
+				<AsyncSubmissionStatus {...defaultProps} success="Done" />
+			);
+			const icon = container.querySelector("svg");
+			expect(icon).toHaveClass("text-emerald-300");
+		});
+	});
 });

--- a/components/AsyncSubmissionStatus.tsx
+++ b/components/AsyncSubmissionStatus.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { AlertCircle, CheckCircle2, Clock3, Loader2 } from "lucide-react";
 import { useAsyncOperations } from "@/lib/context/AsyncOperationsContext";
 import LiveRegion from "@/components/ui/LiveRegion";
+import { ASYNC_STATUS_VISUALS, SUBMISSION_TO_ASYNC_TOKEN } from "@/lib/asyncStatusTokens";
 
 interface AsyncSubmissionStatusProps {
         pending?: boolean; // Made optional
@@ -17,35 +17,26 @@ interface AsyncSubmissionStatusProps {
         errorTitle?: string;
 }
 
+// Labels here are distinct from the panel's queue badges (idle/pending/success/error
+// describe *this* submission, not a queue position) but the color/icon per state
+// is sourced from the same ASYNC_STATUS_VISUALS tokens as AsyncOperationsPanel so
+// the two components read as one system across Split and Bills.
 const statusStyles = {
         idle: {
-                Icon: Clock3,
-                cardClass: "border-white/[0.08] bg-black/20",
-                iconClass: "text-gray-300",
+                ...ASYNC_STATUS_VISUALS[SUBMISSION_TO_ASYNC_TOKEN.idle],
                 label: "Ready",
-                spin: false,
         },
         pending: {
-                Icon: Loader2,
-                cardClass:
-                        "border-red-500/20 bg-[linear-gradient(180deg,rgba(127,29,29,0.18),rgba(16,16,16,0.96))]",
-                iconClass: "text-red-200",
+                ...ASYNC_STATUS_VISUALS[SUBMISSION_TO_ASYNC_TOKEN.pending],
                 label: "In progress",
-                spin: true,
         },
         success: {
-                Icon: CheckCircle2,
-                cardClass: "border-emerald-500/20 bg-emerald-500/[0.08]",
-                iconClass: "text-emerald-300",
+                ...ASYNC_STATUS_VISUALS[SUBMISSION_TO_ASYNC_TOKEN.success],
                 label: "Complete",
-                spin: false,
         },
         error: {
-                Icon: AlertCircle,
-                cardClass: "border-amber-500/20 bg-amber-500/[0.08]",
-                iconClass: "text-amber-200",
+                ...ASYNC_STATUS_VISUALS[SUBMISSION_TO_ASYNC_TOKEN.error],
                 label: "Needs attention",
-                spin: false,
         },
 } as const;
 

--- a/docs/async-contract-submissions-handoff.md
+++ b/docs/async-contract-submissions-handoff.md
@@ -22,6 +22,59 @@ Stacking rules:
 - Compress queued and completed items into smaller cards instead of replacing the active item.
 - On mobile, render the same stack inline below the initiating form or modal footer instead of floating it off-screen.
 
+## Panel redesign (2026-07): spotlight + collapse
+
+`AsyncOperationsPanel` and `AsyncSubmissionStatus` were redesigned to stop the
+stacked rail from competing with the primary form for attention. The rules
+below supersede the older "always-stacked" description above where they
+conflict.
+
+Status tokens (`lib/asyncStatusTokens.ts`):
+- Both components now read color, icon, and badge copy for a status from one
+  shared table, `ASYNC_STATUS_VISUALS`, keyed by `active | queued | complete |
+  failed`. `AsyncSubmissionStatus`'s idle/pending/success/error states map onto
+  the same four tokens via `SUBMISSION_TO_ASYNC_TOKEN` (idle→queued,
+  pending→active, success→complete, error→failed), so a red pulsing treatment
+  always means "in flight" and an amber treatment always means "needs
+  attention," regardless of which component is rendering it.
+- `failed` uses a distinct `AlertCircle` icon (previously it reused the
+  `queued` clock icon, which blurred the two states).
+
+Active-item spotlight:
+- The active operation (if any) always renders in full — title, detail,
+  duration, and a pulsing "Live now" badge — directly under the queue header,
+  outside the collapsible section. It is never hidden by the collapse toggle.
+- This is the single most prominent element in the queue: larger icon well,
+  a ring border, and full (non-truncated) detail copy.
+
+Collapse/expand:
+- Queued, complete, and failed items collapse behind one toggle by default,
+  shown as a single summary row (e.g. "2 more items · 1 queued · 1 confirmed").
+  Expanding reveals compact rows for each; each row still has its own
+  per-item expand for detail + retry (failed only).
+- This replaces the previous `max-h-[220px] overflow-hidden` clipping, which
+  visually cut cards off without a clear affordance to see the rest.
+- Expand state persists per browser session via `sessionStorage
+  ('asyncPanelExpanded')`, unchanged from before.
+- When there is no active operation and no queue items, the panel shows a
+  single sentence explaining it will populate once a contract action starts,
+  instead of rendering an empty queue section.
+
+Placement (unchanged, restated for clarity):
+- Desktop (`xl:` and up): the panel lives in a sticky top-right rail
+  (`aside.xl:sticky.xl:top-6`) alongside the primary form.
+- Mobile/tablet: the same panel renders inline, stacked below the initiating
+  form, in normal document flow (no floating/fixed positioning).
+
+Accessibility:
+- A single `aria-live="polite"` region announces the active operation (or,
+  absent one, the newest queue item) as `"<title>: <badge>"` on every status
+  change — e.g. "Split configuration update: Live now" → "... : Confirmed".
+- Expand/collapse toggles use `aria-expanded` + `aria-controls` and never call
+  `.focus()` on any other element, so opening/closing the queue cannot steal
+  focus from wherever the user currently is (e.g. the form they're filling
+  in).
+
 Duration guidance:
 - Validation: 0-2 seconds
 - Contract build: 2-6 seconds

--- a/lib/asyncStatusTokens.test.ts
+++ b/lib/asyncStatusTokens.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+	ASYNC_STATUS_VISUALS,
+	SUBMISSION_TO_ASYNC_TOKEN,
+	type AsyncStatusToken,
+} from "@/lib/asyncStatusTokens";
+
+const TOKENS: AsyncStatusToken[] = ["active", "queued", "complete", "failed"];
+
+describe("asyncStatusTokens", () => {
+	it("defines a complete visual entry for every status token", () => {
+		TOKENS.forEach((token) => {
+			const visual = ASYNC_STATUS_VISUALS[token];
+			expect(visual.token).toBe(token);
+			expect(visual.badge).toBeTruthy();
+			expect(visual.cardClass).toBeTruthy();
+			expect(visual.iconWrapClass).toBeTruthy();
+			expect(visual.iconClass).toBeTruthy();
+			expect(visual.dotClass).toBeTruthy();
+			expect(typeof visual.Icon).toBe("object");
+			expect(typeof visual.spin).toBe("boolean");
+		});
+	});
+
+	it("only spins the active token's icon", () => {
+		expect(ASYNC_STATUS_VISUALS.active.spin).toBe(true);
+		expect(ASYNC_STATUS_VISUALS.queued.spin).toBe(false);
+		expect(ASYNC_STATUS_VISUALS.complete.spin).toBe(false);
+		expect(ASYNC_STATUS_VISUALS.failed.spin).toBe(false);
+	});
+
+	it("gives failed a distinct icon from queued", () => {
+		expect(ASYNC_STATUS_VISUALS.failed.Icon).not.toBe(ASYNC_STATUS_VISUALS.queued.Icon);
+	});
+
+	it("maps AsyncSubmissionStatus's states onto the queue's status tokens", () => {
+		expect(SUBMISSION_TO_ASYNC_TOKEN).toEqual({
+			idle: "queued",
+			pending: "active",
+			success: "complete",
+			error: "failed",
+		});
+	});
+
+	it("resolves every submission state to a defined visual", () => {
+		(Object.keys(SUBMISSION_TO_ASYNC_TOKEN) as Array<keyof typeof SUBMISSION_TO_ASYNC_TOKEN>).forEach(
+			(submissionState) => {
+				const token = SUBMISSION_TO_ASYNC_TOKEN[submissionState];
+				expect(ASYNC_STATUS_VISUALS[token]).toBeDefined();
+			}
+		);
+	});
+});

--- a/lib/asyncStatusTokens.ts
+++ b/lib/asyncStatusTokens.ts
@@ -1,0 +1,76 @@
+import { AlertCircle, CheckCircle2, Clock3, Loader2, type LucideIcon } from "lucide-react";
+
+/**
+ * Shared status semantics for the async contract-progress UI
+ * (AsyncOperationsPanel + AsyncSubmissionStatus). Keeping one source of
+ * truth for color/icon/copy per status keeps the Split and Bills pages
+ * visually consistent, per docs/async-contract-submissions-handoff.md.
+ */
+export type AsyncStatusToken = "active" | "queued" | "complete" | "failed";
+
+export interface AsyncStatusVisual {
+	token: AsyncStatusToken;
+	/** Short badge copy, e.g. "Live now". */
+	badge: string;
+	cardClass: string;
+	iconWrapClass: string;
+	iconClass: string;
+	dotClass: string;
+	Icon: LucideIcon;
+	spin: boolean;
+}
+
+export const ASYNC_STATUS_VISUALS: Record<AsyncStatusToken, AsyncStatusVisual> = {
+	active: {
+		token: "active",
+		badge: "Live now",
+		cardClass:
+			"border-red-500/25 bg-[linear-gradient(180deg,rgba(127,29,29,0.28),rgba(12,12,12,0.98))]",
+		iconWrapClass: "border-red-400/30 bg-red-500/10",
+		iconClass: "text-red-300",
+		dotClass: "bg-red-400",
+		Icon: Loader2,
+		spin: true,
+	},
+	queued: {
+		token: "queued",
+		badge: "Queued",
+		cardClass: "border-white/10 bg-white/[0.02]",
+		iconWrapClass: "border-white/10 bg-white/[0.03]",
+		iconClass: "text-amber-200",
+		dotClass: "bg-amber-300",
+		Icon: Clock3,
+		spin: false,
+	},
+	complete: {
+		token: "complete",
+		badge: "Confirmed",
+		cardClass: "border-emerald-500/20 bg-emerald-500/[0.06]",
+		iconWrapClass: "border-emerald-400/20 bg-emerald-500/10",
+		iconClass: "text-emerald-300",
+		dotClass: "bg-emerald-400",
+		Icon: CheckCircle2,
+		spin: false,
+	},
+	failed: {
+		token: "failed",
+		badge: "Failed",
+		cardClass: "border-amber-500/30 bg-amber-500/[0.08]",
+		iconWrapClass: "border-amber-400/25 bg-amber-500/10",
+		iconClass: "text-amber-200",
+		dotClass: "bg-amber-400",
+		Icon: AlertCircle,
+		spin: false,
+	},
+};
+
+/** Maps AsyncSubmissionStatus's idle/pending/success/error onto the same token language. */
+export const SUBMISSION_TO_ASYNC_TOKEN: Record<
+	"idle" | "pending" | "success" | "error",
+	AsyncStatusToken
+> = {
+	idle: "queued",
+	pending: "active",
+	success: "complete",
+	error: "failed",
+};

--- a/tests/unit/components/AsyncOperationsPanel.test.tsx
+++ b/tests/unit/components/AsyncOperationsPanel.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { axe } from "jest-axe";
 import AsyncOperationsPanel from "@/components/AsyncOperationsPanel";
 import { AsyncOperationsProvider } from "@/lib/context/AsyncOperationsContext";
 
@@ -12,6 +13,33 @@ const mockProps = {
   queueDescription: "Queue desc",
   queueItems: [],
 };
+
+const queueItems = [
+  {
+    title: "Split configuration update",
+    duration: "Live",
+    detail: "Building the remittance_split contract payload.",
+    status: "active" as const,
+  },
+  {
+    title: "Wallet signature pending",
+    duration: "Waiting",
+    detail: "Secondary work compresses into smaller cards.",
+    status: "queued" as const,
+  },
+  {
+    title: "Previous change confirmed",
+    duration: "< 1 min",
+    detail: "Completed items remain visible briefly.",
+    status: "complete" as const,
+  },
+  {
+    title: "Emergency transfer",
+    duration: "2 min ago",
+    detail: "The wallet rejected the signature request.",
+    status: "failed" as const,
+  },
+];
 
 describe("AsyncOperationsPanel", () => {
   beforeEach(() => {
@@ -69,5 +97,160 @@ describe("AsyncOperationsPanel", () => {
     expect(toggleBtn).toHaveAttribute("aria-expanded", "true");
     
     setItemMock.mockRestore();
+  });
+});
+
+describe("AsyncOperationsPanel — active spotlight", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("always renders the active item in full, outside the collapsed section", () => {
+    render(
+      <AsyncOperationsProvider>
+        <AsyncOperationsPanel {...mockProps} queueItems={queueItems} />
+      </AsyncOperationsProvider>
+    );
+
+    expect(screen.getByText("Split configuration update")).toBeInTheDocument();
+    expect(
+      screen.getByText("Building the remittance_split contract payload.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Live now")).toBeInTheDocument();
+
+    // Rest-of-queue items are collapsed by default.
+    expect(screen.queryByText("Wallet signature pending")).not.toBeInTheDocument();
+    expect(screen.queryByText("Previous change confirmed")).not.toBeInTheDocument();
+    expect(screen.queryByText("Emergency transfer")).not.toBeInTheDocument();
+  });
+
+  it("summarizes the collapsed items by status count", () => {
+    render(
+      <AsyncOperationsProvider>
+        <AsyncOperationsPanel {...mockProps} queueItems={queueItems} />
+      </AsyncOperationsProvider>
+    );
+
+    expect(
+      screen.getByText(/3 more items · 1 queued · 1 confirmed · 1 failed/i)
+    ).toBeInTheDocument();
+  });
+
+  it("reveals compact rows for queued/complete/failed items on expand", () => {
+    render(
+      <AsyncOperationsProvider>
+        <AsyncOperationsPanel {...mockProps} queueItems={queueItems} />
+      </AsyncOperationsProvider>
+    );
+
+    fireEvent.click(screen.getByText(/3 more items/i));
+
+    expect(screen.getByText("Wallet signature pending")).toBeInTheDocument();
+    expect(screen.getByText("Previous change confirmed")).toBeInTheDocument();
+    expect(screen.getByText("Emergency transfer")).toBeInTheDocument();
+  });
+
+  it("does not show Retry until a failed row's own detail toggle is expanded", () => {
+    render(
+      <AsyncOperationsProvider>
+        <AsyncOperationsPanel {...mockProps} queueItems={queueItems} />
+      </AsyncOperationsProvider>
+    );
+
+    fireEvent.click(screen.getByText(/3 more items/i));
+    expect(screen.queryByText("Retry")).not.toBeInTheDocument();
+  });
+
+  it("expanding a failed row's own detail toggle surfaces Retry", () => {
+    render(
+      <AsyncOperationsProvider>
+        <AsyncOperationsPanel {...mockProps} queueItems={queueItems} />
+      </AsyncOperationsProvider>
+    );
+
+    fireEvent.click(screen.getByText(/3 more items/i));
+
+    const failedRow = screen.getByText("Emergency transfer").closest("article");
+    expect(failedRow).not.toBeNull();
+    const rowToggle = failedRow!.querySelector("button");
+    expect(rowToggle).not.toBeNull();
+    fireEvent.click(rowToggle!);
+
+    expect(screen.getByText("Retry")).toBeInTheDocument();
+  });
+
+  it("shows an empty-state message when there are no operations at all", () => {
+    render(
+      <AsyncOperationsProvider>
+        <AsyncOperationsPanel {...mockProps} queueItems={[]} />
+      </AsyncOperationsProvider>
+    );
+
+    expect(
+      screen.getByText(/No operations yet\. This panel populates automatically/i)
+    ).toBeInTheDocument();
+  });
+
+  it("announces the active item's status via the live region", () => {
+    render(
+      <AsyncOperationsProvider>
+        <AsyncOperationsPanel {...mockProps} queueItems={queueItems} />
+      </AsyncOperationsProvider>
+    );
+
+    const live = screen.getByText(/Split configuration update: Live now/i, {
+      selector: "[aria-live='polite']",
+    });
+    expect(live).toBeInTheDocument();
+  });
+
+  it("falls back to announcing the newest queue item when nothing is active", () => {
+    const noActive = queueItems.filter((item) => item.status !== "active");
+    render(
+      <AsyncOperationsProvider>
+        <AsyncOperationsPanel {...mockProps} queueItems={noActive} />
+      </AsyncOperationsProvider>
+    );
+
+    const live = screen.getByText(/Wallet signature pending: Queued/i, {
+      selector: "[aria-live='polite']",
+    });
+    expect(live).toBeInTheDocument();
+  });
+
+  it("does not steal focus from elsewhere when the queue re-renders", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    const { rerender } = render(
+      <AsyncOperationsProvider>
+        <AsyncOperationsPanel {...mockProps} queueItems={queueItems} />
+      </AsyncOperationsProvider>
+    );
+    expect(document.activeElement).toBe(input);
+
+    rerender(
+      <AsyncOperationsProvider>
+        <AsyncOperationsPanel {...mockProps} queueItems={[...queueItems].reverse()} />
+      </AsyncOperationsProvider>
+    );
+    expect(document.activeElement).toBe(input);
+
+    document.body.removeChild(input);
+  });
+
+  it("has no accessibility violations with a full queue rendered and expanded", async () => {
+    const { container } = render(
+      <AsyncOperationsProvider>
+        <AsyncOperationsPanel {...mockProps} queueItems={queueItems} />
+      </AsyncOperationsProvider>
+    );
+
+    fireEvent.click(screen.getByText(/3 more items/i));
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });


### PR DESCRIPTION
Closes #1319

## Summary

Redesigns `AsyncOperationsPanel` and `AsyncSubmissionStatus` — the contract build / wallet-signature / submit-and-confirm progress UI shared by `/split` and `/bills` — so the stacked queue stops competing with the primary form for attention, while keeping users informed with crisp status semantics and a real collapse/expand behavior.

### What changed

- **Shared status tokens** (`lib/asyncStatusTokens.ts`): one table of color/icon/badge visuals per status (`active | queued | complete | failed`) now backs both components, so a red pulsing treatment always means "in flight" and amber always means "needs attention," on both Split and Bills.
- **Active-operation spotlight**: the active operation (if any) always renders in full — title, full detail copy, duration, and a pulsing "Live now" badge — directly under the queue header. It is the single most prominent element and is never hidden by the collapse toggle.
- **Collapse/expand redesign**: queued, complete, and failed items now collapse behind one summary toggle by default (e.g. "2 more items · 1 queued · 1 confirmed") instead of the old `max-h-[220px] overflow-hidden` clipping, which cut cards off with no clear way to see the rest. Expanding reveals compact rows; each row keeps its own detail expand + Retry (failed only). Expand state still persists per session via `sessionStorage`.
- **Bug fix**: `failed` previously reused the `queued` clock icon — it now gets its own `AlertCircle` icon so failure reads distinctly from "waiting."
- **Empty state**: when there are no operations at all, the panel now shows a short explanatory sentence instead of an empty section.
- **Accessibility**: the per-item detail toggle was icon-only with no accessible name — added `aria-label`. The single `aria-live="polite"` region still announces the active operation (or, absent one, the newest item) on every status change, and no code path calls `.focus()`, so opening/closing the queue cannot steal focus from the form the user is filling in.
- **Placement** is unchanged and documented: desktop (`xl:` and up) keeps the panel in the existing sticky top-right rail (`aside.xl:sticky.xl:top-6`) next to the form; mobile/tablet renders the same panel inline, stacked below the form, in normal document flow.

### Files

**New:**
- `lib/asyncStatusTokens.ts` — shared status-token visuals
- `lib/asyncStatusTokens.test.ts` — unit tests for the token table

**Modified:**
- `components/AsyncOperationsPanel.tsx` — spotlight + collapse/expand redesign
- `components/AsyncSubmissionStatus.tsx` — now sources colors/icons from the shared tokens (labels unchanged: Ready / In progress / Complete / Needs attention)
- `docs/async-contract-submissions-handoff.md` — documents the new status-token semantics, spotlight/collapse behavior, and restates desktop-rail vs mobile-inline placement rules
- `components/AsyncSubmissionStatus.test.tsx` — added tests asserting shared visual tokens with the panel
- `tests/unit/components/AsyncOperationsPanel.test.tsx` — added the new spotlight/collapse/a11y test suite

`app/split/page.tsx` and `app/bills/page.tsx` needed no changes — both components' public prop interfaces are unchanged, so existing call sites work as-is.

### Tests added

- `lib/asyncStatusTokens.test.ts`: every status token has a complete visual entry; only `active` spins; `failed` has a distinct icon from `queued`; `AsyncSubmissionStatus`'s idle/pending/success/error states map onto the correct queue tokens.
- `tests/unit/components/AsyncOperationsPanel.test.tsx` (new suite, on top of the 2 existing collapse-persistence tests, which still pass unchanged):
  - active item always renders in full, outside the collapsed section
  - collapsed summary correctly counts queued/confirmed/failed items
  - expanding reveals compact rows for the rest of the queue
  - Retry only appears once a failed row's own detail is expanded
  - empty state message when there are no operations
  - live region announces the active item's status, and falls back to the newest item when nothing is active
  - re-rendering the queue does not steal focus from an element the user has focused elsewhere on the page
  - no axe accessibility violations with a full queue expanded
- `components/AsyncSubmissionStatus.test.tsx`: added assertions that pending/error/success icons carry the same colors as the panel's active/failed/complete tokens (all existing tests still pass unchanged).

All new/updated tests pass (40/40 on the targeted run). A broader sweep across Split/Bills/Insurance-adjacent unit tests (127 tests) also passes except two pre-existing, unrelated failures already present on `main` (a syntax error in `app/bills/page.tsx` and a missing `insurance.page_title` i18n key) — confirmed via `git stash` that both fail identically without this branch's changes.

`npm run build` / `npm run typecheck` / `npm run lint` currently fail on `main` itself due to pre-existing unrelated syntax errors (`app/bills/page.tsx`, `app/send/components/ReviewStep.tsx`, `components/Insights/*`, `components/ui/ChipList.tsx`) and a missing `@next/bundle-analyzer` dependency in `next.config.js` — all reproduced identically on `main` with this branch's changes stashed out, so they predate and are unrelated to this PR. Targeted `tsc --noEmit` and `eslint` runs against every file this PR touches are clean.

### How to test

1. Visit `/split` or `/bills` at 1280px — the panel sits in the sticky top-right rail; trigger a submission and confirm the active operation renders as the prominent spotlight card while any other queue items stay collapsed behind the "N more items" toggle.
2. Resize to 375px — the same panel now renders inline below the form.
3. Click the summary toggle to expand/collapse the rest of the queue; click a compact row's own toggle to see its detail (and Retry, for a failed item).
4. With a screen reader on, confirm the live region announces status changes (e.g. "Split configuration update: Live now" → "... : Confirmed") without focus jumping away from the form.
5. Run `npm run test:unit` / targeted vitest runs listed above.
