### PR TITLE
feat(uiux): respect prefers-reduced-motion on hero and feature card hover animations

### DIFF
--- a/components/DarkFeatureCard.test.tsx
+++ b/components/DarkFeatureCard.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import DarkFeatureCard from "@/components/DarkFeatureCard";
+
+describe("DarkFeatureCard", () => {
+	const props = {
+		icon: <svg data-testid="feature-icon" />,
+		title: "Instant Settlement",
+		description: "Send money across borders in seconds.",
+	};
+
+	it("renders the icon, title, and description", () => {
+		render(<DarkFeatureCard {...props} />);
+		expect(screen.getByTestId("feature-icon")).toBeInTheDocument();
+		expect(screen.getByText(props.title)).toBeInTheDocument();
+		expect(screen.getByText(props.description)).toBeInTheDocument();
+	});
+
+	it("respects prefers-reduced-motion on the icon's hover scale", () => {
+		render(<DarkFeatureCard {...props} />);
+		const icon = screen.getByTestId("feature-icon").parentElement;
+		expect(icon).toHaveClass("group-hover:scale-110");
+		expect(icon).toHaveClass("motion-reduce:group-hover:scale-100");
+	});
+});

--- a/components/DarkFeatureCard.tsx
+++ b/components/DarkFeatureCard.tsx
@@ -10,7 +10,7 @@ const DarkFeatureCard: React.FC<DarkFeatureCardProps> = ({ icon, title, descript
   return (
     <div className="bg-gradient-to-br from-[#1a1a1a] to-[#0f0f0f] p-8 rounded-2xl flex flex-col items-start gap-5 border border-white/8 hover:border-white/15 transition-all duration-300 group shadow-lg shadow-black/20 hover:shadow-xl hover:shadow-red-600/10">
       {/* Icon container with minimal background */}
-      <div className="w-12 h-12 bg-gradient-to-br from-[#DC2626]/10 to-[#8B4513]/5 rounded-xl flex items-center justify-center text-[#FF5544] group-hover:scale-110 transition-transform duration-300 flex-shrink-0">
+      <div className="w-12 h-12 bg-gradient-to-br from-[#DC2626]/10 to-[#8B4513]/5 rounded-xl flex items-center justify-center text-[#FF5544] group-hover:scale-110 motion-reduce:group-hover:scale-100 transition-transform duration-300 flex-shrink-0">
         {icon}
       </div>
       

--- a/components/FeatureSection.test.tsx
+++ b/components/FeatureSection.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+import FeatureSection from "@/components/FeatureSection";
+
+const CORE_FEATURES = [
+	"Instant Settlement",
+	"Smart Split",
+	"Yield Savings",
+	"Global Bills",
+	"Micro-Insurance",
+	"Family Wallets",
+];
+
+describe("FeatureSection", () => {
+	it("renders all six core features from the brand brief", () => {
+		render(<FeatureSection />);
+		CORE_FEATURES.forEach((title) => {
+			expect(screen.getByText(title)).toBeInTheDocument();
+		});
+	});
+
+	it("renders the section heading below the hero's h1 in document order", () => {
+		render(<FeatureSection />);
+		const heading = screen.getByRole("heading", { level: 2, name: /Core Features Built for Global Families/i });
+		expect(heading).toBeInTheDocument();
+	});
+
+	it("has no accessibility violations", async () => {
+		const { container } = render(<FeatureSection />);
+		const results = await axe(container);
+		expect(results).toHaveNoViolations();
+	});
+});

--- a/components/Hero.test.tsx
+++ b/components/Hero.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+import Hero from "@/components/Hero";
+import { CTA_TEST_IDS } from "@/lib/cta-testids";
+import { ToastProvider } from "@/lib/context/ToastContext";
+
+function renderHero() {
+	return render(
+		<ToastProvider>
+			<Hero />
+		</ToastProvider>
+	);
+}
+
+describe("Hero", () => {
+	it("renders a single top-level heading with the brand headline", () => {
+		renderHero();
+		const heading = screen.getByRole("heading", { level: 1 });
+		expect(heading).toHaveTextContent(/Global Payments\s*Without Borders/i);
+	});
+
+	it("renders a primary CTA linking to /send", () => {
+		renderHero();
+		const primary = screen.getByTestId(CTA_TEST_IDS.page.homePrimary);
+		expect(primary).toHaveAttribute("href", "/send");
+		expect(primary).toHaveTextContent(/Send Money Now/i);
+	});
+
+	it("renders a secondary CTA linking to /dashboard", () => {
+		renderHero();
+		const secondary = screen.getByRole("link", { name: /View Dashboard/i });
+		expect(secondary).toHaveAttribute("href", "/dashboard");
+	});
+
+	it("respects prefers-reduced-motion on the primary CTA's hover scale", () => {
+		renderHero();
+		const primary = screen.getByTestId(CTA_TEST_IDS.page.homePrimary);
+		expect(primary).toHaveClass("hover:scale-105");
+		expect(primary).toHaveClass("motion-reduce:hover:scale-100");
+	});
+
+	it("has no accessibility violations", async () => {
+		const { container } = renderHero();
+		const results = await axe(container);
+		expect(results).toHaveNoViolations();
+	});
+});

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -72,7 +72,7 @@ export default function Hero() {
           <Link
             href="/send"
             data-testid={CTA_TEST_IDS.page.homePrimary}
-            className="inline-flex items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-[#DC2626] to-[#B91C1C] px-8 py-4 font-semibold text-white transition-all duration-300 hover:shadow-lg hover:shadow-red-600/40 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-black"
+            className="inline-flex items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-[#DC2626] to-[#B91C1C] px-8 py-4 font-semibold text-white transition-all duration-300 hover:shadow-lg hover:shadow-red-600/40 hover:scale-105 motion-reduce:hover:scale-100 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-black"
           >
             <LightningBoltIcon className="w-5 h-5" />
             Send Money Now


### PR DESCRIPTION
Closes #1321

## Context

This issue asked for a redesign of the landing page hero and feature sections per the RemitWise brand brief (dark warm-gradient theme, "Global Payments Without Borders" headline with primary/secondary CTAs, modular feature cards with subtle shadows and minimal icons, all six core features represented). Checking `components/Hero.tsx` and `components/FeatureSection.tsx` against the brief, that redesign is already implemented and merged on `main` (see PR #450 / commit `6481769`, "redesign landing hero and feature sections per brand brief") — the dark gradient theme, headline, both CTAs, and all six feature cards (Instant Settlement, Smart Split, Yield Savings, Global Bills, Micro-Insurance, Family Wallets) are all present exactly as specified.

This PR is a small, targeted follow-up polish pass on that existing implementation rather than a re-redesign, plus test coverage that was missing.

## What changed

- **`components/Hero.tsx`**: the primary CTA ("Send Money Now") scales up on hover (`hover:scale-105`) with no reduced-motion fallback. Added `motion-reduce:hover:scale-100` so users with `prefers-reduced-motion` still get the shadow/color hover feedback without the transform, which can otherwise trigger discomfort for people with vestibular disorders.
- **`components/DarkFeatureCard.tsx`**: same gap on the feature card icon (`group-hover:scale-110`). Added `motion-reduce:group-hover:scale-100`.

## Files

**Modified:**
- `components/Hero.tsx` — reduced-motion class on the primary CTA
- `components/DarkFeatureCard.tsx` — reduced-motion class on the icon hover scale

**New (tests — none of these three components had any test coverage before this PR):**
- `components/Hero.test.tsx`
- `components/FeatureSection.test.tsx`
- `components/DarkFeatureCard.test.tsx`

## Tests added

- `Hero.test.tsx`: renders a single `<h1>` with the brand headline; primary CTA has the correct `data-testid`/`href`/label; secondary CTA links to `/dashboard`; primary CTA carries both `hover:scale-105` and the new `motion-reduce:hover:scale-100`; zero axe violations.
- `FeatureSection.test.tsx`: all six core features from the brief render by name; the section `<h2>` renders; zero axe violations.
- `DarkFeatureCard.test.tsx`: icon/title/description render from props; the icon wrapper carries both `group-hover:scale-110` and the new `motion-reduce:group-hover:scale-100`.

All 10 new tests pass. Targeted `eslint` and `tsc --noEmit` runs against every file this PR touches are clean. (Note: repo-wide `npm run build` / `npm run lint` / `npm run typecheck` currently fail on `main` itself due to pre-existing, unrelated syntax errors in other files — e.g. `app/bills/page.tsx`, `app/send/components/ReviewStep.tsx`, `components/Insights/*` — and a missing `@next/bundle-analyzer` dependency in `next.config.js`; verified via `git stash` that these fail identically without this branch's changes, so they predate and are unrelated to this PR.)

## How to test

1. Visit `/` at 1280px and 375px — hero headline, both CTAs, and the six feature cards should look unchanged from current `main`.
2. Enable "reduce motion" in your OS/browser accessibility settings, then hover the primary CTA and a feature card icon — they should still show the color/shadow hover feedback but no longer scale up.
3. Run `npx vitest run components/Hero.test.tsx components/FeatureSection.test.tsx components/DarkFeatureCard.test.tsx`.
