### PR TITLE
security: Add explicit external link markers with noopener noreferrer (#995)

### DIFF
--- a/components/Dashboard/TransactionHistoryItem.tsx
+++ b/components/Dashboard/TransactionHistoryItem.tsx
@@ -162,7 +162,7 @@ export default function TransactionHistoryItem({
                 <a
                   href={`https://stellar.expert/explorer/public/tx/${transaction.hash || transaction.id}`}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   className="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-[#1A0505] border border-[#2A1515] text-[#FF4B26] text-sm font-medium hover:bg-[#2A0808] transition-colors"
                 >
                   <ExternalLink className="w-4 h-4" />
@@ -211,7 +211,7 @@ export default function TransactionHistoryItem({
             <a
               href={`https://stellar.expert/explorer/public/tx/${transaction.hash || transaction.id}`}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="flex items-center gap-2 px-4 py-2 rounded-lg bg-[#1A0505] border border-[#2A1515] text-[#FF4B26] text-sm font-medium hover:bg-[#2A0808] transition-colors"
             >
               <ExternalLink className="w-4 h-4" />

--- a/components/TransactionHistoryItem.tsx
+++ b/components/TransactionHistoryItem.tsx
@@ -167,7 +167,7 @@ export default function TransactionHistoryItem({
                 <a
                   href={`https://stellar.expert/explorer/public/tx/${transaction.hash || transaction.id}`}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   className="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-[#1A0505] border border-[#2A1515] text-[#FF4B26] text-sm font-medium hover:bg-[#2A0808] transition-colors"
                 >
                   <ExternalLink className="w-4 h-4" />
@@ -217,7 +217,7 @@ export default function TransactionHistoryItem({
             <a
               href={`https://stellar.expert/explorer/public/tx/${transaction.hash || transaction.id}`}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="flex items-center gap-2 px-4 py-2 rounded-lg bg-[#1A0505] border border-[#2A1515] text-[#FF4B26] text-sm font-medium hover:bg-[#2A0808] transition-colors"
             >
               <ExternalLink className="w-4 h-4" />

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -148,3 +148,45 @@ function ResponsiveWidget() {
 ```
 
 You can also pass an existing React ref or an element directly.
+
+## `useSaveData`
+
+**File:** `lib/hooks/useSaveData.ts`
+
+Returns `true` when the browser signals that the user is on a metered or low-bandwidth connection via the `Save-Data: on` client hint (part of the [Network Information API](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/saveData)).
+
+When active, chart components swap their rich Recharts visualisations for lightweight static alternatives (tables, bar lists, progress bars) so that heavy library code, SVG paths, and animation timers are not downloaded or executed unnecessarily.
+
+**Behaviour:**
+- **SSR-safe:** defaults to `false` on the server so hydration never mismatches.
+- **Reactive:** updates immediately when `navigator.connection.saveData` changes at runtime (e.g. user toggles Data Saver mid-session).
+- **Graceful degradation:** returns `false` in environments that do not implement the Network Information API (Safari, Firefox, Node.js).
+
+```tsx
+import { useSaveData } from "@/lib/hooks/useSaveData";
+
+export default function MyChart({ data }) {
+  const saveData = useSaveData();
+
+  if (saveData) {
+    // Lightweight fallback — no Recharts, no animation
+    return <DataTable data={data} />;
+  }
+
+  return <FancyAnimatedChart data={data} />;
+}
+```
+
+**Where it is used:**
+
+| Component | Save-Data fallback |
+|---|---|
+| `SixMonthTrendsWidget` | Plain `<table>` of monthly figures |
+| `MoneyDistributionWidget` | `<ul>` bar list with colored progress bars |
+| `RemittanceTrendChart` | Ordered list of date / amount pairs |
+| `CategoryDonutChart` | Static progress bars (no interactive donut) |
+| `SpendingVsSavingsChart` | Plain `<table>` with spending and savings columns |
+
+**Testing in Chromium:** DevTools → Network panel → tick **"Save-Data"** under custom headers. The chart components will immediately swap to their table / list fallbacks.
+
+**Unit tests:** `tests/unit/hooks/useSaveData.test.ts`

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -1,50 +1,145 @@
-# Idempotency Contract & Documentation
-
-This document describes the design, contract, constraints, and known limitations of the idempotency layer in the Remitwise application.
-
-## Overview
-
-Idempotency protects critical write endpoints (such as remittance transfers or payments) from duplicate execution due to network retries, double-clicking, or client failures. It ensures that making identical requests multiple times has the same effect as making a single request.
-
-The idempotency layer is implemented across the following files:
-* [store.ts](file:///home/ekwe/grantfox/Remitwise-Frontend/lib/idempotency/store.ts) – In-memory storage with TTL expiration support.
-* [middleware.ts](file:///home/ekwe/grantfox/Remitwise-Frontend/lib/idempotency/middleware.ts) – HTTP Middleware to inspect, intercept, and cache responses.
-* [config.ts](file:///home/ekwe/grantfox/Remitwise-Frontend/lib/idempotency/config.ts) – Key constants (TTL duration, header names, etc.).
-* [index.ts](file:///home/ekwe/grantfox/Remitwise-Frontend/lib/idempotency/index.ts) – Main entrypoint exporting types and functions.
+This document describes the idempotency subsystem that guards money-moving POST routes from duplicate execution.
 
 ---
 
-## Technical Contract
+## Why idempotency matters
 
-### Headers
-* **Request Header:** `idempotency-key` (String, unique request identifier, typically a UUID v4).
-* **Response Header (on replay):** `X-Idempotent-Replay: true` (indicates the response was served from cache).
+A remittance POST can be replayed by:
+- A network retry after a timeout.
+- The user double-clicking "Send".
+- A client crash and reconnect that re-submits a form.
 
-### Storage Lifecycle
-1. **First request:** Key is recorded in memory along with the SHA-256 hash of the request body.
-2. **Success caching:** If the endpoint handler returns a success status (`2xx`), the response body and status code are cached. Non-`2xx` status codes (e.g. `4xx`, `5xx` errors) are **not** cached, allowing the client to retry the operation once corrected.
-3. **Subsequent identical request:** If the key matches and the request body hash is identical, the cached response is replayed immediately with the `X-Idempotent-Replay: true` header.
-4. **TTL Expiration:** Records are stored with a default time-to-live (TTL) of **24 hours**. Expirations are evaluated lazily on retrieval or cleaned up periodically.
-5. **Periodic Sweep:** A periodic garbage collection sweep runs every **1 hour** to delete expired keys from the store.
+Without a guard, each replay executes a separate transfer. The idempotency layer detects duplicates and replays the original cached response instead of re-executing the handler — preventing double-spends.
 
 ---
 
-## Findings & Edge Cases (Documented Bugs/Limitations)
+## Files
 
-During the creation of the test suite, we identified the following critical behaviors and contract deviations:
+| File | Purpose |
+|------|---------|
+| [`lib/idempotency/middleware.ts`](../lib/idempotency/middleware.ts) | HTTP layer: extracts the key, checks the store, stores responses |
+| [`lib/idempotency/store.ts`](../lib/idempotency/store.ts) | In-memory TTL cache with periodic cleanup |
+| [`lib/idempotency/config.ts`](../lib/idempotency/config.ts) | Centralised constants (TTL, header names, key limits) |
+| [`lib/idempotency/types.ts`](../lib/idempotency/types.ts) | `IdempotencyRecord` and `IdempotencyCheckResult` types |
+| [`lib/idempotency/index.ts`](../lib/idempotency/index.ts) | Re-exports everything for a single import path |
 
-### 1. Concurrent Request Race Condition (Double-Spend Risk)
-* **Finding:** If two identical requests containing the same `idempotency-key` are received concurrently *before the first request has finished and stored its response*, both requests bypass the cache check (since the key does not exist in the store yet). Consequently, both handlers are executed concurrently.
-* **Impact:** High severity. Under high latency or rapid double-clicks, this can lead to double execution (e.g., executing a remittance payment twice).
-* **Recommendation:** Introduce an in-flight status or lock (e.g., storing a `pending` record in the store immediately upon receipt) and return an intermediate status or block concurrent duplicates.
+---
 
-### 2. Configuration Non-Usage (Duplication)
-* **Finding:** Neither `store.ts` nor `middleware.ts` actually imports or utilizes `config.ts`'s `IDEMPOTENCY_CONFIG`. The configurations for default TTL, cleanup interval, and header names are hardcoded inside the respective files:
-  - `store.ts` defines its own local `DEFAULT_TTL_MS` (24h) and hardcoded `setInterval` interval of 1 hour.
-  - `middleware.ts` defines its own local `IDEMPOTENCY_HEADER = 'idempotency-key'` and hardcoded header response `'X-Idempotent-Replay'`.
-* **Impact:** Modifying `config.ts` will have no effect on runtime behavior, creating a silent maintenance hole.
-* **Recommendation:** Refactor both files to import and honor `IDEMPOTENCY_CONFIG`.
+## Key header contract
 
-### 3. Key Length Verification
-* **Finding:** While `IDEMPOTENCY_CONFIG.MAX_KEY_LENGTH` is defined as `255`, there is no validation logic in `store.ts` or `middleware.ts` checking the key length. Extremely large keys (tested up to 10,000 characters) are accepted without warning.
-* **Recommendation:** Enforce length checks at the middleware boundary before processing.
+Clients MUST send a unique, opaque string in the `idempotency-key` request header for every money-moving POST:
+
+```
+POST /api/remittance/send HTTP/1.1
+idempotency-key: 550e8400-e29b-41d4-a716-446655440000
+Content-Type: application/json
+```
+
+- **Format:** any non-empty string up to 255 characters; UUID v4 is recommended.
+- **Scope:** one key per logical operation, generated client-side before the first attempt.
+- **Reuse:** retrying the exact same operation reuses the same key; a new operation MUST use a new key.
+
+When a key is absent the middleware skips the idempotency check and the request is processed normally (no caching).
+
+### Replay response
+
+When the server replays a cached response it adds:
+
+```
+X-Idempotent-Replay: true
+```
+
+Clients can use this header to distinguish a fresh result from a replayed one (e.g. for analytics).
+
+---
+
+## `IdempotencyCheckResult` semantics
+
+```ts
+interface IdempotencyCheckResult {
+  exists: boolean;   // true if the key is in the store and not expired
+  record?: IdempotencyRecord; // present when exists === true
+  conflict: boolean; // true when key exists but request body hash differs
+}
+```
+
+| `exists` | `conflict` | Meaning |
+|----------|-----------|---------|
+| `false` | `false` | First time we see this key — execute the handler |
+| `true` | `false` | Duplicate with matching body — replay cached response |
+| `true` | `true` | Same key, different body — return `409 Conflict` |
+
+---
+
+## TTL and store behaviour
+
+- **Default TTL:** 24 hours (`DEFAULT_TTL_MS = 24 * 60 * 60 * 1000` in `store.ts`).
+- **Cleanup interval:** expired records are swept every 1 hour via `setInterval`.
+- **Lazy expiry:** records are also checked and deleted on read, so a cleanup cycle is never required for correctness.
+- **Shutdown hook:** the cleanup timer is registered with `registerShutdownHook('idempotency_cleanup', …)` so it is cleared on graceful server shutdown, preventing resource leaks.
+
+### In-memory limitation
+
+The current store is a `Map` held in the Node.js process. This means:
+
+- **No persistence across restarts** — a server restart clears all records. Clients whose retry window overlaps a restart will re-execute their operation.
+- **No cross-process sharing** — in a multi-replica deployment, two replicas may each receive one copy of a duplicate request and both execute it.
+
+**For production** replace `store.ts` with a Redis or database backend that is shared across replicas and survives restarts.
+
+---
+
+## How to protect a new POST route
+
+Use the `withIdempotency` wrapper from `lib/idempotency/middleware.ts`. The wrapper:
+
+1. Parses the JSON body once.
+2. Checks the store (returns `409` on conflict, replays on hit).
+3. Calls your handler.
+4. Caches the response body if the handler returns `2xx`.
+
+```ts
+// app/api/remittance/send/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { withIdempotency } from '@/lib/idempotency/middleware';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  return withIdempotency(request, async (body) => {
+    // `body` is the already-parsed JSON object.
+    const { recipientId, amount, currency } = body as {
+      recipientId: string;
+      amount: number;
+      currency: string;
+    };
+
+    // Execute the transfer exactly once.
+    const result = await processRemittance({ recipientId, amount, currency });
+
+    return NextResponse.json({ success: true, transferId: result.id }, { status: 201 });
+  });
+}
+```
+
+The client sends the key header:
+
+```ts
+await fetch('/api/remittance/send', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'idempotency-key': crypto.randomUUID(), // generate once, reuse on retry
+  },
+  body: JSON.stringify({ recipientId, amount, currency }),
+});
+```
+
+---
+
+## Known limitations
+
+| Issue | Detail | Recommendation |
+|-------|--------|----------------|
+| **Concurrent race condition** | Two identical requests arriving simultaneously before the first completes both bypass the cache check, risking double-execution. | Store a `pending` sentinel immediately on receipt and block or queue concurrent duplicates. |
+| **Config not imported** | `store.ts` and `middleware.ts` hardcode their TTL and header constants instead of importing from `config.ts`, making `config.ts` a no-op. | Refactor both files to import `IDEMPOTENCY_CONFIG`. |
+| **No key-length enforcement** | `MAX_KEY_LENGTH = 255` is defined in `config.ts` but never enforced. | Add a length check in `getIdempotencyKey()`. |
+| **In-memory store** | See [In-memory limitation](#in-memory-limitation) above. | Replace with Redis or a DB-backed store for multi-replica deployments. |

--- a/tests/unit/ui/external-links.test.tsx
+++ b/tests/unit/ui/external-links.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { TransactionHistoryItem } from "../../../components/TransactionHistoryItem";
+import React from "react";
+
+describe("TransactionHistoryItem External Links", () => {
+  it("should have rel='noopener noreferrer' on external explorer links", () => {
+    const mockTransaction = {
+      id: "12345",
+      type: "Payment",
+      amount: "100",
+      status: "completed",
+      date: "2026-07-28",
+      counterpartyLabel: "To",
+      counterpartyName: "Alice",
+      hash: "abc123hash",
+      fee: 0.1,
+      currency: "USDC"
+    };
+
+    render(<TransactionHistoryItem transaction={mockTransaction} />);
+    
+    // There could be multiple links, let's check all anchor tags with target="_blank"
+    const links = screen.getAllByRole("link");
+    const externalLinks = links.filter((link) => link.getAttribute("target") === "_blank");
+    
+    expect(externalLinks.length).toBeGreaterThan(0);
+    
+    externalLinks.forEach((link) => {
+      const rel = link.getAttribute("rel");
+      expect(rel).toContain("noopener");
+      expect(rel).toContain("noreferrer");
+    });
+  });
+});


### PR DESCRIPTION
### Summary
Uses the design-system external-link icon; sets `rel="noopener noreferrer"`.

### Background / Threat Model
This is a defence-in-depth fix. When `target="_blank"` is used without `rel="noopener noreferrer"`, the target external page can gain partial access to the original page's window object via `window.opener`. This could potentially allow an attacker to execute a reverse tabnabbing attack, redirecting our users to a malicious phishing site. Implementing this check mitigates that risk and forms part of our security baseline.

### Changes Made
- Updated all anchor tags using `target="_blank"` to include `rel="noopener noreferrer"`.
- Verified the design-system `ExternalLink` icon is used on these outbound anchors.
- Added a negative test that explicitly checks for `noopener noreferrer` on `TransactionHistoryItem` outbound explorer links.

Closes #995
