### PR TITLE
logging: add breadcrumb on locale switch

### DIFF
--- a/components/LocaleSwitcher.tsx
+++ b/components/LocaleSwitcher.tsx
@@ -31,6 +31,7 @@ export default function LocaleSwitcher() {
       // Best-effort: cookie is already set, so locale persists locally even
       // if the preferences API call fails.
     }
+    console.info("[Breadcrumb] locale=info locale.switch", locale, "→", newLocale);
     window.location.reload();
   };
 


### PR DESCRIPTION
## Summary

Adds a structured breadcrumb log entry when the user switches the application locale, as specified in #1447.

## Changes

- **`components/LocaleSwitcher.tsx`** — Added `console.info` breadcrumb in `handleLocaleChange` that logs the old and new locale values in structured key=value format
- Format: `[Breadcrumb] locale=info locale.switch en → es`
- Emitted at INFO level for a lifecycle event, following the project's logging guidelines
- No secrets, tokens, or user data included in the log

## Acceptance criteria

- [x] The change matches the summary above
- [x] Lint, type-check, and tests pass locally

Closes #1447
