### PR TITLE
test: add edge case tests for sort preservation when filters change (#1435)

### DIFF
--- a/tests/unit/transactions/page.test.tsx
+++ b/tests/unit/transactions/page.test.tsx
@@ -196,4 +196,59 @@ describe("TransactionsPage Export Component Integration", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText("No transactions yet")).not.toBeInTheDocument();
   });
+
+  it("preserves date sort order when clearing all filters", () => {
+    renderComponent();
+
+    // Sort by date ascending
+    const dateSort = screen.getByRole("button", { name: /date descending/i });
+    fireEvent.click(dateSort);
+    expect(screen.getByRole("button", { name: /date ascending/i })).toBeInTheDocument();
+
+    // Apply a filter
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(screen.getByRole("button", { name: /date ascending/i })).toBeInTheDocument();
+
+    // Clear all filters
+    fireEvent.click(screen.getByRole("button", { name: /clear all/i }));
+
+    // Sort should still be ascending
+    expect(screen.getByRole("button", { name: /date ascending/i })).toBeInTheDocument();
+  });
+
+  it("preserves amount sort when search query changes", () => {
+    renderComponent();
+
+    // Sort by amount ascending
+    const amountSort = screen.getByRole("button", { name: /^amount$/i });
+    fireEvent.click(amountSort);
+
+    // Now add a search query
+    const searchInput = screen.getByPlaceholderText(
+      /search id, recipient, type, status, amount/i
+    );
+    fireEvent.change(searchInput, { target: { value: "TX00" } });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    // Sort should still be ascending
+    expect(screen.getByRole("button", { name: /amount ascending/i })).toBeInTheDocument();
+  });
+
+  it("preserves date sort when date range filter is applied", () => {
+    renderComponent();
+
+    // Sort by date ascending
+    const dateSort = screen.getByRole("button", { name: /date descending/i });
+    fireEvent.click(dateSort);
+    expect(screen.getByRole("button", { name: /date ascending/i })).toBeInTheDocument();
+
+    // Apply a date range filter
+    const fromInput = screen.getByLabelText(/from/i);
+    fireEvent.change(fromInput, { target: { value: "2026-07-01" } });
+
+    // Sort should still be ascending
+    expect(screen.getByRole("button", { name: /date ascending/i })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes #1435

## Summary
Adds edge case tests to verify that table sort order is preserved when:

1. **Clearing all filters** — verifies ascending date sort survives `clearAllFilters()`
2. **Search query changes** — verifies ascending amount sort survives debounced search input
3. **Date range filter is applied** — verifies ascending date sort survives date range (`dateFrom`/`dateTo`) changes

## Background
The existing tests (`keeps ascending date sort when a type filter changes` and `keeps descending amount sort when a status filter changes`) already verify that sort is preserved when type/status filter chips change. This PR extends coverage to the remaining filter interaction patterns — search, date range, and the "clear all" action — so the fix is comprehensively tested across all filter surfaces.

## Verification
- `npm test` — all 13 tests pass (10 existing + 3 new)