### PR TITLE
fix: reject amounts with more than 2 decimal places

### DIFF
--- a/app/send/components/AmountCurrencySection.tsx
+++ b/app/send/components/AmountCurrencySection.tsx
@@ -86,6 +86,13 @@ export default function AmountCurrencySection({ onReview, onBack }: AmountCurren
 
     if (value === "") return
 
+    // Reject amounts with more than 2 decimal places.
+    const parts = value.split(".")
+    if (parts.length === 2 && parts[1].length > 2) {
+      setError("Amount must have at most 2 decimal places")
+      return
+    }
+
     const numValue = parseFloat(value)
     if (isNaN(numValue)) {
       setError("Please enter a valid amount")

--- a/tests/unit/amount-currency-debounce.test.tsx
+++ b/tests/unit/amount-currency-debounce.test.tsx
@@ -169,4 +169,21 @@ describe('AmountCurrencySection — debounce & cancel-in-flight', () => {
     // Even though the fetch was "aborted", no error text should appear.
     expect(screen.queryByText(/error/i)).not.toBeInTheDocument()
   })
+
+  it('rejects amounts with more than 2 decimal places', () => {
+    render(<AmountCurrencySection />)
+    const input = screen.getByPlaceholderText('0.00')
+
+    // "5.123" has 3 decimal places — should show an error.
+    typeAmount(input, '5.123')
+    expect(screen.getByText('Amount must have at most 2 decimal places')).toBeInTheDocument()
+
+    // "5.12" has 2 decimal places — no error.
+    typeAmount(input, '5.12')
+    expect(screen.queryByText('Amount must have at most 2 decimal places')).not.toBeInTheDocument()
+
+    // "5" (integer) has no decimal places — no error.
+    typeAmount(input, '5')
+    expect(screen.queryByText('Amount must have at most 2 decimal places')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary

Reject amounts with more than 2 decimal places in the amount input field.

## Changes

**`app/send/components/AmountCurrencySection.tsx`**
- Added validation in `handleAmountChange` to check decimal places
- When the input value has more than 2 digits after the decimal point, an error message is shown: "Amount must have at most 2 decimal places"
- The validation runs before the existing numeric range checks

**`tests/unit/amount-currency-debounce.test.tsx`**
- Added test: `rejects amounts with more than 2 decimal places`
  - Verifies `5.123` (3 decimal places) shows the error
  - Verifies `5.12` (2 decimal places) does not show the error
  - Verifies `5` (integer) does not show the error

## Testing

- ✅ All 5 existing tests in `amount-currency-debounce.test.tsx` pass
- ✅ New test covers happy path and failure mode
- ✅ Full unit test suite (85 tests) passes

Closes #1443