### PR TITLE
fix: prevent combobox dropdown from rendering off-screen at right edge

### DIFF
--- a/components/ui/Combobox.tsx
+++ b/components/ui/Combobox.tsx
@@ -385,6 +385,40 @@ export function Combobox({
     return () => document.removeEventListener("mousedown", handleClick);
   }, [isOpen, close]);
 
+  // ── Dropdown position adjustment ─────────────────────────────────────────
+  // When the dropdown is near the right edge of the viewport, shift it left
+  // so it doesn't clip off-screen.
+  useEffect(() => {
+    if (!isOpen || !listboxRef.current || !containerRef.current) return;
+
+    const listbox = listboxRef.current;
+    // Reset any previous inline adjustment
+    listbox.style.left = "";
+    listbox.style.width = "";
+
+    // Use requestAnimationFrame to ensure layout is complete after the DOM
+    // insertion of the conditionally-rendered listbox
+    requestAnimationFrame(() => {
+      const rect = listbox.getBoundingClientRect();
+      const viewportWidth = window.innerWidth;
+
+      if (rect.right > viewportWidth) {
+        const overflow = rect.right - viewportWidth + 8; // 8px visual padding
+        // Don't shift more than the left edge allows (keep 8px gutter)
+        const shift = Math.min(overflow, rect.left - 8);
+        if (shift > 0) {
+          listbox.style.left = `-${shift}px`;
+        }
+
+        // If the dropdown still can't fit after shifting, cap its width
+        const newLeft = rect.left - shift;
+        if (newLeft < 0) {
+          listbox.style.width = `${viewportWidth - 16}px`; // 8px gutter on each side
+        }
+      }
+    });
+  }, [isOpen]);
+
   // ── Display label for the selected option ───────────────────────────────
   const selectedOption = useMemo(
     () => options.find((o) => o.value === selectedValue),


### PR DESCRIPTION
## Summary

Fixes the Combobox dropdown listbox overflowing beyond the viewport when the component is positioned near the right edge of the screen.

## Changes

- Added a `useEffect` in `Combobox.tsx` that runs when the dropdown opens
- Uses `getBoundingClientRect()` + `requestAnimationFrame` to detect right-edge overflow
- Dynamically shifts the dropdown left (or caps its width) so the full listbox stays within the viewport with 8px visual padding on each side
- Uses direct DOM manipulation via refs (no extra state re-renders)

## Testing

- All 28 existing Combobox tests pass
- Manual verification: dropdown now stays within viewport bounds when near the right edge

Closes #1427