### PR TITLE
DX: add a `just typecheck` alias (Closes #1428)

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,2 +1,6 @@
 check:
     npm run check
+
+# Run TypeScript type-checking without emitting output
+typecheck:
+    npm run typecheck


### PR DESCRIPTION
Closes #1428

Adds a `just typecheck` alias to the `justfile` so that contributors can run `just typecheck` instead of `npm run typecheck`.

- The `typecheck` script already exists in `package.json` (`tsc --noEmit`)
- This is a DX improvement following the same pattern as the existing `check:` command in the `justfile`