### PR TITLE
fix: prevent date-range picker from allowing end < start (Closes #1536)

### DIFF
--- a/app/dashboard/transaction-history/page.tsx
+++ b/app/dashboard/transaction-history/page.tsx
@@ -23,6 +23,22 @@ import type {
   TransactionStatus,
 } from "@/components/Dashboard/TransactionHistoryItem";
 
+// Guards against dateTo < dateFrom whenever either value changes.
+// Setting dateFrom after dateTo (or dateTo before dateFrom) resets the
+// invalid value so the filter always represents a valid range.
+function useDateRangeValidation(
+  dateFrom: string,
+  dateTo: string,
+  setDateFrom: (v: string) => void,
+  setDateTo: (v: string) => void,
+) {
+  useEffect(() => {
+    if (dateFrom && dateTo && dateTo < dateFrom) {
+      setDateTo("");
+    }
+  }, [dateFrom, dateTo, setDateTo]);
+}
+
 type Direction = "all" | "sent" | "received";
 
 type GroupKey = "today" | "yesterday" | "earlier";
@@ -68,6 +84,9 @@ const TransactionHistoryPage = () => {
   const [isExportDropdownOpen, setIsExportDropdownOpen] = useState(false);
   const exportButtonRef = useRef<HTMLButtonElement>(null);
   const exportDropdownRef = useRef<HTMLDivElement>(null);
+
+  // Keep the date range valid: end < start resets the end value
+  useDateRangeValidation(dateFrom, dateTo, setDateFrom, setDateTo);
 
   const todayStart = useMemo(() => startOfDay(new Date()), []);
   const yesterdayStart = useMemo(() => {
@@ -541,6 +560,7 @@ const TransactionHistoryPage = () => {
                   type="date"
                   value={dateFrom}
                   onChange={(e) => setDateFrom(e.target.value)}
+                  max={dateTo || undefined}
                   className="min-h-[40px] rounded-xl border border-[#FFFFFF14] bg-[#1A1A1A] px-3 py-2 text-sm text-white focus:border-red-400/40 focus:outline-none focus:ring-1 focus:ring-red-400/40"
                 />
               </div>


### PR DESCRIPTION
## Summary

Adds two guards against an invalid date range where `dateTo < dateFrom`:

1. A `useDateRangeValidation` hook that clears `dateTo` whenever `dateFrom` is set to a value after `dateTo` (or vice versa).

2. A `max` attribute on the date-from input so the browser natively prevents selecting a from-date after the to-date.

The `min` attribute on the date-to input was already present, so the pair now forms a full cross-validation.

## Changes

- `app/dashboard/transaction-history/page.tsx` — Added `useDateRangeValidation` hook + `max` attribute on date-from input

## Testing

- `npm run typecheck` — passes (pre-existing errors unchanged)
- `npm run test:unit:vitest` — 5/6 test files pass (1 pre-existing failure in useVisibilityChange)
- No behavioural change for existing date-range filtering logic

Closes #1536