### PR TITLE
feat(uiux): design add/edit savings goal form and lock/withdraw states

### DIFF
--- a/app/dashboard/goals/components/ActionConfirmationModal.tsx
+++ b/app/dashboard/goals/components/ActionConfirmationModal.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import React from 'react'
+import { X, Lock, Unlock, ArrowDownToLine } from 'lucide-react'
+import { useFocusTrap } from '@/lib/hooks/useFocusTrap'
+import { useClientTranslator } from '@/lib/i18n/client'    
+
+export type ActionType = 'lock' | 'unlock' | 'withdraw'
+
+interface ActionConfirmationModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: () => void
+  actionType: ActionType
+  title: string
+  description?: string
+  isActionLoading?: boolean
+}
+
+export default function ActionConfirmationModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  actionType,
+  title,
+  description,
+  isActionLoading = false,
+}: ActionConfirmationModalProps) {
+  const { t } = useClientTranslator()
+  const modalRef = useFocusTrap<HTMLDivElement>({
+    isActive: isOpen,
+    onEscape: onClose,
+  })
+
+  if (!isOpen) return null
+
+  const getActionConfig = () => {
+    switch (actionType) {
+      case 'lock':
+        return {
+          icon: <Lock className="w-6 h-6" />,
+          gradient: { from: '#3b82f6', to: '#2563eb' },
+          confirmLabel: t('savingsGoals.actions.confirmLock') || 'Confirm Lock',
+        }
+      case 'unlock':
+        return {
+          icon: <Unlock className="w-6 h-6" />,
+          gradient: { from: '#f59e0b', to: '#d97706' },
+          confirmLabel: t('savingsGoals.actions.confirmUnlock') || 'Confirm Unlock',
+        }
+      case 'withdraw':
+        return {
+          icon: <ArrowDownToLine className="w-6 h-6" />,
+          gradient: { from: '#10b981', to: '#059669' },
+          confirmLabel: t('savingsGoals.actions.confirmWithdraw') || 'Confirm Withdraw',
+        }
+      default:
+        return {
+          icon: <Lock className="w-6 h-6" />,
+          gradient: { from: '#6b7280', to: '#4b5563' },
+          confirmLabel: 'Confirm',
+        }
+    }
+  }
+
+  const { icon, gradient, confirmLabel } = getActionConfig()
+
+  return (
+    <div
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-black/70 px-4 backdrop-blur-sm motion-reduce:backdrop-blur-none"
+      onClick={onClose}
+    >
+      <div
+        ref={modalRef}
+        className="relative mx-4 w-full max-w-sm rounded-2xl p-6 shadow-2xl motion-safe:animate-slide-in-bottom motion-reduce:animate-none 375:p-8"
+        style={{
+          background: 'linear-gradient(180deg, #0F0F0F 0%, #0A0A0A 100%)',
+          border: '1px solid rgba(255, 255, 255, 0.08)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-modal-title"
+      >
+        <button
+          onClick={onClose}
+          className="touch-target absolute right-4 top-4 flex items-center justify-center p-2 text-white/50 transition-colors hover:text-white motion-reduce:transition-none"
+          aria-label={t('common.close') || 'Close'}
+        >
+          <X className="w-5 h-5" />
+        </button>
+
+        <div className="flex flex-col items-center text-center">
+          <div
+            className="mb-5 flex h-14 w-14 shrink-0 items-center justify-center rounded-[14px]"
+            style={{
+              background: `linear-gradient(180deg, ${gradient.from} 0%, ${gradient.to} 100%)`,
+            }}
+            aria-hidden="true"
+          >
+            <div className="text-white">{icon}</div>
+          </div>
+
+          <h2 id="confirm-modal-title" className="mb-2 text-xl font-bold text-white 375:text-2xl">
+            {title}
+          </h2>
+
+          {description && (
+            <p className="mb-8 text-sm text-white/60">
+              {description}
+            </p>
+          )}
+
+          <div className="grid w-full gap-3 tablet:grid-cols-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isActionLoading}
+              className="touch-target-wide rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition hover:border-white/20 hover:bg-white/10 disabled:opacity-50"
+            >
+              {t('common.cancel') || 'Cancel'}
+            </button>
+            <button
+              type="button"
+              onClick={onConfirm}
+              disabled={isActionLoading}
+              className="touch-target-wide rounded-xl px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:brightness-110 active:scale-[0.98] disabled:opacity-50"
+              style={{
+                background: `linear-gradient(180deg, ${gradient.from} 0%, ${gradient.to} 100%)`,
+              }}
+            >
+              {isActionLoading ? '...' : confirmLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/goals/page.tsx
+++ b/app/dashboard/goals/page.tsx
@@ -11,7 +11,9 @@ import PageHeader from '@/components/PageHeader'
 import SavingsGoalCard from '@/components/Dashboard/SavingsGoalCard'
 import SavingsGoalsStatsCards from './components/SavingsGoalsStatsCards'
 import SavingsGoalModal from './components/SavingsGoalModal'
+import ActionConfirmationModal, { ActionType } from './components/ActionConfirmationModal'
 import { SavingsGoal } from './types'
+import { Target } from 'lucide-react'
 import { calculateDaysLeft, checkIsOverdue } from './utils'
 import { useClientTranslator } from '@/lib/i18n/client'
 import { CTA_TEST_IDS } from '@/lib/cta-testids'
@@ -58,6 +60,7 @@ const initialGoals: SavingsGoal[] = [
     currentAmount: 3000,
     targetAmount: 3000,
     targetDate: '2026-07-01',
+    isLocked: false,
   },
 ]
 
@@ -71,6 +74,16 @@ export default function SavingsGoalsPage() {
   const [goals, setGoals] = useState<SavingsGoal[]>(initialGoals)
   const [showModal, setShowModal] = useState(false)
   const [editingGoal, setEditingGoal] = useState<SavingsGoal | null>(null)
+  
+  const [confirmModalState, setConfirmModalState] = useState<{
+    isOpen: boolean
+    actionType: ActionType
+    goalId: number | string | null
+  }>({
+    isOpen: false,
+    actionType: 'lock',
+    goalId: null,
+  })
 
   // Calculate summary stats dynamically
   const stats = useMemo(() => {
@@ -98,10 +111,30 @@ export default function SavingsGoalsPage() {
         ...goalData,
         id: Date.now(),
         currentAmount: 0,
+        isLocked: false,
       } as SavingsGoal
       setGoals([...goals, newGoal])
     }
     setShowModal(false)
+  }
+
+  const openConfirmModal = (actionType: ActionType, goalId: number | string) => {
+    setConfirmModalState({ isOpen: true, actionType, goalId })
+  }
+
+  const closeConfirmModal = () => {
+    setConfirmModalState(prev => ({ ...prev, isOpen: false }))
+  }
+
+  const handleConfirmAction = () => {
+    const { actionType, goalId } = confirmModalState
+    if (goalId !== null) {
+      if (actionType === 'lock' || actionType === 'unlock') {
+        setGoals(goals.map(g => g.id === goalId ? { ...g, isLocked: actionType === 'lock' } : g))
+      }
+      // For withdraw, we could reset amount, but specs say no logic needed.
+    }
+    closeConfirmModal()
   }
 
   return (
@@ -131,25 +164,46 @@ export default function SavingsGoalsPage() {
           Savings goals are tracked in USDC and stored through the connected savings_goals contract. Funds remain in your wallet until each signed goal action is submitted.
         </div>
 
-        {/* Goals Grid */}
-        <div className="grid min-w-0 grid-cols-1 gap-5 375:gap-6 450:grid-cols-2 xl:grid-cols-3">
-          {goals.map((goal) => (
-            <SavingsGoalCard
-              key={goal.id}
-              title={goal.title}
-              description={goal.description}
-              icon={goal.icon}
-              iconGradient={goal.iconGradient}
-              currentAmount={goal.currentAmount}
-              targetAmount={goal.targetAmount}
-              targetDate={goal.targetDate}
-              daysLeft={calculateDaysLeft(goal.targetDate)}
-              isOverdue={checkIsOverdue(goal.targetDate)}
-              onAddFunds={() => console.log('Add funds to', goal.title)}
-              onEdit={() => handleEditGoal(goal)}
-            />
-          ))}
-        </div>
+        {/* Goals Grid or Empty State */}
+        {goals.length === 0 ? (
+          <div className="flex flex-col items-center justify-center rounded-2xl border border-white/10 bg-white/5 py-16 px-5 text-center mt-6">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white/10 mb-4">
+              <Target className="w-8 h-8 text-white/50" />
+            </div>
+            <h3 className="text-xl font-bold text-white mb-2">No savings goals yet</h3>
+            <p className="text-sm text-white/60 max-w-md mx-auto mb-6">
+              Start setting aside funds for your future by creating your first savings goal.
+            </p>
+            <button
+              onClick={handleNewGoal}
+              className="rounded-xl bg-gradient-to-b from-[#DC2626] to-[#B91C1C] px-6 py-3 text-sm font-bold text-white transition hover:brightness-110"
+            >
+              Create Goal
+            </button>
+          </div>
+        ) : (
+          <div className="grid min-w-0 grid-cols-1 gap-5 375:gap-6 450:grid-cols-2 xl:grid-cols-3">
+            {goals.map((goal) => (
+              <SavingsGoalCard
+                key={goal.id}
+                title={goal.title}
+                description={goal.description}
+                icon={goal.icon}
+                iconGradient={goal.iconGradient}
+                currentAmount={goal.currentAmount}
+                targetAmount={goal.targetAmount}
+                targetDate={goal.targetDate}
+                daysLeft={calculateDaysLeft(goal.targetDate)}
+                isOverdue={checkIsOverdue(goal.targetDate)}
+                isLocked={goal.isLocked}
+                onAddFunds={() => console.log('Add funds to', goal.title)}
+                onEdit={() => handleEditGoal(goal)}
+                onToggleLock={() => openConfirmModal(goal.isLocked ? 'unlock' : 'lock', goal.id)}
+                onWithdraw={() => openConfirmModal('withdraw', goal.id)}
+              />
+            ))}
+          </div>
+        )}
       </main>
 
       {/* Savings Goal Modal */}
@@ -158,6 +212,24 @@ export default function SavingsGoalsPage() {
         onClose={() => setShowModal(false)}
         onSave={handleSaveGoal}
         editingGoal={editingGoal}
+      />
+
+      {/* Action Confirmation Modal */}
+      <ActionConfirmationModal
+        isOpen={confirmModalState.isOpen}
+        onClose={closeConfirmModal}
+        onConfirm={handleConfirmAction}
+        actionType={confirmModalState.actionType}
+        title={
+          confirmModalState.actionType === 'lock' ? 'Lock Goal Funds' :
+          confirmModalState.actionType === 'unlock' ? 'Unlock Goal Funds' :
+          'Withdraw Goal Funds'
+        }
+        description={
+          confirmModalState.actionType === 'lock' ? 'Locking this goal prevents early withdrawals based on smart contract rules.' :
+          confirmModalState.actionType === 'unlock' ? 'Unlocking this goal will allow you to withdraw funds freely.' :
+          'Are you sure you want to withdraw these funds back to your main wallet?'
+        }
       />
     </div>
   )

--- a/app/dashboard/goals/types.ts
+++ b/app/dashboard/goals/types.ts
@@ -9,6 +9,7 @@ export interface SavingsGoal {
   currentAmount: number
   targetAmount: number
   targetDate: string
+  isLocked?: boolean
 }
 
 export interface SavingsGoalFormData {

--- a/components/Dashboard/SavingsGoalCard.tsx
+++ b/components/Dashboard/SavingsGoalCard.tsx
@@ -7,6 +7,9 @@ import {
     CheckCircle2,
     Clock3,
     Sparkles,
+    Lock,
+    Unlock,
+    ArrowDownToLine,
 } from 'lucide-react'
 import { useClientTranslator } from '@/lib/i18n/client'
 
@@ -20,8 +23,11 @@ export interface SavingsGoalCardProps {
     targetDate: string
     daysLeft?: number
     isOverdue?: boolean
+    isLocked?: boolean
     onAddFunds?: () => void
     onEdit?: () => void
+    onToggleLock?: () => void
+    onWithdraw?: () => void
 }
 
 function formatCurrency(amount: number): string {
@@ -157,8 +163,11 @@ export default function SavingsGoalCard({
     targetDate,
     daysLeft,
     isOverdue = false,
+    isLocked = false,
     onAddFunds,
     onEdit,
+    onToggleLock,
+    onWithdraw,
 }: SavingsGoalCardProps) {
     const { t } = useClientTranslator()
 
@@ -209,24 +218,55 @@ export default function SavingsGoalCard({
             />
 
             <div className="relative z-10 flex flex-col gap-5">
-                {/* ── Row 1: icon + status badge ── */}
+                {/* ── Row 1: icon + status badge + actions ── */}
                 <div className="flex min-w-0 items-start justify-between gap-3 375:gap-4">
                     <div
-                        className="w-12 h-12 shrink-0 rounded-[14px] flex items-center justify-center"
+                        className="w-12 h-12 shrink-0 rounded-[14px] flex items-center justify-center relative"
                         style={{
                             background: `linear-gradient(180deg, ${iconGradient.from} 0%, ${iconGradient.to} 100%)`,
                         }}
                         aria-hidden="true"
                     >
                         <div className="w-6 h-6 text-white">{icon}</div>
+                        {isLocked && (
+                            <div className="absolute -bottom-1 -right-1 bg-[#111] p-0.5 rounded-full border border-white/20">
+                                <Lock className="w-3 h-3 text-blue-400" />
+                            </div>
+                        )}
                     </div>
 
-                    {/* Status badge — icon + text label, never color alone */}
-                    <div
-                        className={`inline-flex max-w-full shrink items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold ${badgeClassName}`}
-                    >
-                        <StatusIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-                        <span className="truncate">{statusLabel}</span>
+                    <div className="flex flex-col items-end gap-2 shrink-0">
+                        {/* Status badge — icon + text label, never color alone */}
+                        <div
+                            className={`inline-flex max-w-full shrink items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold ${badgeClassName}`}
+                        >
+                            <StatusIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                            <span className="truncate">{statusLabel}</span>
+                        </div>
+                        
+                        {/* Action buttons (Lock/Withdraw) */}
+                        <div className="flex items-center gap-2">
+                            {onToggleLock && (
+                                <button 
+                                    type="button" 
+                                    onClick={onToggleLock} 
+                                    className="text-white/50 hover:text-white transition-colors p-1.5 bg-white/5 rounded-lg border border-white/10" 
+                                    aria-label={isLocked ? (t('savingsGoals.card.unlock') || 'Unlock') : (t('savingsGoals.card.lock') || 'Lock')}
+                                >
+                                    {isLocked ? <Lock className="w-4 h-4" /> : <Unlock className="w-4 h-4" />}
+                                </button>
+                            )}
+                            {onWithdraw && (
+                                <button 
+                                    type="button" 
+                                    onClick={onWithdraw} 
+                                    className="text-white/50 hover:text-white transition-colors p-1.5 bg-white/5 rounded-lg border border-white/10" 
+                                    aria-label={t('savingsGoals.card.withdraw') || 'Withdraw'}
+                                >
+                                    <ArrowDownToLine className="w-4 h-4" />
+                                </button>
+                            )}
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
Closes #1301 

I have completed the execution of the implementation plan. Here's exactly what was built to resolve this:

Created ActionConfirmationModal.tsx: A highly reusable unified confirmation wrapper implementing the RemitWise aesthetic with sleek background glows, capturing focus trapping, and exposing custom icon/gradient combos mapping to Lock, Unlock, or Withdraw intent.

Embedded Affordances in SavingsGoalCard.tsx: Injected new secondary Lock/Unlock and Withdraw icon-buttons in the status indicator layout row. If a goal is toggled "Locked", a small padlock is now composited to the bottom-right frame of the main icon.

Wired Page Handlers & Empty State (page.tsx): The UI correctly displays a full "Empty State" fallback (featuring a beautiful Target icon centered layout) when there are no savings goals left. The mock-action lock, unlock, and withdraw intents successfully invoke the respective conformation wrappers and handle the mocked UI progression smoothly. 
Tests were done visually targeting A11y and viewport dimensions spanning 375px to 1280px.
