### PR TITLE
perf(family): memoize the derived stats/ordering in FamilyMemberSection

### DIFF
--- a/app/family/components/FamilyMemberSection.tsx
+++ b/app/family/components/FamilyMemberSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import FamilyMemberStatCard, { FamilyMember } from "./FamilyMemberStatCard";
 import FamilyMemberDetailDrawer from "./FamilyMemberDetailDrawer";
 import { useClientTranslator } from "@/lib/i18n/client";
@@ -60,17 +60,24 @@ const FamilyMemberSection: React.FC = () => {
 	const { t } = useClientTranslator();
 	const [selectedMember, setSelectedMember] = useState<FamilyMember | null>(null);
 	const activeCount = getActiveMemberCount();
-	const totalLimit = familyMembers.reduce(
-		(sum, member) => sum + member.spendingLimit,
-		0
-	);
-	const totalUsed = familyMembers.reduce((sum, member) => sum + member.used, 0);
-	const nearLimitCount = familyMembers.filter(
-		(member) => member.usedPercentage >= 75
-	).length;
-	const orderedMembers = [...familyMembers].sort(
-		(a, b) => b.usedPercentage - a.usedPercentage
-	);
+	// familyMembers is a module-level constant, but the reduce/filter/sort
+	// transforms below previously re-ran (and, for the sort, allocated a new
+	// array) on every render of this section -- including renders triggered
+	// by unrelated state, like selecting a member to open the detail drawer.
+	// Memoized so they only recompute if the underlying data actually
+	// changes; the derived values are identical to before, this only changes
+	// when they're computed.
+	const { totalLimit, totalUsed, nearLimitCount, orderedMembers } = useMemo(() => {
+		return {
+			totalLimit: familyMembers.reduce((sum, member) => sum + member.spendingLimit, 0),
+			totalUsed: familyMembers.reduce((sum, member) => sum + member.used, 0),
+			nearLimitCount: familyMembers.filter((member) => member.usedPercentage >= 75)
+				.length,
+			orderedMembers: [...familyMembers].sort(
+				(a, b) => b.usedPercentage - a.usedPercentage
+			),
+		};
+	}, []);
 
 	return (
 		<section className='space-y-6'>

--- a/tests/unit/FamilyMemberSection.test.tsx
+++ b/tests/unit/FamilyMemberSection.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Regression coverage for the useMemo refactor in FamilyMemberSection:
+ * the derived stats (total limit/used, near-limit count) and the
+ * usedPercentage-descending member order must render identically to the
+ * pre-refactor inline reduce/filter/sort.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import FamilyMemberSection, {
+  familyMembers,
+} from "../../app/family/components/FamilyMemberSection";
+import { ToastProvider } from "../../lib/context/ToastContext";
+
+function renderSection() {
+  return render(
+    <ToastProvider>
+      <FamilyMemberSection />
+    </ToastProvider>
+  );
+}
+
+describe("FamilyMemberSection", () => {
+  it("renders the correct remaining-budget and near-limit stats", () => {
+    renderSection();
+
+    const totalLimit = familyMembers.reduce((sum, m) => sum + m.spendingLimit, 0);
+    const totalUsed = familyMembers.reduce((sum, m) => sum + m.used, 0);
+    const remaining = totalLimit - totalUsed;
+    const nearLimitCount = familyMembers.filter((m) => m.usedPercentage >= 75).length;
+
+    const formatter = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    });
+
+    expect(screen.getByText(formatter.format(remaining))).toBeInTheDocument();
+    expect(screen.getByText(String(nearLimitCount))).toBeInTheDocument();
+    expect(screen.getByText(String(familyMembers.length))).toBeInTheDocument();
+  });
+
+  it("orders members by usedPercentage descending", () => {
+    renderSection();
+
+    const expectedOrder = [...familyMembers]
+      .sort((a, b) => b.usedPercentage - a.usedPercentage)
+      .map((m) => m.name);
+
+    const renderedNames = expectedOrder.map((name) => screen.getByText(name));
+    for (let i = 1; i < renderedNames.length; i++) {
+      // Each name must appear later in the document than the previous one.
+      expect(
+        renderedNames[i - 1].compareDocumentPosition(renderedNames[i]) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`FamilyMemberSection` recomputed `totalLimit`/`totalUsed`/`nearLimitCount` (reduce/filter) and `orderedMembers` (a sort that allocates a new array) inline on every render — including renders triggered by unrelated state, like `setSelectedMember` when opening the detail drawer. Wrapped all four in a single `useMemo` keyed on the module-level `familyMembers` constant (empty deps, since that array never changes at runtime).

Behavior is unchanged — same values, same order, only when they're computed changes.

Closes #1523

## Test plan
- `npm run lint`
- `npm run typecheck` (no new errors introduced by this file; the repo has pre-existing unrelated typecheck errors from the in-progress CI stabilization effort)
- `npm test -- tests/unit/FamilyMemberSection.test.tsx` — 2 new tests: rendered stat values match the expected computed totals, and members render in usedPercentage-descending document order