### PR TITLE
feat(validate): reject file uploads with non-image mime types

### DIFF
--- a/lib/validation/imageUpload.test.ts
+++ b/lib/validation/imageUpload.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { validateImageMimeType, ACCEPTED_IMAGE_MIME_TYPES } from './imageUpload';
+
+describe('validateImageMimeType', () => {
+  it.each(ACCEPTED_IMAGE_MIME_TYPES)('accepts %s', (mimeType) => {
+    expect(validateImageMimeType({ type: mimeType })).toEqual({ ok: true });
+  });
+
+  it('rejects a PDF', () => {
+    expect(validateImageMimeType({ type: 'application/pdf' })).toEqual({
+      ok: false,
+      error: 'unsupported_mime_type',
+      mimeType: 'application/pdf',
+    });
+  });
+
+  it('rejects an executable', () => {
+    expect(validateImageMimeType({ type: 'application/x-msdownload' })).toEqual({
+      ok: false,
+      error: 'unsupported_mime_type',
+      mimeType: 'application/x-msdownload',
+    });
+  });
+
+  it('rejects a missing/empty MIME type rather than treating it as accepted', () => {
+    expect(validateImageMimeType({ type: '' })).toEqual({
+      ok: false,
+      error: 'missing_mime_type',
+      mimeType: '',
+    });
+  });
+
+  it('rejects an SVG (can embed script content, not treated as a safe raster image here)', () => {
+    expect(validateImageMimeType({ type: 'image/svg+xml' })).toEqual({
+      ok: false,
+      error: 'unsupported_mime_type',
+      mimeType: 'image/svg+xml',
+    });
+  });
+});

--- a/lib/validation/imageUpload.ts
+++ b/lib/validation/imageUpload.ts
@@ -1,0 +1,38 @@
+/**
+ * Validates that an uploaded file's MIME type is an accepted image type.
+ * Rejects at this boundary -- before the file is read, previewed, or sent
+ * anywhere -- rather than letting a non-image file (a PDF, an executable
+ * with a spoofed extension, etc.) reach code that assumes image data.
+ *
+ * Checks `file.type` (the browser-reported MIME type), not the filename
+ * extension, which is easy to spoof and doesn't reflect actual content.
+ */
+
+export const ACCEPTED_IMAGE_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+] as const;
+
+export type AcceptedImageMimeType = (typeof ACCEPTED_IMAGE_MIME_TYPES)[number];
+
+export type ImageMimeTypeValidationResult =
+  | { ok: true }
+  | { ok: false; error: 'missing_mime_type' | 'unsupported_mime_type'; mimeType: string };
+
+export function validateImageMimeType(
+  file: Pick<File, 'type'>
+): ImageMimeTypeValidationResult {
+  const mimeType = file.type;
+
+  if (!mimeType) {
+    return { ok: false, error: 'missing_mime_type', mimeType };
+  }
+
+  if (!(ACCEPTED_IMAGE_MIME_TYPES as readonly string[]).includes(mimeType)) {
+    return { ok: false, error: 'unsupported_mime_type', mimeType };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary

No file-upload validation exists yet in this app. Adds `validateImageMimeType(file)` in `lib/validation/imageUpload.ts` as the boundary check: rejects a missing MIME type and any type outside a small allowlist (jpeg/png/gif/webp), checked before the file is ever read, previewed, or sent anywhere.

Checks the browser-reported `file.type`, not the filename extension (easy to spoof, doesn't reflect actual content). SVG is deliberately excluded from the allowlist -- it can embed script content and isn't treated as a safe raster image here.

Closes #1526

## Test plan
- `npm run lint`
- `npm run typecheck`
- `npm test -- lib/validation/imageUpload.test.ts` -- 8 new tests: all 4 accepted types pass, a PDF and an executable MIME type are rejected, an empty/missing MIME type is rejected (not silently accepted), SVG is rejected