### PR TITLE
feat(validate): reject file uploads over 25 MiB on the client

### DIFF
--- a/lib/validation/fileSize.test.ts
+++ b/lib/validation/fileSize.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { validateFileSize, MAX_UPLOAD_SIZE_BYTES } from './fileSize';
+
+describe('validateFileSize', () => {
+  it('accepts a file exactly at the 25 MiB limit (inclusive boundary)', () => {
+    expect(validateFileSize({ size: MAX_UPLOAD_SIZE_BYTES })).toEqual({ ok: true });
+  });
+
+  it('accepts a small file', () => {
+    expect(validateFileSize({ size: 1024 })).toEqual({ ok: true });
+  });
+
+  it('rejects a file one byte over the limit', () => {
+    expect(validateFileSize({ size: MAX_UPLOAD_SIZE_BYTES + 1 })).toEqual({
+      ok: false,
+      error: 'file_too_large',
+      sizeBytes: MAX_UPLOAD_SIZE_BYTES + 1,
+      maxSizeBytes: MAX_UPLOAD_SIZE_BYTES,
+    });
+  });
+
+  it('rejects a file far over the limit', () => {
+    const oversized = 100 * 1024 * 1024; // 100 MiB
+    expect(validateFileSize({ size: oversized })).toEqual({
+      ok: false,
+      error: 'file_too_large',
+      sizeBytes: oversized,
+      maxSizeBytes: MAX_UPLOAD_SIZE_BYTES,
+    });
+  });
+
+  it('accepts a zero-byte file (empty-file handling is a separate concern)', () => {
+    expect(validateFileSize({ size: 0 })).toEqual({ ok: true });
+  });
+
+  it('honors a custom max size override', () => {
+    const oneKb = 1024;
+    expect(validateFileSize({ size: 2048 }, oneKb)).toEqual({
+      ok: false,
+      error: 'file_too_large',
+      sizeBytes: 2048,
+      maxSizeBytes: oneKb,
+    });
+  });
+});

--- a/lib/validation/fileSize.ts
+++ b/lib/validation/fileSize.ts
@@ -1,0 +1,29 @@
+/**
+ * Validates that an uploaded file doesn't exceed the client-side size cap.
+ * Threat-modeled boundary: without this, a user (or a malicious script
+ * driving the file input) could hand a multi-gigabyte file to code that
+ * reads it into memory (e.g. `FileReader.readAsDataURL`) or uploads it,
+ * hanging or crashing the tab and wasting the user's bandwidth long before
+ * any server-side limit gets a chance to reject it.
+ */
+
+export const MAX_UPLOAD_SIZE_BYTES = 25 * 1024 * 1024; // 25 MiB
+
+export type FileSizeValidationResult =
+  | { ok: true }
+  | { ok: false; error: 'file_too_large'; sizeBytes: number; maxSizeBytes: number };
+
+export function validateFileSize(
+  file: Pick<File, 'size'>,
+  maxSizeBytes: number = MAX_UPLOAD_SIZE_BYTES
+): FileSizeValidationResult {
+  if (file.size > maxSizeBytes) {
+    return {
+      ok: false,
+      error: 'file_too_large',
+      sizeBytes: file.size,
+      maxSizeBytes,
+    };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary

**Threat model:** without a client-side size cap, a user (or a script driving the file input) can hand a multi-gigabyte file to code that reads it into memory (e.g. `FileReader.readAsDataURL`) or attempts to upload it -- hanging or crashing the tab long before any server-side limit gets a chance to reject it.

Adds `validateFileSize(file, maxSizeBytes?)` in `lib/validation/fileSize.ts`: rejects a file over 25 MiB (the default cap, overridable per call site) with a typed result carrying the actual and max size in bytes, so the UI can render a precise message.

Closes #1527

## Test plan
- `npm run lint`
- `npm run typecheck`
- `npm test -- lib/validation/fileSize.test.ts` -- 6 new tests: exactly-at-limit accepted (inclusive boundary), small file accepted, one byte over rejected, far over rejected, zero-byte file accepted, custom max-size override honored