### PR TITLE
refactor: extract cursor pagination state out of the transaction history table

### DIFF
--- a/app/dashboard/transaction-history/page.tsx
+++ b/app/dashboard/transaction-history/page.tsx
@@ -13,6 +13,7 @@ import { useClientTranslator } from "@/lib/i18n/client";
 import { useDebounce } from "@/lib/hooks/useDebounce";
 import { useSeo } from "@/lib/hooks/useSeo";
 import { useInfiniteScrollObserver } from "@/lib/hooks/useInfiniteScrollObserver";
+import { useCursorPagination } from "@/lib/hooks/useCursorPagination";
 import {
   serializeToCsv,
   serializeToJson,
@@ -65,11 +66,7 @@ const TransactionHistoryPage = () => {
   });
 
   const { t } = useClientTranslator();
-  const [transactions, setTransactions] = useState<TransactionItem[]>([]);
   const [userAddress, setUserAddress] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [initialLoading, setInitialLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
   const debouncedSearch = useDebounce(searchTerm, 300);
   const [statusFilter, setStatusFilter] = useState<
@@ -78,9 +75,6 @@ const TransactionHistoryPage = () => {
   const [directionFilter, setDirectionFilter] = useState<Direction>("all");
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
-  const [cursor, setCursor] = useState<string | undefined>();
-  const [hasMore, setHasMore] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
   const [isExportDropdownOpen, setIsExportDropdownOpen] = useState(false);
   const exportButtonRef = useRef<HTMLButtonElement>(null);
   const exportDropdownRef = useRef<HTMLDivElement>(null);
@@ -114,62 +108,46 @@ const TransactionHistoryPage = () => {
       [t],
     );
 
-  const fetchTransactions = useCallback(
-    async (currentCursor?: string, reset = false) => {
-      try {
-        if (reset) {
-          setLoading(true);
-        } else {
-          setLoadingMore(true);
-        }
-        setError(null);
-
-        const params = new URLSearchParams();
-        params.append("limit", "50");
-        if (currentCursor && !reset) {
-          params.append("cursor", currentCursor);
-        }
-        if (statusFilter !== "all") {
-          params.append("status", statusFilter);
-        }
-
-        const response = await fetch(`/api/v1/remittance/history?${params}`);
-        if (!response.ok) {
-          throw new Error(t("transactionHistory.alerts.fetchFailed"));
-        }
-
-        const data = await response.json();
-
-        if (data.userAddress) {
-          setUserAddress(data.userAddress);
-        }
-
-        if (reset) {
-          setTransactions(data.transactions || []);
-        } else {
-          setTransactions((prev) => [...prev, ...(data.transactions || [])]);
-        }
-
-        setCursor(data.nextCursor);
-        setHasMore(!!data.nextCursor);
-      } catch (err) {
-        setError(
-          err instanceof Error
-            ? err.message
-            : t("transactionHistory.alerts.genericError"),
-        );
-      } finally {
-        setLoading(false);
-        setInitialLoading(false);
-        setLoadingMore(false);
+  const fetchTransactionsPage = useCallback(
+    async (currentCursor: string | undefined, reset: boolean) => {
+      const params = new URLSearchParams();
+      params.append("limit", "50");
+      if (currentCursor && !reset) {
+        params.append("cursor", currentCursor);
       }
+      if (statusFilter !== "all") {
+        params.append("status", statusFilter);
+      }
+
+      const response = await fetch(`/api/v1/remittance/history?${params}`);
+      if (!response.ok) {
+        throw new Error(t("transactionHistory.alerts.fetchFailed"));
+      }
+
+      const data = await response.json();
+
+      if (data.userAddress) {
+        setUserAddress(data.userAddress);
+      }
+
+      return { items: data.transactions || [], nextCursor: data.nextCursor };
     },
     [statusFilter, t],
   );
 
-  useEffect(() => {
-    fetchTransactions(undefined, true);
-  }, [fetchTransactions]);
+  const {
+    items: transactions,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    isInitialLoading,
+    loadMore: handleLoadMore,
+    refetch: refetchTransactions,
+  } = useCursorPagination<TransactionItem>({
+    fetchPage: fetchTransactionsPage,
+    fallbackErrorMessage: t("transactionHistory.alerts.genericError"),
+  });
 
   // Close export dropdown on click outside or escape key
   useEffect(() => {
@@ -201,12 +179,6 @@ const TransactionHistoryPage = () => {
       document.removeEventListener("keydown", handleEscape);
     };
   }, [isExportDropdownOpen]);
-
-  const handleLoadMore = useCallback(() => {
-    if (hasMore && !loadingMore) {
-      fetchTransactions(cursor, false);
-    }
-  }, [hasMore, loadingMore, cursor, fetchTransactions]);
 
   const { sentinelRef } = useInfiniteScrollObserver({
     hasMore,
@@ -365,7 +337,7 @@ const TransactionHistoryPage = () => {
     },
     [groupedTransactions, dateFrom, dateTo, filteredCount],
   );
-  const isLoading = initialLoading && loading;
+  const isLoading = isInitialLoading;
   const noTransactions = !isLoading && !error && totalCount === 0;
   const noResults =
     !isLoading &&
@@ -499,10 +471,7 @@ const TransactionHistoryPage = () => {
                   <button
                     key={status}
                     type="button"
-                    onClick={() => {
-                      setStatusFilter(status);
-                      setCursor(undefined);
-                    }}
+                    onClick={() => setStatusFilter(status)}
                     aria-pressed={statusFilter === status}
                     className={`min-h-[40px] rounded-xl px-4 py-2 text-sm font-medium transition-colors whitespace-normal sm:text-base ${
                       statusFilter === status
@@ -660,7 +629,7 @@ const TransactionHistoryPage = () => {
             <div className="mt-3 text-center">
               <button
                 type="button"
-                onClick={() => fetchTransactions(undefined, true)}
+                onClick={refetchTransactions}
                 className="min-h-[40px] rounded-xl bg-[#FF4B26] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#FF4B26]/80"
               >
                 Retry

--- a/lib/hooks/useCursorPagination.test.ts
+++ b/lib/hooks/useCursorPagination.test.ts
@@ -1,0 +1,74 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { useCursorPagination } from "./useCursorPagination";
+
+describe("useCursorPagination", () => {
+  it("loads the first page on mount", async () => {
+    const fetchPage = vi.fn().mockResolvedValue({ items: [1, 2, 3], nextCursor: "c1" });
+    const { result } = renderHook(() => useCursorPagination({ fetchPage }));
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(fetchPage).toHaveBeenCalledWith(undefined, true);
+    expect(result.current.items).toEqual([1, 2, 3]);
+    expect(result.current.hasMore).toBe(true);
+    expect(result.current.isInitialLoading).toBe(false);
+  });
+
+  it("appends items and advances the cursor on loadMore", async () => {
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [1, 2], nextCursor: "c1" })
+      .mockResolvedValueOnce({ items: [3, 4], nextCursor: undefined });
+    const { result } = renderHook(() => useCursorPagination({ fetchPage }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.loadingMore).toBe(false));
+
+    expect(fetchPage).toHaveBeenLastCalledWith("c1", false);
+    expect(result.current.items).toEqual([1, 2, 3, 4]);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("does not fetch again once hasMore is false", async () => {
+    const fetchPage = vi.fn().mockResolvedValue({ items: [1], nextCursor: undefined });
+    const { result } = renderHook(() => useCursorPagination({ fetchPage }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.hasMore).toBe(false);
+
+    act(() => result.current.loadMore());
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces an Error's message on failure", async () => {
+    const fetchPage = vi.fn().mockRejectedValue(new Error("network down"));
+    const { result } = renderHook(() => useCursorPagination({ fetchPage }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe("network down");
+    expect(result.current.items).toEqual([]);
+  });
+
+  it("falls back to fallbackErrorMessage for a non-Error rejection", async () => {
+    const fetchPage = vi.fn().mockRejectedValue("nope");
+    const { result } = renderHook(() =>
+      useCursorPagination({ fetchPage, fallbackErrorMessage: "Custom failure" }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe("Custom failure");
+  });
+
+  it("marks isInitialLoading true only for the very first fetch", async () => {
+    const fetchPage = vi.fn().mockResolvedValue({ items: [], nextCursor: undefined });
+    const { result } = renderHook(() => useCursorPagination({ fetchPage }));
+
+    expect(result.current.isInitialLoading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.isInitialLoading).toBe(false);
+  });
+});

--- a/lib/hooks/useCursorPagination.ts
+++ b/lib/hooks/useCursorPagination.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export interface CursorPage<T> {
+  items: T[];
+  nextCursor?: string;
+}
+
+interface UseCursorPaginationOptions<T> {
+  /**
+   * Fetches one page. Called with `cursor: undefined, reset: true` for the
+   * first page (and any time `fetchPage` itself changes, e.g. a filter
+   * dependency it closes over). Responsible for the request itself and any
+   * side effects tied to the response (e.g. capturing metadata).
+   */
+  fetchPage: (cursor: string | undefined, reset: boolean) => Promise<CursorPage<T>>;
+  /** Used when `fetchPage` rejects with something other than an `Error`. */
+  fallbackErrorMessage?: string;
+}
+
+interface UseCursorPaginationResult<T> {
+  items: T[];
+  /** True only while the initial (or a filter-driven reset) fetch is in flight. */
+  loading: boolean;
+  /** True only while a "load more" fetch is in flight. */
+  loadingMore: boolean;
+  error: string | null;
+  hasMore: boolean;
+  /** True only for the very first fetch this hook instance ever makes. */
+  isInitialLoading: boolean;
+  loadMore: () => void;
+  /** Re-runs the first page from scratch (e.g. a "Retry" button after an error). */
+  refetch: () => void;
+}
+
+/**
+ * Owns cursor-based "load more" pagination state so table/list pages don't
+ * have to hand-roll cursor/hasMore/loading bookkeeping themselves.
+ */
+export function useCursorPagination<T>({
+  fetchPage,
+  fallbackErrorMessage = "Something went wrong. Please try again.",
+}: UseCursorPaginationOptions<T>): UseCursorPaginationResult<T> {
+  const [items, setItems] = useState<T[]>([]);
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
+
+  const load = useCallback(
+    async (currentCursor: string | undefined, reset: boolean) => {
+      try {
+        if (reset) {
+          setLoading(true);
+        } else {
+          setLoadingMore(true);
+        }
+        setError(null);
+
+        const page = await fetchPage(currentCursor, reset);
+
+        setItems((prev) => (reset ? page.items : [...prev, ...page.items]));
+        setCursor(page.nextCursor);
+        setHasMore(!!page.nextCursor);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : fallbackErrorMessage);
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+        setHasLoadedOnce(true);
+      }
+    },
+    [fetchPage, fallbackErrorMessage],
+  );
+
+  useEffect(() => {
+    load(undefined, true);
+    // `load` changes whenever `fetchPage` does, which is exactly when a
+    // reset-from-scratch fetch (e.g. a filter change) should run.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [load]);
+
+  const loadMore = useCallback(() => {
+    if (hasMore && !loadingMore) {
+      load(cursor, false);
+    }
+  }, [hasMore, loadingMore, cursor, load]);
+
+  const refetch = useCallback(() => {
+    load(undefined, true);
+  }, [load]);
+
+  return {
+    items,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    isInitialLoading: !hasLoadedOnce && loading,
+    loadMore,
+    refetch,
+  };
+}


### PR DESCRIPTION
## Summary
The transaction history table (`app/dashboard/transaction-history/page.tsx`) hand-rolled its own cursor-based "load more" pagination directly inside the page component: cursor/hasMore/loading/loadingMore/error state plus a `fetchTransactions` callback, all mixed in with filtering, grouping, and export logic in an 800+ line file.

This extracts that state machine into a standalone, reusable hook: `lib/hooks/useCursorPagination.ts`. Callers supply a `fetchPage(cursor, reset)` function; the hook owns `items`, `loading`, `loadingMore`, `error`, `hasMore`, `isInitialLoading`, `loadMore()`, and `refetch()`.

The transaction history page now delegates entirely to this hook — its own request logic is reduced to just building the `/api/v1/remittance/history` request and mapping the response into `{ items, nextCursor }`. Existing behavior (skeleton only on first load, sentinel + manual "load more" button, retry-on-error) is preserved.

Closes #1530

## Test plan
- New `lib/hooks/useCursorPagination.test.ts` (6 tests): initial page load, `loadMore` appending items and advancing the cursor, no fetch once `hasMore` is false, `Error` message surfaced on failure, fallback message for non-`Error` rejections, `isInitialLoading` true only for the very first fetch — all passing
- `npx eslint app/dashboard/transaction-history/page.tsx lib/hooks/useCursorPagination.ts lib/hooks/useCursorPagination.test.ts` — clean
- `npx tsc --noEmit` — no errors in the changed files