### PR TITLE
feat: add a typed hook for the bill alerts endpoint

### DIFF
--- a/lib/hooks/useBillAlerts.test.ts
+++ b/lib/hooks/useBillAlerts.test.ts
@@ -1,0 +1,68 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { apiClient } from "@/lib/client/apiClient";
+import { useBillAlerts } from "./useBillAlerts";
+import type { BillReminder } from "@/lib/bills-reminders";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const reminder: BillReminder = {
+  billId: "bill-1",
+  name: "Electricity",
+  amount: 42,
+  dueDate: "2026-08-01",
+  urgency: "urgent",
+};
+
+describe("useBillAlerts", () => {
+  it("loads alerts from the bills due-soon endpoint on mount", async () => {
+    vi.spyOn(apiClient, "getJson").mockResolvedValueOnce([reminder]);
+    const { result } = renderHook(() => useBillAlerts());
+
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(apiClient.getJson).toHaveBeenCalledWith("/api/v1/bills/due-soon");
+    expect(result.current.alerts).toEqual([reminder]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces an Error's message on failure", async () => {
+    vi.spyOn(apiClient, "getJson").mockRejectedValueOnce(new Error("boom"));
+    const { result } = renderHook(() => useBillAlerts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBe("boom");
+    expect(result.current.alerts).toEqual([]);
+  });
+
+  it("leaves alerts empty without setting an error when the session-expiry flow takes over", async () => {
+    vi.spyOn(apiClient, "getJson").mockResolvedValueOnce(null);
+    const { result } = renderHook(() => useBillAlerts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.alerts).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("refresh() re-fetches", async () => {
+    const getJson = vi
+      .spyOn(apiClient, "getJson")
+      .mockResolvedValueOnce([reminder])
+      .mockResolvedValueOnce([]);
+    const { result } = renderHook(() => useBillAlerts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.alerts).toEqual([reminder]);
+
+    await act(async () => {
+      result.current.refresh();
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(getJson).toHaveBeenCalledTimes(2);
+    expect(result.current.alerts).toEqual([]);
+  });
+});

--- a/lib/hooks/useBillAlerts.ts
+++ b/lib/hooks/useBillAlerts.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { apiClient } from "@/lib/client/apiClient";
+import type { BillReminder } from "@/lib/bills-reminders";
+
+export interface UseBillAlertsResult {
+  /** Bills due soon (or overdue) — see `getBillsDueSoon` for the window rules. */
+  alerts: BillReminder[];
+  isLoading: boolean;
+  error: string | null;
+  /** Re-fetches the alerts list. Safe to call from event handlers. */
+  refresh: () => void;
+}
+
+/**
+ * Typed hook for `GET /api/v1/bills/due-soon` — this app's alerts endpoint:
+ * upcoming/overdue bill reminders for the signed-in wallet.
+ */
+export function useBillAlerts(): UseBillAlertsResult {
+  const [alerts, setAlerts] = useState<BillReminder[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await apiClient.getJson<BillReminder[]>("/api/v1/bills/due-soon");
+      // `null` means the session-expiry flow already took over (redirect).
+      if (data === null) return;
+      setAlerts(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load alerts");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { alerts, isLoading, error, refresh: load };
+}


### PR DESCRIPTION
## Summary
This codebase doesn't have a generic "alerts" concept — the closest real thing is `GET /api/v1/bills/due-soon` (`app/api/v1/bills/due-soon/route.ts`), which surfaces upcoming/overdue bill reminders (built on `getBillsDueSoon` in `lib/bills-reminders.ts`). That endpoint already existed but had no client hook consuming it — components would have had to hand-roll a `fetch` + auth/session handling themselves.

Adds `useBillAlerts()` (`lib/hooks/useBillAlerts.ts`), a typed hook wrapping that endpoint via the shared `apiClient.getJson<BillReminder[]>`, so it gets the same timeout/retry/session-expiry handling as the rest of the app for free. Returns `{ alerts, isLoading, error, refresh }`.

Closes #1531

## Test plan
- New `lib/hooks/useBillAlerts.test.ts` (4 tests): loads alerts on mount, surfaces an `Error`'s message on failure, leaves `alerts` empty without setting an error when the session-expiry flow takes over (`apiClient` returns `null`), `refresh()` re-fetches — all passing
- `npx eslint lib/hooks/useBillAlerts.ts lib/hooks/useBillAlerts.test.ts` — clean
- `npx tsc --noEmit` — no errors in the new files