### PR TITLE
refactor: hoist transaction status colors into the shared status-semantics system

### DIFF
--- a/components/Dashboard/TransactionHistoryItem.tsx
+++ b/components/Dashboard/TransactionHistoryItem.tsx
@@ -18,6 +18,10 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { usePrefersReducedMotion } from "@/lib/hooks/usePrefersReducedMotion";
+import {
+  getSemanticTonePresentation,
+  type SemanticStatusPresentation,
+} from "@/lib/ui/status-semantics";
 
 export type TransactionStatus = "Completed" | "Pending" | "Failed";
 
@@ -70,29 +74,44 @@ const getIcon = (type: TransactionType, className?: string) => {
   }
 };
 
-const StatusBadge = ({ status }: { status: TransactionStatus }) => {
-  if (status === "Completed") {
-    return (
-      <div className="flex items-center gap-1.5 px-3 py-1 rounded-full bg-[#DC26261A] border border-[#DC262633]">
-        <Check className="w-3.5 h-3.5 text-[#FF4B26]" />
-        <span className="text-xs font-medium text-[#FF4B26]">Completed</span>
-      </div>
-    );
-  } else if (status === "Pending") {
-    return (
-      <div className="flex items-center gap-1.5 px-3 py-1 rounded-full bg-[#1F1F1F] border border-[#333]">
-        <Clock className="w-3.5 h-3.5 text-gray-400" />
-        <span className="text-xs font-medium text-gray-400">Pending</span>
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex items-center gap-1.5 px-3 py-1 rounded-full bg-[#1F1F1F] border border-[#333]">
-        <X className="w-3.5 h-3.5 text-gray-400" />
-        <span className="text-xs font-medium text-red-500">Failed</span>
-      </div>
-    );
+// Colors/icons come from the shared status-semantics system (see
+// TransactionStatusIndicator) instead of being hardcoded here, so a
+// transaction's status always reads consistently with bills/insurance/live
+// status elsewhere in the app.
+function getStatusPresentation(status: TransactionStatus): SemanticStatusPresentation {
+  switch (status) {
+    case "Completed":
+      return getSemanticTonePresentation("success", {
+        label: "Completed",
+        emphasis: "Transaction completed",
+        icon: Check,
+      });
+    case "Pending":
+      return getSemanticTonePresentation("warning", {
+        label: "Pending",
+        emphasis: "Transaction pending",
+        icon: Clock,
+      });
+    case "Failed":
+      return getSemanticTonePresentation("error", {
+        label: "Failed",
+        emphasis: "Transaction failed",
+        icon: X,
+      });
   }
+}
+
+const StatusBadge = ({ status }: { status: TransactionStatus }) => {
+  const presentation = getStatusPresentation(status);
+  const Icon = presentation.icon;
+  return (
+    <div
+      className={`flex items-center gap-1.5 px-3 py-1 rounded-full border ${presentation.badgeClassName}`}
+    >
+      <Icon className="w-3.5 h-3.5" aria-hidden="true" />
+      <span className="text-xs font-medium">{presentation.label}</span>
+    </div>
+  );
 };
 
 export default function TransactionHistoryItem({

--- a/tests/unit/dashboard/transaction-history-item-status.test.tsx
+++ b/tests/unit/dashboard/transaction-history-item-status.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import TransactionHistoryItem, {
+  type Transaction,
+} from "@/components/Dashboard/TransactionHistoryItem";
+
+const baseTransaction: Transaction = {
+  id: "tx-1",
+  hash: "abc123",
+  type: "Send Money",
+  amount: -25,
+  currency: "USDC",
+  counterpartyName: "Jane Doe",
+  counterpartyLabel: "To",
+  date: "2026-07-01 10:00",
+  fee: 0.5,
+  status: "Completed",
+};
+
+describe("TransactionHistoryItem status badge", () => {
+  it("renders the shared success tone for Completed", () => {
+    render(<TransactionHistoryItem transaction={{ ...baseTransaction, status: "Completed" }} />);
+    const badge = screen.getByText("Completed").closest("div");
+    expect(badge?.className).toContain("status-success");
+  });
+
+  it("renders the shared warning tone for Pending", () => {
+    render(<TransactionHistoryItem transaction={{ ...baseTransaction, status: "Pending" }} />);
+    const badge = screen.getByText("Pending").closest("div");
+    expect(badge?.className).toContain("status-warning");
+  });
+
+  it("renders the shared error tone for Failed, with matching icon and text color", () => {
+    render(<TransactionHistoryItem transaction={{ ...baseTransaction, status: "Failed" }} />);
+    const badge = screen.getByText("Failed").closest("div");
+    expect(badge?.className).toContain("status-error");
+    // Previously the icon/border used gray while the label text used red —
+    // the shared presentation applies one consistent tone to the whole badge.
+    expect(badge?.className).not.toContain("gray");
+  });
+});


### PR DESCRIPTION
## Summary
`components/Dashboard/TransactionHistoryItem.tsx`'s `StatusBadge` hardcoded its own colors per status (`bg-[#DC26261A]`/`text-[#FF4B26]` for Completed, ad-hoc gray for Pending/Failed) instead of using the shared status-color system in `lib/ui/status-semantics.ts` that `TransactionStatusIndicator.tsx` (and bills/insurance) already use. This meant the same concept — a transaction's status — could render with two different color languages depending on which component showed it, and the "Failed" badge had a real inconsistency: gray icon/border with red-500 text.

Replaces the hardcoded if/else with a small `getStatusPresentation` mapper (mirroring the one already in `TransactionStatusIndicator.tsx`) that calls the shared `getSemanticTonePresentation` — Completed → success, Pending → warning, Failed → error — so the badge now reads consistently with the rest of the app and there's one place (`status-semantics.ts`) that owns the actual color values.

Closes #1532

## Test plan
- New `tests/unit/dashboard/transaction-history-item-status.test.tsx` (3 tests): Completed renders the shared success tone, Pending renders the shared warning tone, Failed renders the shared error tone with a single consistent color (no more gray/red mismatch) — all passing
- `npx eslint components/Dashboard/TransactionHistoryItem.tsx tests/unit/dashboard/transaction-history-item-status.test.tsx` — clean
- `npx tsc --noEmit` — no errors in the changed files
- Note: `tests/unit/ui/external-links.test.tsx` fails both before and after this change (pre-existing, unrelated — it imports a different, unused duplicate component at `components/TransactionHistoryItem.tsx` that has no matching named export)