### PR TITLE
feat: capture unhandled promise rejections

### DIFF
--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -15,6 +15,7 @@ import ToastRegion from "@/components/ToastRegion";
 import SessionExpiryProvider from "@/components/SessionExpiryProvider";
 import CommandPalette from "@/components/CommandPalette";
 import ShortcutHelpModal from "@/components/ShortcutHelpModal";
+import UnhandledRejectionListener from "@/components/UnhandledRejectionListener";
 import { apiClient } from "@/lib/client/apiClient";
 
 /** Keeps the API client's authorization header aligned with wallet state. */
@@ -41,6 +42,7 @@ export default function Providers({ children }: { children: ReactNode }) {
   return (
     <WalletProvider>
       <ApiClientAuthBridge />
+      <UnhandledRejectionListener />
       <ToastProvider>
         <DensityProvider>
           <TelemetryProvider>

--- a/components/UnhandledRejectionListener.tsx
+++ b/components/UnhandledRejectionListener.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useEffect } from "react";
+import { registerUnhandledRejectionHandler } from "@/lib/client/unhandledRejection";
+
+/** Reports unhandled promise rejections through the shared error reporter. Renders nothing. */
+export default function UnhandledRejectionListener() {
+  useEffect(() => {
+    return registerUnhandledRejectionHandler();
+  }, []);
+
+  return null;
+}

--- a/lib/client/unhandledRejection.test.ts
+++ b/lib/client/unhandledRejection.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { errorReporter } from "./errorReporter";
+import {
+  handleUnhandledRejection,
+  registerUnhandledRejectionHandler,
+} from "./unhandledRejection";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("handleUnhandledRejection", () => {
+  it("reports an Error reason as-is", () => {
+    const spy = vi.spyOn(errorReporter, "captureException").mockImplementation(() => {});
+    const error = new Error("boom");
+
+    handleUnhandledRejection({ reason: error });
+
+    expect(spy).toHaveBeenCalledWith(error, { source: "unhandledrejection" });
+  });
+
+  it("wraps a string reason in an Error with that message", () => {
+    const spy = vi.spyOn(errorReporter, "captureException").mockImplementation(() => {});
+
+    handleUnhandledRejection({ reason: "rejected with a string" });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [reportedError] = spy.mock.calls[0];
+    expect(reportedError).toBeInstanceOf(Error);
+    expect((reportedError as Error).message).toBe("rejected with a string");
+  });
+
+  it("wraps a non-Error, non-string reason (e.g. a plain object) in an Error", () => {
+    const spy = vi.spyOn(errorReporter, "captureException").mockImplementation(() => {});
+
+    handleUnhandledRejection({ reason: { code: "TIMEOUT" } });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [reportedError] = spy.mock.calls[0];
+    expect(reportedError).toBeInstanceOf(Error);
+    expect((reportedError as Error).message).toBe('{"code":"TIMEOUT"}');
+  });
+
+  it("never throws for an unserializable reason", () => {
+    const spy = vi.spyOn(errorReporter, "captureException").mockImplementation(() => {});
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(() => handleUnhandledRejection({ reason: circular })).not.toThrow();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("registerUnhandledRejectionHandler", () => {
+  it("reports through the shared error reporter when the window fires unhandledrejection", () => {
+    const spy = vi.spyOn(errorReporter, "captureException").mockImplementation(() => {});
+    const unregister = registerUnhandledRejectionHandler();
+
+    const error = new Error("from a real event");
+    window.dispatchEvent(
+      Object.assign(new Event("unhandledrejection"), { reason: error }) as PromiseRejectionEvent,
+    );
+
+    expect(spy).toHaveBeenCalledWith(error, { source: "unhandledrejection" });
+    unregister();
+  });
+
+  it("stops reporting after the returned cleanup function is called", () => {
+    const spy = vi.spyOn(errorReporter, "captureException").mockImplementation(() => {});
+    const unregister = registerUnhandledRejectionHandler();
+    unregister();
+
+    window.dispatchEvent(
+      Object.assign(new Event("unhandledrejection"), { reason: new Error("late") }) as PromiseRejectionEvent,
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/lib/client/unhandledRejection.ts
+++ b/lib/client/unhandledRejection.ts
@@ -1,0 +1,43 @@
+import { errorReporter } from "./errorReporter";
+
+export interface UnhandledRejectionLike {
+  reason: unknown;
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Normalizes a rejection's `reason` (which can be anything — an `Error`, a
+ * string, a plain object, `undefined`) into an `Error` and reports it through
+ * the shared error reporter, so a promise rejected with no `.catch()` is
+ * never silently swallowed.
+ */
+export function handleUnhandledRejection(event: UnhandledRejectionLike): void {
+  const { reason } = event;
+  const error =
+    reason instanceof Error
+      ? reason
+      : new Error(typeof reason === "string" ? reason : safeStringify(reason));
+
+  errorReporter.captureException(error, { source: "unhandledrejection" });
+}
+
+/**
+ * Registers a window-level `unhandledrejection` listener.
+ *
+ * @returns A cleanup function that removes the listener — call it from a
+ *   `useEffect` return so the listener doesn't leak across remounts.
+ */
+export function registerUnhandledRejectionHandler(): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  const listener = (event: PromiseRejectionEvent) => handleUnhandledRejection(event);
+  window.addEventListener("unhandledrejection", listener);
+  return () => window.removeEventListener("unhandledrejection", listener);
+}


### PR DESCRIPTION
## Summary
Nothing in the app listened for `window`'s `unhandledrejection` event, so a promise that rejects without a `.catch()` anywhere in the call chain (a stray `fetch`, an unawaited async call in an event handler, etc.) went completely unreported — not even a console log, let alone to Sentry.

Adds:
- `lib/client/unhandledRejection.ts` — `handleUnhandledRejection(event)` normalizes the rejection's `reason` (which can be an `Error`, a string, a plain object, or anything else) into an `Error` and reports it through the existing shared `errorReporter` (`lib/client/errorReporter.ts`), tagged with `{ source: 'unhandledrejection' }`. `registerUnhandledRejectionHandler()` wires that up to `window`'s `unhandledrejection` event and returns a cleanup function.
- `components/UnhandledRejectionListener.tsx` — a thin client component (same shape as the existing `ApiClientAuthBridge` in `Providers.tsx`) that registers the handler in a `useEffect` and cleans it up on unmount.
- Mounted once in `components/Providers.tsx`, alongside the other app-wide client-side setup.

Closes #1535

## Test plan
- New `lib/client/unhandledRejection.test.ts` (6 tests): reports an `Error` reason as-is, wraps a string reason in an `Error`, wraps a plain-object reason (JSON-stringified) in an `Error`, never throws for an unserializable (circular) reason, reports through the reporter when a real `unhandledrejection` event fires on `window`, and stops reporting after the returned cleanup function runs — all passing
- `npx eslint lib/client/unhandledRejection.ts lib/client/unhandledRejection.test.ts components/UnhandledRejectionListener.tsx components/Providers.tsx` — clean
- `npx tsc --noEmit` — no errors in the changed files
- Ran the existing test suites that render `Providers`/dashboard widgets (`tests/react/dashboard-widgets-smoke.test.tsx`, `tests/unit/metadata.test.ts`) to confirm mounting the new listener doesn't affect anything else — still passing