### PR TITLE
perf(providers): lazy-load CommandPalette and its icon set

### DIFF
--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useEffect, lazy, Suspense } from "react";
 import { WalletProvider, useWallet } from "stellar-wallet-kit";
 import { DensityProvider } from "@/lib/context/DensityContext";
 import { TelemetryProvider } from "@/lib/context/TelemetryContext";
@@ -13,10 +13,18 @@ import { ShortcutHelpProvider } from "@/lib/context/ShortcutHelpContext";
 import LayoutWrapper from "@/components/LayoutWrapper";
 import ToastRegion from "@/components/ToastRegion";
 import SessionExpiryProvider from "@/components/SessionExpiryProvider";
-import CommandPalette from "@/components/CommandPalette";
 import ShortcutHelpModal from "@/components/ShortcutHelpModal";
 import UnhandledRejectionListener from "@/components/UnhandledRejectionListener";
 import { apiClient } from "@/lib/client/apiClient";
+
+/**
+ * Lazy-loaded: CommandPalette pulls in its own icon set (13 lucide-react
+ * icons) and renders `null` until the user opens it (Cmd/Ctrl+K), but was
+ * previously a static import here -- mounted on every route via `Providers`,
+ * its icons shipped in the initial bundle on every page load regardless of
+ * whether the palette was ever opened.
+ */
+const CommandPalette = lazy(() => import("@/components/CommandPalette"));
 
 /** Keeps the API client's authorization header aligned with wallet state. */
 function ApiClientAuthBridge() {
@@ -51,7 +59,9 @@ export default function Providers({ children }: { children: ReactNode }) {
                 <ShortcutHelpProvider>
                   <LayoutWrapper>{children}</LayoutWrapper>
                   <ToastRegion />
-                  <CommandPalette />
+                  <Suspense fallback={null}>
+                    <CommandPalette />
+                  </Suspense>
                   <ShortcutHelpModal />
                 </ShortcutHelpProvider>
               </SessionExpiryProvider>


### PR DESCRIPTION
## Summary

\`CommandPalette\` imports 13 \`lucide-react\` icons and renders \`null\` until the user opens it (Cmd/Ctrl+K), but was a static import in \`components/Providers.tsx\` -- mounted on every route regardless of whether the palette is ever opened, so its icons shipped in the main bundle on every page load.

Converts the import to \`React.lazy\` + \`Suspense\` (\`fallback={null}\`, since the component itself renders nothing until opened -- there's no visible loading state to show). This moves \`CommandPalette\` and its icon imports into their own async chunk instead of the shared bundle.

## Testing / verification notes

- \`npm run typecheck\` — 94 pre-existing errors, unchanged by this PR
- \`npx eslint components/Providers.tsx\` — clean
- \`npm test\` (curated suite) — 85 vitest + 28 node tests, all pass, unaffected

**Could not verify with a real build:** \`npm run build\` currently fails on \`main\` regardless of this change -- \`next.config.js\` unconditionally \`require\`s \`@next/bundle-analyzer\`, which isn't listed in \`package.json\` and isn't installed. Pre-existing and unrelated to this PR; flagging rather than fixing since it's outside this issue's scope.

**Did not add a new automated test:** \`components/CommandPalette.test.tsx\` and \`tests/unit/ui/commandPalette.test.tsx\` already fail on \`main\` (confirmed identically with and without this change) due to an unrelated pre-existing bug inside \`CommandPalette.tsx\` itself (\`ReferenceError: recentList is not defined\` when the palette is opened) -- also out of scope here. A behavioral test of the lazy-loading wiring would require rendering the full \`Providers\` tree, which pulls in ~10 unrelated context providers (wallet, session, shortcuts, layout, etc.) not currently exercised together in any existing test; that felt disproportionate to a one-line code-splitting change, so I'm flagging both pre-existing issues transparently instead.

Closes #1513