### PR TITLE
ci: matrix Node 20 and 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,12 @@ env:
 
 jobs:
   lint-and-test:
-    name: Lint and test
+    name: Lint and test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20", "22"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ${{ matrix.node-version }}
           cache: "npm"
 
       - name: Install dependencies
@@ -39,7 +43,7 @@ jobs:
               echo "${name}=${value}" >> "$GITHUB_ENV"
             done < .env.test
           fi
-        shell: bash || true
+        shell: bash
         continue-on-error: true
 
       - name: Run lint


### PR DESCRIPTION
## Summary

Runs the \`lint-and-test\` job across both Node 20 and Node 22 (\`strategy.matrix\`) instead of just 20. \`package.json\`'s \`engines\` field doesn't pin a specific Node version, so both are equally "supported" today, and a Node-version-specific regression currently would only surface in whichever version a contributor happens to run locally.

Also fixed \`shell: bash || true\` → \`shell: bash\` on the \`.env.test\` step -- \`actionlint\` flags \`bash || true\` as an invalid shell name (pre-existing, unrelated to the matrix change, but a one-line fix in the same step I was already touching, and it's why the workflow wasn't previously \`actionlint\`-clean).

## Testing

- \`actionlint .github/workflows/ci.yml\` — clean (was failing on the shell-name issue before)

Closes #1515