### PR TITLE
chore(dx): add a Playwright smoke test to the pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run test:smoke

--- a/README.md
+++ b/README.md
@@ -242,6 +242,15 @@ To run the Playwright end-to-end tests for authentication and protected routes:
 npm run test:e2e
 ```
 
+A lightweight smoke test (`npm run test:smoke`) runs automatically in a
+`pre-push` git hook (via husky — installed as part of `npm install`'s
+`prepare` script). It starts the dev server and checks that `/api/health`
+responds at all (200 healthy or 503 degraded both count — this isn't a
+dependency health check, just confirmation the app itself booted), using
+its own `playwright.smoke.config.ts` so it never depends on the root page
+rendering successfully. It's meant to be fast: no browser is launched, since
+the test only uses Playwright's `request` fixture.
+
 For validating responsive breakpoints and layouts across different viewports, see the [Responsive Testing Guide](docs/RESPONSIVE_TESTING.md).
 
 For verifying components in a right-to-left (RTL) locale (Arabic, Hebrew), see the [RTL Testing Guide](docs/RTL_TESTING.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@next/bundle-analyzer": "^16.2.12",
         "@playwright/test": "^1.58.2",
         "@storybook/addon-essentials": "^8.6.18",
         "@storybook/react": "^8.6.18",
@@ -53,6 +54,7 @@
         "eslint": "^8.57.1",
         "eslint-config-next": "^14.2.35",
         "http-server": "^14.1.1",
+        "husky": "^9.1.7",
         "jest": "^30.2.0",
         "jest-axe": "^10.0.0",
         "jsdom": "^29.1.1",
@@ -1037,6 +1039,16 @@
       "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3121,6 +3133,16 @@
       "peerDependencies": {
         "@emnapi/core": "^2.0.0-alpha.3",
         "@emnapi/runtime": "^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.2.12.tgz",
+      "integrity": "sha512-0dYhmCYsTMFYUFaoEUx+VKw/oYP6b3XiGgq47EujXTE2UGgwVWAaur2tbko2pxfUka3WRZ9YWxa3PlSv3luWNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
       }
     },
     "node_modules/@next/env": {
@@ -10986,6 +11008,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/aes-js": {
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
@@ -13069,6 +13104,13 @@
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -13480,6 +13522,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -15444,6 +15493,22 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/h3": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
@@ -15836,6 +15901,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/i18next": {
@@ -16558,6 +16639,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -19406,7 +19497,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -26340,6 +26430,59 @@
         "webpack-cli": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/webpack-dev-middleware": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "prepare": "husky",
     "postinstall": "node scripts/patch-next-config.js",
     "generate:types": "openapi-typescript ./openapi.yaml --output ./src/api/types.ts",
     "prebuild": "npm run generate:types",
@@ -23,6 +24,7 @@
     "test:property": "node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/property",
     "test:integration": "node --test tests/integration/auth.test.cjs tests/integration/health.test.cjs tests/integration/validation.test.cjs && node node_modules/vitest/vitest.mjs run --config vitest.config.mjs --configLoader runner tests/integration/api",
     "test:e2e": "playwright test",
+    "test:smoke": "playwright test --config playwright.smoke.config.ts",
     "test:perf": "npx playwright test tests/e2e/dashboard-performance.spec.ts",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build --quiet"
@@ -55,6 +57,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^16.2.12",
     "@playwright/test": "^1.58.2",
     "@storybook/addon-essentials": "^8.6.18",
     "@storybook/react": "^8.6.18",
@@ -72,6 +75,7 @@
     "eslint": "^8.57.1",
     "eslint-config-next": "^14.2.35",
     "http-server": "^14.1.1",
+    "husky": "^9.1.7",
     "jest": "^30.2.0",
     "jest-axe": "^10.0.0",
     "jsdom": "^29.1.1",

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig } from '@playwright/test';
+import path from 'path';
+
+/**
+ * Dedicated config for the pre-push smoke test (see .husky/pre-push).
+ *
+ * Deliberately separate from playwright.config.ts: that config's webServer
+ * readiness check polls `/` (the root page), which is unrelated to what the
+ * smoke test needs to verify and can fail for reasons that have nothing to
+ * do with whether the server itself booted. This config points readiness at
+ * /api/health instead, so the smoke test only depends on the one thing it's
+ * actually checking.
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: '**/smoke.spec.ts',
+
+  retries: 0,
+  reporter: [['dot']],
+
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000/api/health',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60 * 1000,
+    cwd: path.resolve(__dirname),
+    env: {
+      DATABASE_URL: `file:${path.resolve(__dirname, 'prisma/ci.db')}`,
+      SESSION_PASSWORD: 'supersecurelongsessionpasswordatleast32characters!!',
+      AUTH_SECRET: 'ci-test-secret',
+      NEXT_PUBLIC_APP_URL: 'http://localhost:3000',
+      STELLAR_NETWORK: 'testnet',
+      SOROBAN_RPC_URL: 'https://soroban-testnet.stellar.org',
+    },
+  },
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,24 @@
+/**
+ * Pre-push smoke test — see .husky/pre-push.
+ *
+ * Uses Playwright's `request` fixture only (no `page`), so it never launches
+ * a browser: just confirms the dev server the webServer config starts is
+ * actually up and /api/health returns valid JSON. This is deliberately not a
+ * health assertion (`status: "degraded"` is a legitimate response when a
+ * dependency like the RPC node is unreachable locally) -- it's a "did the
+ * server boot and respond at all" check, fast enough to run on every push.
+ */
+import { test, expect } from '@playwright/test';
+
+test('dev server responds to /api/health', async ({ request }) => {
+  const response = await request.get('/api/health');
+
+  // Any response at all (200 healthy, 503 degraded) proves the server booted
+  // and this route executed without throwing -- a connection failure or an
+  // unhandled exception is what this test exists to catch.
+  expect([200, 503]).toContain(response.status());
+
+  const body = await response.json();
+  expect(body).toHaveProperty('status');
+  expect(body).toHaveProperty('timestamp');
+});


### PR DESCRIPTION
## Summary

Adds \`npm run test:smoke\` (\`tests/e2e/smoke.spec.ts\`) and wires it into a new husky \`pre-push\` hook, so a contributor finds out the app doesn't even boot before pushing, not several minutes later in CI.

- The smoke test hits \`/api/health\` and accepts either \`200\` (healthy) or \`503\` (degraded) -- deliberately not a dependency health check, just confirmation the server booted and this route executed without throwing.
- Uses Playwright's \`request\` fixture only (no \`page\`), so no browser launch is needed -- fast enough for a pre-push hook.
- Uses its own \`playwright.smoke.config.ts\` rather than the shared \`playwright.config.ts\`: that config's \`webServer\` readiness check polls \`/\` (the root page), which currently throws (\"No QueryClient set\", a separate pre-existing bug, out of scope here) and would make the smoke test's own server never report ready. Pointing readiness at \`/api/health\` instead means this hook only depends on the one thing it's actually checking.

**Also adds the missing \`@next/bundle-analyzer\` devDependency** -- \`next.config.js\` unconditionally \`require\`s it, and without it \`npm run dev\` can't even load the Next config. I found this out because my own pre-push hook caught it on the first push attempt from this branch (which didn't have the fix yet) -- a nice confirmation the hook actually works. The same one-line dependency is added independently in #1514; whichever merges first makes the other a no-op on that line.

## Testing

- \`npm run test:smoke\` — passes locally
- Confirmed the hook fires for real: pushing this branch before the bundle-analyzer fix was included made \`git push\` fail with the pre-push script's error output; after adding the fix, the push succeeded with the smoke test passing inline.
- \`npm test\` — 85 vitest + 28 node tests, unaffected
- \`npm run typecheck\` — 94 pre-existing errors, unchanged by this PR
- \`npx eslint\` on the changed files — clean

Closes #1517