### PR TITLE
chore: add just typecheck alias

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,5 +2,6 @@ check:
     npm run check
 
 # Run TypeScript type-checking without emitting output
+alias tc := typecheck
 typecheck:
     npm run typecheck


### PR DESCRIPTION
Title: chore: add just typecheck alias

Description:

Summary
Added a tc alias for the typecheck command in the justfile to make it quicker and easier to run TypeScript type-checks locally.

Background
We want to keep the cross-border remittance UI auditable and safe to change. Landing this issue tightens one specific corner and gives reviewers a clear diff to reason about rather than a general "cleanup" commit. It is scoped small enough to close in a single PR.

Acceptance criteria
 The change matches the summary above.
 Tests cover the new behavior (happy path + one explicit failure mode) — N/A for an alias change.
 Lint, type-check, and tests all pass locally.
 
Closes #1374