### PR TITLE
Fix: repair two JSX syntax errors blocking typecheck on main

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -72,7 +72,11 @@ export default function SettingsPage() {
       {/* ── Sticky top bar (mobile breadcrumb / desktop title) ── */}
       <header className="sticky top-0 z-30 bg-white/80 dark:bg-gray-900/80 backdrop-blur border-b border-gray-100 dark:border-gray-800">
         <div className="mx-auto flex h-14 max-w-5xl items-center gap-3 overflow-hidden px-4 sm:px-6">
-          <h1 className="shrink-0 text-base font-semibold text-gray-900 dark:text-white">
+          <PageHeadingLink
+            headingId="settings-page-heading"
+            label={t("settings.page_title")}
+            headingClassName="shrink-0 text-base font-semibold text-gray-900 dark:text-white"
+          >
             {t("settings.page_title")}
           </PageHeadingLink>
           {/* Mobile: horizontal scrollable nav pills */}

--- a/components/Nav/PrimaryNav.tsx
+++ b/components/Nav/PrimaryNav.tsx
@@ -29,6 +29,7 @@ const PrimaryNav = () => {
     };
 
     return (
+        <>
         <header className="fixed top-0 left-0 right-0 z-[60] overflow-x-hidden border-b border-white/5 bg-brand-dark/50 backdrop-blur-xl">
             <div className="mx-auto max-w-7xl overflow-x-hidden px-4 sm:px-6 lg:px-8">
                 <div className="flex h-16 min-w-0 items-center justify-between gap-2 375:h-20">


### PR DESCRIPTION
## Summary
`main` currently fails `tsc --noEmit` with real parse errors (not just type errors) in two files, unrelated to any specific issue but blocking every PR's typecheck:

- `app/settings/page.tsx`: opened with `<h1 ...>` but closed with `</PageHeadingLink>` (every other page uses `<PageHeadingLink>` consistently -- this one just had the opening tag swapped). Fixed to match the pattern used everywhere else in the app.
- `components/Nav/PrimaryNav.tsx`: the component returns `<header>...</header>` followed by a sibling `<WrongNetworkBanner />` with a closing `</>` at the end, but no opening `<>` -- added the missing Fragment opener.

Note: the rest of the repo has substantial pre-existing, unrelated type errors (duplicate declarations in `lib/contracts/savings-goal.ts`, missing `@/lib/utils`, Storybook types, etc.) and CI's lint/test steps all currently run with `continue-on-error: true`, so none of this is actually gating merges today. I'm not attempting to fix all of that here -- out of scope for a small PR -- just these two files, which were outright parse failures.

## Testing
- `npx tsc --noEmit` -- both files no longer appear in the error output (the rest of the pre-existing errors are unrelated and untouched)
- `npx eslint app/settings/page.tsx components/Nav/PrimaryNav.tsx` -- clean
- `npm run test:unit:vitest` -- improves from 9 failed test files/297 passing tests to 8 failed/303 passing (the `PrimaryNav` fix un-breaks `tests/unit/ui/navigation.test.tsx`, previously failing to even load); no regressions

Closes #1610