### PR TITLE
API: expose `useCorridorList()`

### DIFF
--- a/lib/hooks/useCorridorList.ts
+++ b/lib/hooks/useCorridorList.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { apiClient } from "@/lib/client/apiClient";
+import type { ExchangeRate } from "@/lib/anchor/client";
+
+export interface Corridor {
+  /** Source asset/currency, e.g. "USDC". */
+  from: string;
+  /** Destination asset/currency, e.g. "PHP". */
+  to: string;
+  /** Units of `to` received per one unit of `from`. */
+  rate: number;
+}
+
+export interface UseCorridorListResult {
+  corridors: Corridor[];
+  loading: boolean;
+  error: string | null;
+  /** True when `/api/anchor/rates` served a cached fallback because the
+   * upstream Anchor call failed -- corridors are still shown, just possibly
+   * outdated. */
+  stale: boolean;
+}
+
+function toCorridors(rates: ExchangeRate[]): Corridor[] {
+  return rates.map((rate) => ({
+    from: rate.sell_asset,
+    to: rate.buy_asset,
+    rate: parseFloat(rate.price),
+  }));
+}
+
+const IDLE: UseCorridorListResult = { corridors: [], loading: true, error: null, stale: false };
+
+/** Fetches the list of supported send corridors (currency pairs + rate)
+ * from `/api/anchor/rates`, reshaped from the raw `ExchangeRate[]` the
+ * Anchor client returns. Centralizes that reshaping so callers (e.g. the
+ * send flow's currency picker) don't each re-derive it from scratch. */
+export function useCorridorList(): UseCorridorListResult {
+  const [result, setResult] = useState<UseCorridorListResult>(IDLE);
+
+  const load = useCallback(async () => {
+    setResult((current) => ({ ...current, loading: true, error: null }));
+
+    const res = await apiClient.get("/api/anchor/rates");
+    if (res === null) return; // session-expiry flow already handled this
+
+    if (!res.ok) {
+      setResult({ corridors: [], loading: false, error: `Request failed with status ${res.status}`, stale: false });
+      return;
+    }
+
+    const body = (await res.json()) as { rates: ExchangeRate[]; stale: boolean };
+    setResult({ corridors: toCorridors(body.rates ?? []), loading: false, error: null, stale: Boolean(body.stale) });
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return result;
+}

--- a/tests/unit/hooks/useCorridorList.test.ts
+++ b/tests/unit/hooks/useCorridorList.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { apiClient } from "@/lib/client/apiClient";
+import { useCorridorList } from "@/lib/hooks/useCorridorList";
+
+vi.mock("@/lib/client/apiClient", () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => body } as Response;
+}
+
+describe("useCorridorList", () => {
+  beforeEach(() => {
+    vi.mocked(apiClient.get).mockReset();
+  });
+
+  it("reshapes exchange rates into corridors", async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(
+      jsonResponse({
+        rates: [{ sell_asset: "USDC", buy_asset: "PHP", price: "56.2" }],
+        stale: false,
+      })
+    );
+
+    const { result } = renderHook(() => useCorridorList());
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.corridors).toEqual([{ from: "USDC", to: "PHP", rate: 56.2 }]);
+    expect(result.current.error).toBeNull();
+    expect(result.current.stale).toBe(false);
+  });
+
+  it("surfaces staleness from the response", async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(
+      jsonResponse({ rates: [], stale: true })
+    );
+
+    const { result } = renderHook(() => useCorridorList());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.stale).toBe(true);
+  });
+
+  it("surfaces a non-OK response as an error with an empty corridor list", async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(jsonResponse(null, false, 503));
+
+    const { result } = renderHook(() => useCorridorList());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.corridors).toEqual([]);
+    expect(result.current.error).toBe("Request failed with status 503");
+  });
+
+  it("does nothing further when apiClient.get returns null (session-expiry flow)", async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(null as unknown as Response);
+
+    const { result } = renderHook(() => useCorridorList());
+    await waitFor(() => expect(apiClient.get).toHaveBeenCalled());
+
+    expect(result.current.loading).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Adds `useCorridorList()` (`lib/hooks/useCorridorList.ts`), fetching `/api/anchor/rates` and reshaping the raw `ExchangeRate[]` into typed `Corridor { from, to, rate }` objects, plus `loading`/`error`/`stale` state (the route's own stale-cache-fallback flag is passed through). `app/send/components/AmountCurrencySection.tsx` currently re-derives an equivalent `conversionRates` map inline from the same raw rates -- this centralizes that shape so future consumers don't each redo it. Not wired into that component in this PR to keep the diff additive and reviewable.

## Testing
- `node node_modules/vitest/vitest.mjs run ... tests/unit/hooks/useCorridorList.test.ts` -- 4/4 pass (happy path reshaping, stale flag, non-OK response, session-expiry null-response handling)
- `npm run test:unit:vitest` -- 301 passing (was 297 on `main`), zero regressions
- `npx eslint lib/hooks/useCorridorList.ts tests/unit/hooks/useCorridorList.test.ts` -- clean
- `npx tsc --noEmit` -- no new errors in either touched file

Closes #1499