### PR TITLE
Validate: reject empty submit on the search box

### DIFF
--- a/app/dashboard/transaction-history/components/transaction-history-search-input.tsx
+++ b/app/dashboard/transaction-history/components/transaction-history-search-input.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState, type FormEvent } from "react";
 import { Search } from "lucide-react";
 
 interface TransactionHistorySearchInputProps {
@@ -10,13 +10,15 @@ interface TransactionHistorySearchInputProps {
   mobilePlaceholder?: string;
 }
 
-const TransactionHistorySearchInput = ({ 
-  value = '', 
+const TransactionHistorySearchInput = ({
+  value = '',
   onChange,
   placeholder = "Search by ID, recipient, or transaction hash...",
   mobilePlaceholder,
 }: TransactionHistorySearchInputProps) => {
   const [isMobile, setIsMobile] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const errorId = useId();
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -30,19 +32,41 @@ const TransactionHistorySearchInput = ({
     return () => mediaQuery.removeEventListener("change", updateMatch);
   }, []);
 
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // Results already update live via onChange as the user types -- submit
+    // (pressing Enter) exists to reject a blank query, not to trigger the
+    // search itself.
+    setError(value.trim().length === 0 ? "Enter a search term before submitting." : null);
+  };
+
+  const handleChange = (nextValue: string) => {
+    if (error) setError(null);
+    onChange?.(nextValue);
+  };
+
   return (
-    <div className="relative w-full max-w-4xl xl:min-w-[680px]">
-      <div className="absolute inset-y-0 left-0 flex items-center pl-3.5 pointer-events-none">
-        <Search size={17} className="text-[#FFFFFF80]" />
+    <form role="search" onSubmit={handleSubmit} className="w-full max-w-4xl xl:min-w-[680px]" noValidate>
+      <div className="relative">
+        <div className="absolute inset-y-0 left-0 flex items-center pl-3.5 pointer-events-none">
+          <Search size={17} className="text-[#FFFFFF80]" />
+        </div>
+        <input
+          type="search"
+          value={value}
+          onChange={(e) => handleChange(e.target.value)}
+          placeholder={isMobile && mobilePlaceholder ? mobilePlaceholder : placeholder}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? errorId : undefined}
+          className="w-full rounded-[14px] border border-[#FFFFFF14] bg-white/5 py-3 pl-10 pr-4 text-sm tracking-[-0.2px] text-white placeholder:text-sm placeholder:font-normal placeholder:leading-5 placeholder:text-[#FFFFFF80] focus:border-[#FFFFFF30] focus:outline-none focus:ring-2 focus:ring-red-400/60 transition-all sm:text-base sm:tracking-[-0.31px] sm:placeholder:text-base"
+        />
       </div>
-      <input
-        type="text"
-        value={value}
-        onChange={(e) => onChange?.(e.target.value)}
-        placeholder={isMobile && mobilePlaceholder ? mobilePlaceholder : placeholder}
-        className="w-full rounded-[14px] border border-[#FFFFFF14] bg-white/5 py-3 pl-10 pr-4 text-sm tracking-[-0.2px] text-white placeholder:text-sm placeholder:font-normal placeholder:leading-5 placeholder:text-[#FFFFFF80] focus:border-[#FFFFFF30] focus:outline-none focus:ring-2 focus:ring-red-400/60 transition-all sm:text-base sm:tracking-[-0.31px] sm:placeholder:text-base"
-      />
-    </div>
+      {error && (
+        <p id={errorId} role="alert" className="mt-1.5 text-xs text-red-400">
+          {error}
+        </p>
+      )}
+    </form>
   );
 };
 

--- a/tests/unit/dashboard/transaction-history-search-input.test.tsx
+++ b/tests/unit/dashboard/transaction-history-search-input.test.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TransactionHistorySearchInput from "@/app/dashboard/transaction-history/components/transaction-history-search-input";
+
+describe("TransactionHistorySearchInput", () => {
+  it("shows a validation error when submitted empty, without calling onChange", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TransactionHistorySearchInput value="" onChange={onChange} />);
+
+    await user.click(screen.getByRole("searchbox"));
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Enter a search term");
+    expect(screen.getByRole("searchbox")).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("does not show an error when submitted with a non-empty value", async () => {
+    const user = userEvent.setup();
+    render(<TransactionHistorySearchInput value="acme" onChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("searchbox"));
+    await user.keyboard("{Enter}");
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("does not show an error when submitted with whitespace-only value", async () => {
+    const user = userEvent.setup();
+    render(<TransactionHistorySearchInput value="   " onChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("searchbox"));
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Enter a search term");
+  });
+
+  it("clears a previous error as soon as the user types", async () => {
+    const user = userEvent.setup();
+    function Wrapper() {
+      const [value, setValue] = useState("");
+      return <TransactionHistorySearchInput value={value} onChange={setValue} />;
+    }
+    render(<Wrapper />);
+
+    await user.click(screen.getByRole("searchbox"));
+    await user.keyboard("{Enter}");
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    await user.type(screen.getByRole("searchbox"), "a");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("still calls onChange for every keystroke (live filtering is unaffected)", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TransactionHistorySearchInput value="" onChange={onChange} />);
+
+    await user.type(screen.getByRole("searchbox"), "abc");
+
+    expect(onChange).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary
`TransactionHistorySearchInput` had no submit concept at all -- just a bare `<input>` with live `onChange` filtering. Wraps it in a proper `<form role="search">`: pressing Enter (or otherwise submitting) with a blank or whitespace-only value shows an inline, `role="alert"` validation message instead of silently no-oping, and clears as soon as the user types again. Live filtering via `onChange` on every keystroke is unchanged -- submit only adds the blank-query guard on top. Also switched the input to `type="search"` to match the form's `role="search"` semantics.

## Testing
- `node node_modules/vitest/vitest.mjs run ... tests/unit/dashboard/transaction-history-search-input.test.tsx` -- 5/5 pass (empty submit shows the error, non-empty submit doesn't, whitespace-only counts as empty, typing clears a previous error, every keystroke still calls `onChange`)
- `npm run test:unit:vitest` -- 302 passing (was 297 on `main`), zero regressions
- `npx eslint` on both touched files -- clean
- `npx tsc --noEmit` -- no new errors in either touched file

Closes #1494