### PR TITLE
Harden: reject clipboard-paste HTML on the message field

### DIFF
--- a/app/dashboard/goals/components/SavingsGoalModal.tsx
+++ b/app/dashboard/goals/components/SavingsGoalModal.tsx
@@ -10,12 +10,13 @@ import {
   AlertCircle
 } from 'lucide-react'
 import { SavingsGoal, SavingsGoalFormData } from '../types'
-import { 
-  validateGoalName, 
+import {
+  validateGoalName,
   validateGoalDescription,
-  validateAmount, 
-  validateFutureDate 
+  validateAmount,
+  validateFutureDate
 } from '@/lib/validation/savings-goals'
+import { sanitizePastedValue } from '@/lib/validation/sanitizePaste'
 import { useClientTranslator } from '@/lib/i18n/client'
 
 interface SavingsGoalModalProps {
@@ -112,6 +113,23 @@ export default function SavingsGoalModal({
 
   if (!isOpen) return null
 
+  const handleDescriptionPaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    // Only intervene when the clipboard actually carries an HTML payload
+    // (e.g. copied from a web page); a plain-text copy is left to the
+    // browser's normal paste behavior.
+    if (!e.clipboardData.types.includes('text/html')) return
+
+    e.preventDefault()
+    const target = e.currentTarget
+    const nextValue = sanitizePastedValue(
+      e.clipboardData,
+      target.value,
+      target.selectionStart,
+      target.selectionEnd
+    )
+    setFormData((prev) => ({ ...prev, description: nextValue }))
+  }
+
   const validate = (): boolean => {
     const newErrors: Record<string, string> = {}
     
@@ -206,6 +224,7 @@ export default function SavingsGoalModal({
               id="description"
               value={formData.description}
               onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+              onPaste={handleDescriptionPaste}
               className={`w-full rounded-xl bg-white/5 border ${errors.description ? 'border-red-500' : 'border-white/10'} px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-red-500/50 transition-all motion-reduce:transition-none resize-none h-20`}
               placeholder={t('savingsGoals.modal.descriptionPlaceholder')}
             />

--- a/lib/validation/sanitizePaste.ts
+++ b/lib/validation/sanitizePaste.ts
@@ -1,0 +1,31 @@
+/**
+ * Strips HTML tags from pasted text. `textarea`/`input` elements only ever
+ * store plain text -- pasting can't inject a rendered `<script>` into
+ * them -- but a clipboard payload that carries an HTML MIME type (e.g.
+ * copied from a web page or a rich editor) can still carry raw markup as
+ * its *plain-text* representation on some browsers/clipboard managers.
+ * This strips it so what lands in the field is always plain prose, not
+ * literal tag soup, regardless of what produced the clipboard content.
+ */
+export function stripHtml(value: string): string {
+  return value
+    .replace(/<[^>]*>/g, "")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/**
+ * Reads plain text out of a paste event, stripping any HTML tags, and
+ * splices it into `currentValue` at the given selection -- the same
+ * insert-at-cursor behavior the browser's default paste would have done.
+ */
+export function sanitizePastedValue(
+  clipboardData: DataTransfer,
+  currentValue: string,
+  selectionStart: number,
+  selectionEnd: number
+): string {
+  const pasted = stripHtml(clipboardData.getData("text/plain"));
+  return currentValue.slice(0, selectionStart) + pasted + currentValue.slice(selectionEnd);
+}

--- a/tests/unit/goals/SavingsGoalModal-paste.test.tsx
+++ b/tests/unit/goals/SavingsGoalModal-paste.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import SavingsGoalModal from "@/app/dashboard/goals/components/SavingsGoalModal";
+
+function pasteEvent(plainText: string, types: string[]) {
+  return {
+    clipboardData: {
+      types,
+      getData: (type: string) => (type === "text/plain" ? plainText : ""),
+    },
+  };
+}
+
+describe("SavingsGoalModal description paste handling", () => {
+  it("strips HTML tags when the clipboard carries an HTML payload", () => {
+    render(
+      <SavingsGoalModal isOpen onClose={vi.fn()} onSave={vi.fn()} editingGoal={null} />
+    );
+
+    const textarea = screen.getByLabelText(/description/i) as HTMLTextAreaElement;
+    fireEvent.paste(textarea, pasteEvent("<b>rich</b> text", ["text/html", "text/plain"]));
+
+    expect(textarea.value).toBe("rich text");
+  });
+
+  it("leaves a plain-text-only paste to the browser's default handling", () => {
+    render(
+      <SavingsGoalModal isOpen onClose={vi.fn()} onSave={vi.fn()} editingGoal={null} />
+    );
+
+    const textarea = screen.getByLabelText(/description/i) as HTMLTextAreaElement;
+    const event = pasteEvent("plain text only", ["text/plain"]);
+    const defaultPrevented = !fireEvent.paste(textarea, event);
+
+    // No text/html type present -- the handler should not have called
+    // preventDefault, leaving the paste to the browser (jsdom doesn't
+    // actually insert text on a synthetic paste, so we only assert the
+    // handler declined to intercept it).
+    expect(defaultPrevented).toBe(false);
+  });
+});

--- a/tests/unit/validation/sanitizePaste.test.ts
+++ b/tests/unit/validation/sanitizePaste.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { stripHtml, sanitizePastedValue } from "@/lib/validation/sanitizePaste";
+
+describe("stripHtml", () => {
+  it("removes HTML tags, keeping the text content", () => {
+    expect(stripHtml("<b>Hello</b> world")).toBe("Hello world");
+  });
+
+  it("strips a script tag down to its (inert, unexecuted) text content", () => {
+    // A stripped tag's text content becomes plain text in a textarea --
+    // "alert(1)" here can never execute, it's just visible characters.
+    expect(stripHtml("<script>alert(1)</script>")).toBe("alert(1)");
+  });
+
+  it("leaves plain text untouched", () => {
+    expect(stripHtml("Just a normal description.")).toBe("Just a normal description.");
+  });
+
+  it("collapses runs of horizontal whitespace left behind by stripped tags", () => {
+    expect(stripHtml("Hello<div>   </div>world")).toBe("Hello world");
+  });
+
+  it("collapses excessive blank lines to at most one", () => {
+    expect(stripHtml("Line one\n\n\n\nLine two")).toBe("Line one\n\nLine two");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(stripHtml("  <p>padded</p>  ")).toBe("padded");
+  });
+});
+
+describe("sanitizePastedValue", () => {
+  function clipboardWith(plainText: string): DataTransfer {
+    return {
+      getData: (type: string) => (type === "text/plain" ? plainText : ""),
+    } as unknown as DataTransfer;
+  }
+
+  it("splices sanitized pasted text in at the cursor position", () => {
+    const result = sanitizePastedValue(
+      clipboardWith("<b>pasted</b>"),
+      "before  after",
+      "before ".length,
+      "before ".length
+    );
+
+    expect(result).toBe("before pasted after");
+  });
+
+  it("replaces a selected range rather than just inserting", () => {
+    const result = sanitizePastedValue(clipboardWith("NEW"), "old text here", 0, 3);
+
+    expect(result).toBe("NEW text here");
+  });
+});


### PR DESCRIPTION
## Summary
The only free-text `<textarea>` in the app is the savings-goal "description" field (`SavingsGoalModal.tsx`). A `textarea` can only ever hold plain text -- pasting can't inject rendered markup -- but a clipboard payload carrying an HTML MIME type can still deliver raw tag soup as its plain-text representation on some browsers/clipboard managers. Adds `stripHtml`/`sanitizePastedValue` (`lib/validation/sanitizePaste.ts`) and an `onPaste` handler: when the clipboard carries a `text/html` type, it intercepts the paste, strips tags from the plain-text payload, and splices the result in at the cursor position (same insert-at-cursor behavior the browser's default paste would have). A plain-text-only copy (the common case) is left entirely to the browser's normal paste handling.

## Testing
- `node node_modules/vitest/vitest.mjs run ... tests/unit/validation/sanitizePaste.test.ts tests/unit/goals/SavingsGoalModal-paste.test.tsx` -- 10/10 pass (tag stripping, whitespace/blank-line collapsing, cursor-position splicing, and the component actually intercepting an HTML-flagged paste while leaving a plain-text paste alone)
- `npm run test:unit:vitest` -- 307 passing (was 297 on `main`), zero regressions
- `npx eslint` on all touched files -- clean
- `npx tsc --noEmit` -- no new errors in any touched file

Closes #1471