### PR TITLE
Refactor: collapse two identical Tailwind classnames helpers

### DIFF
--- a/components/Toggle.tsx
+++ b/components/Toggle.tsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import { cn } from "@/lib/utils/cn";
 
 interface ToggleProps {
   enabled: boolean;
@@ -37,14 +38,16 @@ export default function Toggle({
         disabled={disabled}
       >
         <div
-          className={`relative w-[44px] h-[24px] rounded-full transition-colors duration-200 ease-in-out ${
-            enabled ? "bg-[#DC2626]" : "bg-zinc-700"
-          }`}
+          className={cn(
+            "relative w-[44px] h-[24px] rounded-full transition-colors duration-200 ease-in-out",
+            enabled ? "bg-[#DC2626]" : "bg-zinc-700",
+          )}
         >
           <div
-            className={`absolute top-0.5 left-0.5 w-[20px] h-[20px] bg-[#FFFFFF] rounded-full shadow-md transition-transform duration-200 ease-in-out ${
-              enabled ? "translate-x-5" : "translate-x-0"
-            }`}
+            className={cn(
+              "absolute top-0.5 left-0.5 w-[20px] h-[20px] bg-[#FFFFFF] rounded-full shadow-md transition-transform duration-200 ease-in-out",
+              enabled ? "translate-x-5" : "translate-x-0",
+            )}
           />
         </div>
       </button>
@@ -56,9 +59,10 @@ export default function Toggle({
       id={id}
       type="button"
       onClick={() => onChange(!enabled)}
-      className={`${
-        enabled ? "bg-red-500" : "bg-gray-700"
-      } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:cursor-not-allowed disabled:opacity-60`}
+      className={cn(
+        enabled ? "bg-red-500" : "bg-gray-700",
+        "relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:cursor-not-allowed disabled:opacity-60",
+      )}
       role="switch"
       aria-checked={enabled}
       aria-label={ariaLabel}
@@ -66,9 +70,10 @@ export default function Toggle({
       disabled={disabled}
     >
       <span
-        className={`${
-          enabled ? "translate-x-6" : "translate-x-1"
-        } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
+        className={cn(
+          enabled ? "translate-x-6" : "translate-x-1",
+          "inline-block h-4 w-4 transform rounded-full bg-white transition-transform",
+        )}
       />
     </button>
   );

--- a/lib/utils/cn.test.ts
+++ b/lib/utils/cn.test.ts
@@ -1,0 +1,18 @@
+import { cn } from "./cn";
+
+describe("cn", () => {
+  it("joins truthy class values and drops falsy ones", () => {
+    expect(cn("a", false && "b", null, undefined, "c")).toBe("a c");
+  });
+
+  it("resolves conflicting Tailwind utilities in favor of the last one", () => {
+    expect(cn("bg-red-500", "bg-gray-700")).toBe("bg-gray-700");
+  });
+
+  it("supports the conditional-ternary usage pattern it replaces", () => {
+    const enabled = true;
+    expect(cn(enabled ? "bg-[#DC2626]" : "bg-zinc-700", "rounded-full")).toBe(
+      "bg-[#DC2626] rounded-full",
+    );
+  });
+});

--- a/lib/utils/cn.ts
+++ b/lib/utils/cn.ts
@@ -1,0 +1,12 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * Merges Tailwind class names, resolving conflicting utilities (e.g.
+ * `bg-red-500` vs `bg-zinc-700`) in favor of the last one applied, and
+ * dropping falsy values. Use this instead of hand-rolled
+ * `` `${base} ${cond ? "a" : "b"}` `` template-literal concatenation.
+ */
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Note on scope
I didn't find two literally-duplicated standalone classnames helper *functions* anywhere in the codebase (\`clsx\`/\`tailwind-merge\` are project dependencies but were unused everywhere). What I did find is \`components/Toggle.tsx\` reimplementing the same ad-hoc \`` `${cond ? \"a\" : \"b\"} rest-of-classes` ``-style conditional-classname construction by hand, twice, once per variant -- the same pattern duplicated with no shared helper and no conflict resolution between base and conditional utility classes.

## Change
- New \`lib/utils/cn.ts\`: a small shared \`cn()\` wrapping the already-installed \`clsx\` + \`tailwind-merge\`.
- \`Toggle.tsx\`'s two variants (\`notification\`, \`default\`) now both call \`cn(...)\` instead of hand-rolled template literals.

## Tests
Added \`lib/utils/cn.test.ts\`: drops falsy values, resolves conflicting Tailwind utilities (last wins), and pins the exact conditional-ternary usage pattern it replaces.

\`npx vitest run lib/utils/cn.test.ts\`: 3 passed. \`npx tsc --noEmit\`: no new errors (2 pre-existing unrelated errors in \`app/settings/page.tsx\` / \`components/Nav/PrimaryNav.tsx\` present on \`main\` before this change). \`npx eslint\` on changed files: clean.

Closes #1481