### PR TITLE
Harden: hide raw contract addresses from telemetry

### DIFF
--- a/lib/sanitize.ts
+++ b/lib/sanitize.ts
@@ -32,6 +32,10 @@ const PARTIAL_MASK_FIELDS = new Set([
   'public_key',
   'walletaddress',
   'wallet_address',
+  'contractaddress',
+  'contract_address',
+  'contractid',
+  'contract_id',
 ]);
 
 const MAX_DEPTH = 5;
@@ -64,6 +68,15 @@ function maskAddress(address: string): string {
  * Public wrapper around the internal {@link maskAddress} helper.
  */
 export function sanitizeWalletAddress(address: string): string {
+  return maskAddress(address);
+}
+
+/**
+ * Partially masks a Soroban contract address/ID for safe inclusion in
+ * logs/telemetry. Public wrapper around the internal {@link maskAddress}
+ * helper, mirroring {@link sanitizeWalletAddress}.
+ */
+export function sanitizeContractAddress(address: string): string {
   return maskAddress(address);
 }
 
@@ -129,7 +142,11 @@ export function sanitizeObject(
           lowerKey === 'publickey' ||
           lowerKey === 'public_key' ||
           lowerKey === 'walletaddress' ||
-          lowerKey === 'wallet_address'
+          lowerKey === 'wallet_address' ||
+          lowerKey === 'contractaddress' ||
+          lowerKey === 'contract_address' ||
+          lowerKey === 'contractid' ||
+          lowerKey === 'contract_id'
         ) {
           sanitized[key] = maskAddress(value);
         } else if (lowerKey === 'phone') {

--- a/tests/unit/sanitize.test.ts
+++ b/tests/unit/sanitize.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { sanitizeObject, sanitizeString } from '@/lib/sanitize';
+import { sanitizeObject, sanitizeString, sanitizeContractAddress } from '@/lib/sanitize';
 import { logResponse } from '@/lib/logger';
 
 describe('sanitizeObject', () => {
@@ -32,6 +32,22 @@ describe('sanitizeObject', () => {
       address: 'GBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
     });
     expect(result.address).toBe('GBXXXX***');
+  });
+
+  it('partially masks contract addresses/IDs', () => {
+    const result = sanitizeObject({
+      contractAddress: 'CBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      contract_id: 'CDYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY',
+    });
+    expect(result.contractAddress).toBe('CBXXXX***');
+    expect(result.contract_id).toBe('CDYYYY***');
+    expect(JSON.stringify(result)).not.toContain('XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX');
+  });
+
+  it('sanitizeContractAddress masks a raw contract address for direct call sites', () => {
+    expect(sanitizeContractAddress('CBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')).toBe(
+      'CBXXXX***',
+    );
   });
 
   it('leaves safe fields unchanged', () => {


### PR DESCRIPTION
## Summary
\`sanitizeObject\` (used to scrub telemetry/log payloads) already partially masked \`walletAddress\`/\`publicKey\` fields, but Soroban contract addresses/IDs -- passed around throughout \`lib/contracts\` as \`contractId\` -- had no matching entry, so they'd land in logs/telemetry unmasked.

## Change
- Add \`contractaddress\`, \`contract_address\`, \`contractid\`, \`contract_id\` to \`PARTIAL_MASK_FIELDS\` and route them through the existing \`maskAddress\` masking (same treatment as wallet addresses/public keys, since Soroban contract IDs are strkey-formatted like wallet addresses).
- Add \`sanitizeContractAddress()\`, mirroring the existing \`sanitizeWalletAddress()\` wrapper, for call sites that log a contract address directly rather than through \`sanitizeObject\`.

## Tests
Added tests: \`contractAddress\`/\`contract_id\` fields get masked through \`sanitizeObject\`, and \`sanitizeContractAddress\` masks a raw address directly.

\`npx vitest run tests/unit/sanitize.test.ts\`: 38 passed. \`npx tsc --noEmit\`: no new errors. \`npx eslint\`: clean.

Closes #1482