### PR TITLE
fix(api): reject invalid Stellar recipient public keys in /api/send

### DIFF
--- a/app/api/send/route.ts
+++ b/app/api/send/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { StrKey } from '@stellar/stellar-sdk';
 import { withAuth } from '@/lib/auth';
 import type {
   SendTransactionRequest,
@@ -39,6 +40,17 @@ async function handler(
   if (!recipient || typeof recipient !== 'string' || recipient.trim() === '') {
     return NextResponse.json<SendTransactionErrorResponse>(
       { success: false, error: 'recipient is required.' },
+      { status: 400 },
+    );
+  }
+
+  // The client-side RecipientAddressInput form already blocks invalid
+  // addresses, but that's UI, not a security boundary — a request sent
+  // directly to this route bypasses it entirely. Re-validate here, at the
+  // actual boundary that builds the payout.
+  if (!StrKey.isValidEd25519PublicKey(recipient.trim())) {
+    return NextResponse.json<SendTransactionErrorResponse>(
+      { success: false, error: 'recipient must be a valid Stellar public key (G...).' },
       { status: 400 },
     );
   }

--- a/tests/unit/send-route.test.ts
+++ b/tests/unit/send-route.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { Keypair } from '@stellar/stellar-sdk';
+
+// Stub withAuth so it forwards the request and injects a fixed address
+vi.mock('@/lib/auth', () => ({
+    withAuth: (handler: (req: NextRequest, address: string) => Promise<Response>) =>
+        (req: NextRequest) =>
+            handler(req, 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'),
+}));
+
+import { POST } from '@/app/api/send/route';
+
+const VALID_RECIPIENT = Keypair.random().publicKey();
+
+function makePostRequest(body: unknown): NextRequest {
+    return new NextRequest('http://localhost/api/send', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+}
+
+describe('POST /api/send', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('builds a transaction for a valid Stellar recipient', async () => {
+        const res = await POST(
+            makePostRequest({ recipient: VALID_RECIPIENT, amount: 100, currency: 'USDC' }),
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.success).toBe(true);
+    });
+
+    it('rejects a recipient that is not a Stellar-shaped address at all', async () => {
+        const res = await POST(
+            makePostRequest({
+                recipient: '0x71C7656EC7ab88b098defB751B7401B5f6d8976',
+                amount: 100,
+                currency: 'USDC',
+            }),
+        );
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.success).toBe(false);
+        expect(body.error).toMatch(/valid Stellar public key/);
+    });
+
+    it('rejects a structurally valid but bad-checksum recipient', async () => {
+        const lastChar = VALID_RECIPIENT.at(-1);
+        const badChecksum = `${VALID_RECIPIENT.slice(0, -1)}${lastChar === 'A' ? 'B' : 'A'}`;
+
+        const res = await POST(
+            makePostRequest({ recipient: badChecksum, amount: 100, currency: 'USDC' }),
+        );
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.success).toBe(false);
+        expect(body.error).toMatch(/valid Stellar public key/);
+    });
+
+    it('still requires a non-empty recipient (existing check, unaffected)', async () => {
+        const res = await POST(makePostRequest({ recipient: '', amount: 100, currency: 'USDC' }));
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toBe('recipient is required.');
+    });
+});


### PR DESCRIPTION
## Summary
The client-side payout form (`RecipientAddressInput.tsx`) already does thorough Stellar address validation — prefix, length, charset, and full checksum verification via `StrKey.isValidEd25519PublicKey` — and disables the "Continue" button until the address passes. That's UI, not a security boundary: a request sent directly to `POST /api/send` (curl, a script, a modified client) bypasses it entirely. The route itself only checked that `recipient` was a non-empty string — no format or checksum validation at all.

## Threat model
Without server-side validation, `POST /api/send` would happily build a transaction against a `recipient` that isn't a real Stellar public key — garbage input, a copy-pasted Ethereum address, or a structurally-correct-looking string with a corrupted checksum (a single mistyped character). Since this route's own doc comment says it builds a transaction ("non-custodial: returns unsigned XDR... until Stellar broadcasting is wired"), an invalid recipient here means broken/wasted transactions at best, and — once broadcasting is wired up — funds directed at an address that can never actually receive them, with no clean, structured error telling the caller why.

## Change
Added a `StrKey.isValidEd25519PublicKey(recipient.trim())` check in `app/api/send/route.ts`, right after the existing "recipient is required" check (reject bad input at the boundary, before any other work). Matches the existing route's established error-response convention (`{ success: false, error: string }`, `400`) rather than introducing a different error shape just for this one check.

Closes #1537

## Test plan
- New `tests/unit/send-route.test.ts` (4 tests, mocking `withAuth` the same way `tests/unit/family-members-route.test.ts` does): a valid Stellar recipient (generated via `Keypair.random().publicKey()`) succeeds with `200`; a non-Stellar-shaped address (Ethereum-style `0x...`) is rejected with `400` and the new error message; a structurally-valid-but-bad-checksum address (one flipped trailing character) is also rejected; the pre-existing empty-recipient check still works unaffected — all passing.
- `npx eslint app/api/send/route.ts tests/unit/send-route.test.ts` — clean
- `npx tsc --noEmit` — no errors in the changed files