### PR TITLE
API: add a typed hook for the /health/deep endpoint

### DIFF
--- a/lib/hooks/useHealthDeep.ts
+++ b/lib/hooks/useHealthDeep.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { apiClient } from "@/lib/client/apiClient";
+
+export const HEALTH_DEEP_URL = "/api/health";
+
+export type HealthDeepStatus = "ok" | "degraded";
+
+export interface HealthDeepDependency {
+  reachable: boolean;
+  error?: string;
+}
+
+export interface HealthDeepRpcDependency extends HealthDeepDependency {
+  latestLedger?: number;
+  protocolVersion?: number;
+  networkPassphrase?: string;
+  network?: string;
+}
+
+/** Response shape of `GET /api/health` (the full/deep dependency check). */
+export interface HealthDeepResponse {
+  status: HealthDeepStatus;
+  database: HealthDeepDependency;
+  rpc: HealthDeepRpcDependency;
+  anchor: HealthDeepDependency;
+  contractIds?: Record<string, string>;
+  timestamp: string;
+}
+
+export interface UseHealthDeepResult {
+  data: HealthDeepResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+/**
+ * Typed hook for the deep health-check endpoint (`GET /api/health`), which
+ * probes the database, Soroban RPC, and anchor and returns 503 when any
+ * critical dependency is unreachable. Intended for admin/ops surfaces, not
+ * for gating end-user flows.
+ */
+export function useHealthDeep(): UseHealthDeepResult {
+  const [data, setData] = useState<HealthDeepResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  const refresh = useCallback(() => {
+    setRefreshToken((n) => n + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setIsLoading(true);
+      setError(null);
+
+      const res = await apiClient.get(HEALTH_DEEP_URL);
+      if (cancelled) return;
+
+      if (res === null) {
+        // session expiry handler already ran in apiClient
+        setIsLoading(false);
+        return;
+      }
+
+      // 503 is a valid, informative response here (a dependency is down) --
+      // the body is still parsed and surfaced, not treated as a fetch failure.
+      const body = (await res.json().catch(() => null)) as HealthDeepResponse | null;
+
+      if (!body) {
+        setError(res.statusText || "Failed to parse health response");
+        setIsLoading(false);
+        return;
+      }
+
+      setData(body);
+      setIsLoading(false);
+    }
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshToken]);
+
+  return { data, isLoading, error, refresh };
+}

--- a/tests/unit/hooks/useHealthDeep.test.tsx
+++ b/tests/unit/hooks/useHealthDeep.test.tsx
@@ -1,0 +1,97 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { apiClient } from "@/lib/client/apiClient";
+import { HEALTH_DEEP_URL, useHealthDeep } from "@/lib/hooks/useHealthDeep";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useHealthDeep", () => {
+  it("fetches the deep health endpoint and exposes the parsed body", async () => {
+    const get = vi.spyOn(apiClient, "get").mockResolvedValue(
+      jsonResponse({
+        status: "ok",
+        database: { reachable: true },
+        rpc: { reachable: true, latestLedger: 42 },
+        anchor: { reachable: true },
+        timestamp: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+
+    const { result } = renderHook(() => useHealthDeep());
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(get).toHaveBeenCalledWith(HEALTH_DEEP_URL);
+    expect(result.current.data?.status).toBe("ok");
+    expect(result.current.data?.rpc.latestLedger).toBe(42);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a degraded (503) response body instead of treating it as an error", async () => {
+    vi.spyOn(apiClient, "get").mockResolvedValue(
+      jsonResponse(
+        {
+          status: "degraded",
+          database: { reachable: false, error: "unreachable" },
+          rpc: { reachable: true },
+          anchor: { reachable: true },
+          timestamp: "2026-01-01T00:00:00.000Z",
+        },
+        503,
+      ),
+    );
+
+    const { result } = renderHook(() => useHealthDeep());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data?.status).toBe("degraded");
+    expect(result.current.data?.database.reachable).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("stops loading without setting data when apiClient returns null (session expiry)", async () => {
+    vi.spyOn(apiClient, "get").mockResolvedValue(null);
+
+    const { result } = renderHook(() => useHealthDeep());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it("refresh() re-fetches", async () => {
+    const get = vi
+      .spyOn(apiClient, "get")
+      .mockResolvedValue(
+        jsonResponse({
+          status: "ok",
+          database: { reachable: true },
+          rpc: { reachable: true },
+          anchor: { reachable: true },
+          timestamp: "2026-01-01T00:00:00.000Z",
+        }),
+      );
+
+    const { result } = renderHook(() => useHealthDeep());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(get).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(2));
+  });
+});


### PR DESCRIPTION
## Note on scope
There is no literal \`/health/deep\` route -- \`GET /api/health\` *is* the deep/full dependency check (database + Soroban RPC + anchor, 503 when any is unreachable), as opposed to \`/api/v1/health\` which is a separate simpler check. This hook targets \`/api/health\`.

## Summary
Adds \`useHealthDeep()\`, a typed hook wrapping \`GET /api/health\`, following the existing \`apiClient\`-based hook pattern (\`useUserPreferences\`, \`useTransactionStatus\`).

## Change
- \`lib/hooks/useHealthDeep.ts\`: typed \`HealthDeepResponse\` matching the route's actual response shape, and a hook exposing \`{ data, isLoading, error, refresh }\`.
- Treats a \`503\` (\`status: "degraded"\`) response as a valid, parsed result -- not a fetch error -- since surfacing *which* dependency is down is the point of the endpoint.
- Respects \`apiClient\`'s \`Response | null\` contract (\`null\` means the session-expiry interceptor already handled it).

## Tests
Added \`tests/unit/hooks/useHealthDeep.test.tsx\` (renderHook + mocked \`apiClient.get\`, matching \`useTransactionStatus\`'s test style): happy path, 503/degraded body surfaced correctly, \`null\` (session expiry) handled, \`refresh()\` re-fetches.

\`npx vitest run tests/unit/hooks/useHealthDeep.test.tsx\`: 4 passed. \`npx tsc --noEmit\`: no new errors. \`npx eslint\`: clean.

Closes #1478