### PR TITLE
API: add a useTenant() hook backed by the auth context

### DIFF
--- a/lib/hooks/useTenant.ts
+++ b/lib/hooks/useTenant.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { apiClient } from "@/lib/client/apiClient";
+
+export const AUTH_ME_URL = "/api/auth/me";
+
+export interface TenantInfo {
+  /** The signed-in wallet address. This app is single-tenant-per-session:
+   * the "tenant" is the authenticated address itself, not a separate
+   * organization/workspace id. */
+  tenantId: string;
+  expiresAt?: number;
+}
+
+export interface UseTenantResult {
+  tenant: TenantInfo | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * Resolves the current tenant (the authenticated wallet address) from the
+ * session, backed by `GET /api/auth/me`. Returns `isAuthenticated: false`
+ * (not an error) for the expected 401-when-signed-out case.
+ */
+export function useTenant(): UseTenantResult {
+  const [tenant, setTenant] = useState<TenantInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setIsLoading(true);
+      setError(null);
+
+      const res = await apiClient.get(AUTH_ME_URL);
+      if (cancelled) return;
+
+      if (res === null) {
+        // session expiry handler already ran in apiClient
+        setIsLoading(false);
+        return;
+      }
+
+      if (res.status === 401) {
+        setTenant(null);
+        setIsLoading(false);
+        return;
+      }
+
+      if (!res.ok) {
+        setError(res.statusText || "Failed to resolve tenant");
+        setIsLoading(false);
+        return;
+      }
+
+      const data = (await res.json().catch(() => null)) as
+        | { address?: string; expiresAt?: number }
+        | null;
+
+      if (!data?.address) {
+        setError("Malformed session response");
+        setIsLoading(false);
+        return;
+      }
+
+      setTenant({ tenantId: data.address, expiresAt: data.expiresAt });
+      setIsLoading(false);
+    }
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { tenant, isAuthenticated: tenant !== null, isLoading, error };
+}

--- a/tests/unit/hooks/useTenant.test.tsx
+++ b/tests/unit/hooks/useTenant.test.tsx
@@ -1,0 +1,64 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { apiClient } from "@/lib/client/apiClient";
+import { AUTH_ME_URL, useTenant } from "@/lib/hooks/useTenant";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useTenant", () => {
+  it("resolves the tenant from the authenticated session", async () => {
+    const get = vi
+      .spyOn(apiClient, "get")
+      .mockResolvedValue(jsonResponse({ address: "GABC123", expiresAt: 999 }));
+
+    const { result } = renderHook(() => useTenant());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(get).toHaveBeenCalledWith(AUTH_ME_URL);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.tenant).toEqual({ tenantId: "GABC123", expiresAt: 999 });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("treats a 401 as signed-out, not an error", async () => {
+    vi.spyOn(apiClient, "get").mockResolvedValue(
+      jsonResponse({ error: "Unauthorized" }, 401),
+    );
+
+    const { result } = renderHook(() => useTenant());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.tenant).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets an error for a malformed 200 response", async () => {
+    vi.spyOn(apiClient, "get").mockResolvedValue(jsonResponse({}));
+
+    const { result } = renderHook(() => useTenant());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.error).toBe("Malformed session response");
+  });
+
+  it("stops loading without setting a tenant when apiClient returns null", async () => {
+    vi.spyOn(apiClient, "get").mockResolvedValue(null);
+
+    const { result } = renderHook(() => useTenant());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.tenant).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+});


### PR DESCRIPTION
## Note on scope
There's no separate multi-tenant/org concept or React auth context provider in this app -- it's single-tenant-per-session (a signed-in wallet address). \`useTenant()\` resolves that address as the tenant, backed by the session (\`GET /api/auth/me\`), following the same \`apiClient\`-based pattern already used by \`useUserPreferences\`/\`useSessionExpiry\` rather than introducing a new context provider (out of scope for this issue).

## Change
\`lib/hooks/useTenant.ts\`: \`useTenant()\` returns \`{ tenant, isAuthenticated, isLoading, error }\`, where \`tenant.tenantId\` is the authenticated wallet address. A \`401\` is treated as "signed out" (\`isAuthenticated: false\`, no error), not a failure.

## Tests
Added \`tests/unit/hooks/useTenant.test.tsx\`: resolves tenant from a valid session, treats 401 as signed-out, surfaces an error for a malformed 200 body, and handles \`apiClient\` returning \`null\` (session-expiry interceptor already ran).

\`npx vitest run tests/unit/hooks/useTenant.test.tsx\`: 4 passed. \`npx tsc --noEmit\`: no new errors. \`npx eslint\`: clean.

Closes #1485