### PR TITLE
Logging: add a breadcrumb on locale switch

### DIFF
--- a/components/LocaleSwitcher.test.tsx
+++ b/components/LocaleSwitcher.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import LocaleSwitcher from "@/components/LocaleSwitcher";
+
+const addBreadcrumb = vi.fn();
+
+vi.mock("@sentry/nextjs", () => ({
+  addBreadcrumb: (...args: unknown[]) => addBreadcrumb(...args),
+}));
+
+describe("LocaleSwitcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.cookie = "locale=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+    Object.defineProperty(window.navigator, "language", {
+      value: "en-US",
+      configurable: true,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+    );
+    // jsdom doesn't implement navigation; avoid the "not implemented" noise.
+    // @ts-expect-error -- test-only stub
+    delete window.location;
+    // @ts-expect-error -- test-only stub
+    window.location = { reload: vi.fn() };
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("emits a structured breadcrumb with the from/to locale on switch", async () => {
+    render(<LocaleSwitcher />);
+
+    // `t()` falls back to the raw key string when a translation is missing
+    // (see lib/i18n/client.ts), which this app's en.json currently does for
+    // the whole `localeSwitcher` namespace -- so the trigger's accessible
+    // name and the dropdown item text are the literal key paths, not copy.
+    fireEvent.click(screen.getByRole("button", { name: "localeSwitcher.label" }));
+    fireEvent.click(await screen.findByText("localeSwitcher.spanish"));
+
+    await waitFor(() => expect(addBreadcrumb).toHaveBeenCalledTimes(1));
+    expect(addBreadcrumb).toHaveBeenCalledWith({
+      category: "locale",
+      level: "info",
+      data: { from: "en", to: "es" },
+    });
+  });
+
+  it("does not log the locale change as a free-form message", async () => {
+    render(<LocaleSwitcher />);
+
+    fireEvent.click(screen.getByRole("button", { name: "localeSwitcher.label" }));
+    fireEvent.click(await screen.findByText("localeSwitcher.spanish"));
+
+    await waitFor(() => expect(addBreadcrumb).toHaveBeenCalledTimes(1));
+    const call = addBreadcrumb.mock.calls[0][0];
+    expect(call.message).toBeUndefined();
+  });
+});

--- a/components/LocaleSwitcher.tsx
+++ b/components/LocaleSwitcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import * as Sentry from "@sentry/nextjs";
 import { useClientTranslator, useClientLocale } from "@/lib/i18n/client";
 import { setLocaleCookie, type SupportedLocale } from "@/lib/i18n/cookie";
 import { Globe } from "lucide-react";
@@ -18,6 +19,15 @@ export default function LocaleSwitcher() {
   const currentLocale = locales.find((l) => l.code === locale) || locales[0];
 
   const handleLocaleChange = async (newLocale: SupportedLocale) => {
+    // Structured breadcrumb (no free-form message) so a locale switch shows
+    // up in the timeline leading up to any error reported after it -- these
+    // are common triggers for locale-dependent formatting/routing bugs.
+    Sentry.addBreadcrumb({
+      category: "locale",
+      level: "info",
+      data: { from: locale, to: newLocale },
+    });
+
     // Set cookie immediately (readable by both server and client)
     setLocaleCookie(newLocale);
     // Persist to server-side user preferences so it survives across devices


### PR DESCRIPTION
## Summary
Locale changes are a common trigger for locale-dependent formatting/routing bugs that surface *after* the switch, but nothing recorded the switch in the error-reporting timeline -- so a bug report following a locale change had no breadcrumb trail leading up to it.

## Change
\`components/LocaleSwitcher.tsx\`: \`handleLocaleChange\` now calls \`Sentry.addBreadcrumb\` (the app already initializes \`@sentry/nextjs\` client-side, see \`sentry.client.config.ts\`; \`RootErrorBoundary\` already imports it the same way) right before setting the cookie:
\`\`\`ts
Sentry.addBreadcrumb({ category: "locale", level: "info", data: { from: locale, to: newLocale } });
\`\`\`
Structured data only, no free-form message -- matching the issue's logging guidance.

## Tests
Added \`components/LocaleSwitcher.test.tsx\` (mocks \`@sentry/nextjs\`, following the same pattern as \`RootErrorBoundary.test.tsx\`): asserts the breadcrumb fires with the correct \`{ from, to }\` on a locale switch, and that no free-form \`message\` is set.

\`npx vitest run components/LocaleSwitcher.test.tsx\`: 2 passed. \`npx tsc --noEmit\`: no new errors. \`npx eslint\`: clean.

Closes #1473