### PR TITLE
feat(logging): add a per-tab session ID to client error logs

### DIFF
--- a/lib/client/errorReporter.ts
+++ b/lib/client/errorReporter.ts
@@ -1,4 +1,5 @@
 import { sanitizeWalletAddress } from '../sanitize';
+import { getSessionId } from './sessionId';
 
 /**
  * Short, scoped label identifying which part of the app raised the error
@@ -18,7 +19,9 @@ const getReporter = (): Reporter => {
   if (!dsn) {
     return {
       captureException: (err, _context, tag) =>
-        console.error('[ErrorReporter No-Op]', tag ? `[${tag}]` : '', err),
+        console.error('[ErrorReporter No-Op]', tag ? `[${tag}]` : '', err, {
+          sessionId: getSessionId(),
+        }),
     };
   }
 
@@ -33,6 +36,7 @@ const getReporter = (): Reporter => {
       console.log('[ErrorReporter] Reporting to Sentry:', err, {
         ...(tag ? { tag } : {}),
         context: scrubbedContext,
+        sessionId: getSessionId(),
       });
     }
   };

--- a/lib/client/sessionId.ts
+++ b/lib/client/sessionId.ts
@@ -1,0 +1,52 @@
+/**
+ * Per-tab client session identifier, for correlating client-side logs
+ * without persisting any user-identifying information.
+ *
+ * Generated once per browser tab and stored in `sessionStorage`, so it
+ * survives reloads within the same tab but resets for a new tab/window --
+ * unlike `localStorage`, it is never shared across tabs or persisted after
+ * the tab closes.
+ */
+
+const SESSION_ID_KEY = "rw_session_id";
+
+function generateSessionId(): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).substring(2, 10);
+  return `sess-${timestamp}-${random}`;
+}
+
+let cachedSessionId: string | undefined;
+
+/**
+ * Returns the current tab's session ID, creating and persisting one on
+ * first call. Returns `undefined` when called outside a browser (SSR) --
+ * callers should omit the field rather than log a placeholder.
+ */
+export function getSessionId(): string | undefined {
+  if (typeof window === "undefined" || !window.sessionStorage) {
+    return undefined;
+  }
+
+  if (cachedSessionId) {
+    return cachedSessionId;
+  }
+
+  try {
+    const existing = window.sessionStorage.getItem(SESSION_ID_KEY);
+    if (existing) {
+      cachedSessionId = existing;
+      return cachedSessionId;
+    }
+
+    const created = generateSessionId();
+    window.sessionStorage.setItem(SESSION_ID_KEY, created);
+    cachedSessionId = created;
+    return cachedSessionId;
+  } catch {
+    // Private-browsing modes or storage quota errors -- fall back to an
+    // in-memory-only ID for the lifetime of this page load.
+    cachedSessionId = cachedSessionId ?? generateSessionId();
+    return cachedSessionId;
+  }
+}

--- a/tests/unit/errorReporter.test.ts
+++ b/tests/unit/errorReporter.test.ts
@@ -22,7 +22,8 @@ test('no-op reporter includes the scoped tag in the console output when provided
   expect(consoleSpy).toHaveBeenCalledWith(
     '[ErrorReporter No-Op]',
     '[payout-form]',
-    expect.any(Error)
+    expect.any(Error),
+    { sessionId: expect.any(String) }
   );
 });
 
@@ -30,5 +31,17 @@ test('no-op reporter omits the tag marker entirely when none is provided', () =>
   const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   errorReporter.captureException(new Error('boom'));
 
-  expect(consoleSpy).toHaveBeenCalledWith('[ErrorReporter No-Op]', '', expect.any(Error));
+  expect(consoleSpy).toHaveBeenCalledWith('[ErrorReporter No-Op]', '', expect.any(Error), {
+    sessionId: expect.any(String),
+  });
+});
+
+test('every logged entry carries the same session ID across calls', () => {
+  const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  errorReporter.captureException(new Error('first'));
+  errorReporter.captureException(new Error('second'));
+
+  const firstSessionId = consoleSpy.mock.calls[0][3].sessionId;
+  const secondSessionId = consoleSpy.mock.calls[1][3].sessionId;
+  expect(firstSessionId).toBe(secondSessionId);
 });

--- a/tests/unit/sessionId.test.ts
+++ b/tests/unit/sessionId.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("getSessionId", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("generates and persists a session ID in sessionStorage on first call", async () => {
+    const { getSessionId } = await import("../../lib/client/sessionId");
+    const id = getSessionId();
+
+    expect(id).toMatch(/^sess-[a-z0-9]+-[a-z0-9]+$/);
+    expect(window.sessionStorage.getItem("rw_session_id")).toBe(id);
+  });
+
+  it("returns the same ID on repeated calls within the same module instance", async () => {
+    const { getSessionId } = await import("../../lib/client/sessionId");
+    expect(getSessionId()).toBe(getSessionId());
+  });
+
+  it("reuses the sessionStorage value across a fresh module load (survives reload)", async () => {
+    const first = await import("../../lib/client/sessionId");
+    const id = first.getSessionId();
+
+    vi.resetModules();
+    const second = await import("../../lib/client/sessionId");
+    expect(second.getSessionId()).toBe(id);
+  });
+
+  it("falls back to an in-memory ID when sessionStorage throws", async () => {
+    const getItemSpy = vi
+      .spyOn(window.sessionStorage.__proto__, "getItem")
+      .mockImplementation(() => {
+        throw new Error("storage disabled");
+      });
+
+    const { getSessionId } = await import("../../lib/client/sessionId");
+    const id = getSessionId();
+
+    expect(id).toMatch(/^sess-/);
+    getItemSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #1434

## Summary
Adds a per-tab session ID to client-side error logs, so log entries from the same browser session can be correlated without exposing any user-identifying information.

- `lib/client/sessionId.ts`: `getSessionId()` generates a session ID once per browser tab and persists it in `sessionStorage` — it survives reloads within the same tab, but resets for a new tab/window (unlike `localStorage`, which would leak across tabs and persist indefinitely). Falls back to an in-memory-only ID if `sessionStorage` throws (private-browsing mode, quota errors), and returns `undefined` during SSR rather than logging a placeholder.
- `lib/client/errorReporter.ts`: `captureException` now includes `{ sessionId: getSessionId() }` in every logged entry, on both the no-op console path and the Sentry-reporting path (this was the existing, concrete "client log" call site in the codebase already exercised by tests).

## Tests
- `tests/unit/sessionId.test.ts` (new): generates + persists an ID on first call, returns the same ID on repeated calls, reuses the `sessionStorage` value across a fresh module load (simulating survives-reload), falls back gracefully when `sessionStorage` throws.
- `tests/unit/errorReporter.test.ts` (updated): the two existing exact-argument assertions now also expect the `{ sessionId: expect.any(String) }` trailing argument; added a new test confirming the same session ID is reused across multiple log calls.

## Verification
`npx vitest run --config vitest.config.mjs --configLoader runner tests/unit/sessionId.test.ts tests/unit/errorReporter.test.ts` — 8/8 pass. `npx tsc --noEmit` and `npx eslint` show no new errors from these files (this large repo has ~123 pre-existing, unrelated type errors elsewhere).
