### PR TITLE
fix(toast): stop queuing a state update after a toast unmounts

### DIFF
--- a/components/Toast.test.tsx
+++ b/components/Toast.test.tsx
@@ -566,4 +566,38 @@ describe('Toast', () => {
       expect(screen.queryByText('Timestamp:')).not.toBeInTheDocument();
     });
   });
+
+  describe('unmount safety', () => {
+    it('does not warn about a state update on an unmounted component when dismissed', () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { unmount } = render(<Toast toast={mockToast} onDismiss={mockOnDismiss} />);
+
+      // Unmount partway through the auto-dismiss timer, mirroring the
+      // pause/resume effect's cleanup running mid-countdown.
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      unmount();
+
+      const stateUpdateWarning = consoleError.mock.calls.some((args) =>
+        String(args[0]).includes('a component'),
+      );
+      expect(stateUpdateWarning).toBe(false);
+    });
+
+    it('does not fire onDismiss again after unmounting mid-countdown', () => {
+      const { unmount } = render(<Toast toast={mockToast} onDismiss={mockOnDismiss} />);
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      unmount();
+      mockOnDismiss.mockClear();
+
+      act(() => {
+        vi.advanceTimersByTime(10000);
+      });
+      expect(mockOnDismiss).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -44,6 +44,17 @@ export default function Toast({ toast, onDismiss }: ToastProps) {
   const [isDisclosureOpen, setIsDisclosureOpen] = useState(false);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const startTimeRef = useRef<number>(Date.now());
+  const isMountedRef = useRef(true);
+
+  // Tracks real unmount (as opposed to this effect's own pause/resume
+  // re-runs) so the pause/resume effect below can skip its state update
+  // once the toast is actually gone, rather than queuing a setRemaining
+  // call against an unmounted component on every dismissal.
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   // Determine if diagnostic details are available (only for error variant)
   const hasDiagnostics = 
@@ -71,6 +82,7 @@ export default function Toast({ toast, onDismiss }: ToastProps) {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }
+      if (!isMountedRef.current) return;
       const elapsed = Date.now() - startTimeRef.current;
       setRemaining((prev) => Math.max(0, prev - elapsed));
     };


### PR DESCRIPTION
Closes #1465

## Summary
`Toast`'s auto-dismiss timer effect pauses/resumes on hover/focus, tracking the remaining time in `remaining` state. Its cleanup function unconditionally called `setRemaining(...)` — including when the cleanup runs because the toast is being **unmounted** (dismissed, or evicted once the 3-toast cap is exceeded), not just when the effect re-runs due to a pause/resume dependency change. That queues a state update against a component instance that's already gone on every single toast dismissal — the "leak" described by this issue.

Fixed by tracking real unmount with a dedicated `isMountedRef`, flipped by its own mount-tracking effect (declared *before* the timer effect, so its cleanup runs first on unmount — verified empirically that React runs effect cleanups in declaration order, not reverse). The timer effect's cleanup now checks that ref and skips `setRemaining` once it's `false`.

## Tests
Added to `components/Toast.test.tsx`:
- unmounting mid-countdown does not trigger a "state update on an unmounted component"-style console warning
- unmounting mid-countdown does not fire `onDismiss` again once the original timer would have elapsed

## Verification
`npx vitest run --config vitest.config.mjs --configLoader runner components/Toast.test.tsx` — 47/49 pass (2 new + 45 pre-existing pass; the 2 failures are pre-existing and unrelated — a `getByText` ambiguous-match issue in the diagnostics-disclosure tests, present identically on a clean checkout of `main`). `npx tsc --noEmit` and `npx eslint` show no new errors.
