### PR TITLE
security: CSRF protection docs and client-side hardening baseline

### DIFF
--- a/app/dashboard/transaction-history/components/transaction-history-search-input.tsx
+++ b/app/dashboard/transaction-history/components/transaction-history-search-input.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useId, useState, type FormEvent } from "react";
+import { useEffect, useId, useState, type ClipboardEvent, type FormEvent } from "react";
 import { Search } from "lucide-react";
 import layoutConfig from "@/lib/config/layout.json";
+import { sanitizePastedValue } from "@/lib/validation/sanitizePaste";
 
 const { MOBILE_MAX_WIDTH } = layoutConfig.BREAKPOINTS;
 
@@ -48,6 +49,27 @@ const TransactionHistorySearchInput = ({
     onChange?.(nextValue);
   };
 
+  /**
+   * Strip HTML tags from clipboard payloads that carry a text/html MIME type.
+   * Plain-text pastes are left to the browser's default handling.
+   * This prevents literal tag markup from landing in the search field when
+   * content is copied from a rich editor or web page.
+   */
+  const handlePaste = (event: ClipboardEvent<HTMLInputElement>) => {
+    const { clipboardData } = event;
+    if (!clipboardData || !clipboardData.types.includes("text/html")) return;
+
+    event.preventDefault();
+    const target = event.currentTarget;
+    const next = sanitizePastedValue(
+      clipboardData,
+      target.value,
+      target.selectionStart ?? target.value.length,
+      target.selectionEnd ?? target.value.length,
+    );
+    handleChange(next);
+  };
+
   return (
     <form role="search" onSubmit={handleSubmit} className="w-full max-w-4xl xl:min-w-[680px]" noValidate>
       <div className="relative">
@@ -58,6 +80,7 @@ const TransactionHistorySearchInput = ({
           type="search"
           value={value}
           onChange={(e) => handleChange(e.target.value)}
+          onPaste={handlePaste}
           placeholder={isMobile && mobilePlaceholder ? mobilePlaceholder : placeholder}
           aria-invalid={error ? true : undefined}
           aria-describedby={error ? errorId : undefined}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { FileText, MapPin, Settings as SettingsIcon, Search } from "lucide-react";
 import { getGlobalSearchResults, type GlobalSearchCategory } from "@/lib/search/globalSearchCatalog";
+import { sanitizeSearchQuery } from "@/lib/sanitize";
 
 interface SearchResultsPageProps {
   searchParams?: {
@@ -34,8 +35,8 @@ function groupResultsByCategory(results: ReturnType<typeof getGlobalSearchResult
   );
 }
 
-function SearchResultsPage({ searchParams }: SearchResultsPageProps) {
-  const query = searchParams?.q?.trim() ?? "";
+export function SearchResultsPage({ searchParams }: SearchResultsPageProps) {
+  const query = sanitizeSearchQuery(searchParams?.q ?? "");
   const results = getGlobalSearchResults(query);
   const groupedResults = groupResultsByCategory(results);
 

--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -7,6 +7,7 @@ import { SHORTCUTS_PRINTABLE_PATH } from "@/lib/config/shortcuts";
 import { useClientTranslator } from "@/lib/i18n/client";
 import { useRecentItems } from "@/lib/hooks/useRecentItems";
 import { RECENT_COMMANDS_STORAGE_KEY } from "@/lib/config/recent";
+import { sanitizeSearchQuery } from "@/lib/sanitize";
 
 interface CommandItem {
   id: string;
@@ -94,7 +95,7 @@ export default function CommandPalette() {
       label: "Global Search",
       description: "Search invoices, addresses, and settings",
       icon: <SearchCheck className="w-4 h-4" />,
-      action: () => router.push(`/search?q=${encodeURIComponent(searchQuery.trim())}`),
+      action: () => router.push(`/search?q=${encodeURIComponent(sanitizeSearchQuery(searchQuery))}`),
       category: "routes",
     },
     // Quick Actions

--- a/docs/CSRF_PROTECTION.md
+++ b/docs/CSRF_PROTECTION.md
@@ -1,0 +1,229 @@
+# CSRF Protection
+
+> **Audience:** Contributors working on authentication, API routes, or form
+> submissions. Security reviewers auditing the defence-in-depth posture.
+
+---
+
+## Overview
+
+Cross-Site Request Forgery (CSRF) is an attack where a malicious third-party
+page tricks an authenticated user's browser into making an unwanted state-changing
+request to RemitWise. If the attack succeeds, the attacker can transfer funds,
+change settings, or perform any action the victim is authorised to perform —
+without the victim's knowledge.
+
+RemitWise defends against CSRF in two complementary layers:
+
+1. **`SameSite` cookie attribute** — the primary defence (covered in depth below).
+2. **Nonce-based wallet authentication** — a secondary property that renders most
+   CSRF attacks harmless even if the cookie were ever sent cross-origin.
+
+---
+
+## Threat model
+
+| Attacker goal | Pre-condition | Mitigated by |
+|---|---|---|
+| Trigger a state-changing API call (POST/PUT/PATCH/DELETE) as an authenticated user | User is logged in; attacker can embed a form or XHR on a page the user visits | `SameSite=Lax` cookie prevents the session cookie from being sent on cross-origin POST requests |
+| Steal the session token | User visits a malicious page | `HttpOnly` flag on `remitwise_session` prevents JS access; `SameSite` prevents cross-origin submission |
+| Forge a wallet-signature login | Attacker cannot read the server-generated nonce without same-origin access | Nonce-challenge/response requires the attacker to read a one-time value they cannot obtain |
+
+---
+
+## Primary defence: `SameSite=Lax` on `remitwise_session`
+
+The session cookie is configured in `lib/session.ts`:
+
+```typescript
+// lib/session.ts
+export function getSessionCookieHeader(sealed: string): string {
+  const sessionMaxAge = getSessionMaxAge();
+  return `${SESSION_COOKIE}=${sealed}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${sessionMaxAge}${
+    process.env.NODE_ENV === 'production' ? '; Secure' : ''
+  }`;
+}
+```
+
+### Why `Lax` and not `Strict`?
+
+`SameSite=Strict` would block the cookie from being sent on _any_ cross-site
+navigation, including clicking a link from an external page to RemitWise. That
+would force users to re-authenticate every time they arrive via an email link or
+bookmark manager, which is an unacceptable UX regression.
+
+`SameSite=Lax` is the right trade-off:
+
+| Request type | `Lax` sends cookie? | Risk |
+|---|---|---|
+| Top-level `GET` navigation (link click, redirect) | ✅ Yes | No state change from a GET |
+| Cross-site `<form method="POST">` | ❌ No | CSRF blocked |
+| Cross-site XHR/fetch (`credentials: include`) | ❌ No | CSRF blocked |
+| Same-origin request (any method) | ✅ Yes | Legitimate |
+
+### What an attacker gets without this fix
+
+Without `SameSite=Lax`, a malicious page could embed:
+
+```html
+<!-- on evil.example.com -->
+<form method="POST" action="https://app.remitwise.com/api/send">
+  <input name="recipient" value="ATTACKER_STELLAR_ADDRESS" />
+  <input name="amountMinor" value="100000" />
+</form>
+<script>document.forms[0].submit();</script>
+```
+
+If the user had an active session, the browser would attach `remitwise_session`
+to this forged request and the API route would treat it as legitimate. `SameSite=Lax`
+closes this vector entirely.
+
+---
+
+## Secondary defence: nonce-based wallet authentication
+
+Even for endpoints that accept mutations, RemitWise requires wallet ownership
+proof before session creation (`POST /api/auth/login`):
+
+1. Server issues a random 32-byte hex nonce (`POST /api/auth/nonce`).
+2. The client's wallet signs the nonce with the user's Stellar private key.
+3. The server verifies the signature before issuing a session cookie.
+
+A CSRF attacker cannot replicate this handshake because:
+- They cannot read the one-time nonce (same-origin policy blocks cross-origin reads).
+- They cannot sign the nonce without the user's private key.
+
+This means CSRF against the login endpoint is effectively impossible regardless
+of the cookie policy.
+
+---
+
+## Additional hardening measures
+
+### 1. Same-origin redirect enforcement
+
+All client-side redirects (post-logout, post-auth, session-expiry) pass through
+`safeRedirectPath()` in `lib/client/logout.ts` before the target URL is used:
+
+```typescript
+// lib/client/logout.ts
+export function safeRedirectPath(path: string | null | undefined): string {
+  if (!path || typeof path !== 'string') return '/';
+  // Must start with '/' but not '//' (protocol-relative)
+  if (!path.startsWith('/') || path.startsWith('//')) return '/';
+  // Catch any URL-encoded or embedded absolute URLs
+  if (path.includes('://')) return '/';
+  return path;
+}
+```
+
+This prevents _open-redirect_ vulnerabilities where a crafted `?next=` or
+`redirectTo` parameter could send the user to an attacker-controlled domain
+after authentication.
+
+### 2. Form state wiped on logout
+
+On every logout and session-expiry event, `wipeClientState()` in
+`lib/client/sessionHandler.ts` removes:
+
+- All known auth-related `localStorage` keys (`wallet_address`, `wallet_connected`, etc.).
+- All `localStorage` keys with the `remitwise_form_` prefix (catches dynamically-named draft entries).
+- Known `sessionStorage` draft keys (`form_draft`, `transfer_draft`, `bill_draft`).
+
+This ensures a subsequent user of the same browser session cannot access a prior
+user's unsaved form data.
+
+### 3. Sanitized search queries
+
+Search queries read from URL params (`?q=`) pass through `sanitizeSearchQuery()`
+in `lib/sanitize.ts` before being used in filtering or rendering:
+
+```typescript
+export function sanitizeSearchQuery(query: string): string {
+  if (typeof query !== 'string') return '';
+  const withoutControlChars = query.replace(/[\x00-\x1F\x7F]/g, '');
+  const collapsedWhitespace = withoutControlChars.replace(/\s+/g, ' ').trim();
+  return collapsedWhitespace.slice(0, MAX_SEARCH_QUERY_LENGTH); // 200 chars
+}
+```
+
+This removes CRLF injection characters that could corrupt HTTP log lines or
+smuggle forged log entries, and caps the output at 200 characters.
+
+### 4. Clipboard paste stripping
+
+Text fields that accept free-form user input reject clipboard payloads that
+contain HTML markup. The `sanitizePastedValue()` utility in
+`lib/validation/sanitizePaste.ts` is applied in `onPaste` handlers:
+
+```typescript
+// lib/validation/sanitizePaste.ts
+export function sanitizePastedValue(
+  clipboardData: DataTransfer,
+  currentValue: string,
+  selectionStart: number,
+  selectionEnd: number
+): string {
+  const pasted = stripHtml(clipboardData.getData("text/plain"));
+  return currentValue.slice(0, selectionStart) + pasted + currentValue.slice(selectionEnd);
+}
+```
+
+Although `<input>` and `<textarea>` elements render plain text only, a
+clipboard payload that carries an HTML MIME type can include raw tag markup
+as its plain-text representation on some clipboard managers. Stripping the
+tags before insertion prevents literal `<script>` text from reaching field
+values that are later echoed into the DOM or sent to the server.
+
+---
+
+## Content Security Policy synergy
+
+The nonce-based CSP declared in `middleware.ts` and documented in
+[docs/SECURITY.md](SECURITY.md) provides a complementary XSS barrier. Even if
+an injected script somehow reached the DOM, the browser would refuse to execute
+it without a valid per-request nonce. Because CSRF tokens and XSS both exploit
+the trust relationship between browser and origin, a strong CSP reduces the
+attack surface CSRF would need to be combined with.
+
+---
+
+## Where CSRF tokens are **not** needed
+
+RemitWise does not implement a separate CSRF token header (e.g.
+`X-CSRF-Token`) because:
+
+1. `SameSite=Lax` provides equivalent cross-origin POST protection for all
+   modern browsers (>98% global usage as of 2025).
+2. The wallet-signature login flow already requires round-trip proof of key
+   ownership, making a CSRF attack against authentication infeasible.
+3. All API mutations are performed with `Content-Type: application/json`, which
+   browsers treat as a non-simple request and therefore block for cross-origin
+   callers without an explicit CORS pre-flight — and RemitWise's CORS policy
+   restricts `Access-Control-Allow-Origin` to the configured `ALLOWED_ORIGINS`
+   list (see `middleware.ts`).
+
+If a future integration ever requires `SameSite=None` cookies (e.g. embedded
+iframe flows), a synchronised CSRF token should be added at that point.
+
+---
+
+## Testing
+
+| Test file | What it covers |
+|---|---|
+| `tests/unit/logout-client.test.ts` | `safeRedirectPath` rejects absolute and protocol-relative URLs |
+| `tests/unit/sessionHandler.test.ts` | `wipeClientState` clears auth and form-state storage |
+| `tests/unit/sanitize.test.ts` | `sanitizeSearchQuery` strips control chars and caps length |
+| `tests/unit/validation/sanitizePaste.test.ts` | `stripHtml` and `sanitizePastedValue` |
+| `tests/unit/goals/SavingsGoalModal-paste.test.tsx` | HTML clipboard paste is stripped on the description textarea |
+| `tests/unit/search-page.test.tsx` | Search page sanitizes the `?q=` param before rendering |
+
+---
+
+## Related documentation
+
+- [docs/SECURITY.md](SECURITY.md) — Content Security Policy and XSS hardening.
+- [docs/COOKIE_HANDLING.md](COOKIE_HANDLING.md) — Full cookie inventory with `SameSite` rationale.
+- [docs/AUTH_IMPLEMENTATION.md](AUTH_IMPLEMENTATION.md) — Nonce challenge-response login flow.
+- [docs/frontend-session-handling.md](frontend-session-handling.md) — Session lifecycle and expiry flow.

--- a/tests/unit/dashboard/transaction-history-search-input.test.tsx
+++ b/tests/unit/dashboard/transaction-history-search-input.test.tsx
@@ -1,8 +1,17 @@
 import { useState } from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TransactionHistorySearchInput from "@/app/dashboard/transaction-history/components/transaction-history-search-input";
+
+function makePasteEvent(plainText: string, types: string[]) {
+  return {
+    clipboardData: {
+      types,
+      getData: (type: string) => (type === "text/plain" ? plainText : ""),
+    },
+  };
+}
 
 describe("TransactionHistorySearchInput", () => {
   it("shows a validation error when submitted empty, without calling onChange", async () => {
@@ -61,5 +70,30 @@ describe("TransactionHistorySearchInput", () => {
     await user.type(screen.getByRole("searchbox"), "abc");
 
     expect(onChange).toHaveBeenCalledTimes(3);
+  });
+
+  // Issue #1401 — clipboard paste HTML rejection
+  it("strips HTML tags when a clipboard payload carries text/html (Issue #1401)", () => {
+    const onChange = vi.fn();
+    render(<TransactionHistorySearchInput value="" onChange={onChange} />);
+
+    const input = screen.getByRole("searchbox");
+    fireEvent.paste(input, makePasteEvent("<b>rich</b> text", ["text/html", "text/plain"]));
+
+    // onChange must have been called with the stripped plain text, not the raw HTML
+    expect(onChange).toHaveBeenCalledWith("rich text");
+  });
+
+  it("leaves a plain-text-only paste to the browser default (Issue #1401)", () => {
+    const onChange = vi.fn();
+    render(<TransactionHistorySearchInput value="" onChange={onChange} />);
+
+    const input = screen.getByRole("searchbox");
+    const event = makePasteEvent("plain only", ["text/plain"]);
+    // When there is no text/html type, the handler must not call preventDefault,
+    // so onChange is never called by our handler (browser handles it natively).
+    const defaultPrevented = !fireEvent.paste(input, event);
+    expect(defaultPrevented).toBe(false);
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/search-page.test.tsx
+++ b/tests/unit/search-page.test.tsx
@@ -16,4 +16,24 @@ describe("SearchResultsPage", () => {
 
     expect(screen.getByText(/search for invoices, addresses, or settings to surface relevant results/i)).toBeInTheDocument();
   });
+
+  it("strips control characters from the ?q= param before rendering (Issue #1419)", () => {
+    // A query with embedded CRLF — without sanitization this would reach the
+    // rendered output and could corrupt HTTP log lines or smuggle forged entries.
+    render(<SearchResultsPage searchParams={{ q: "invoice\r\n\x00" }} />);
+
+    // The displayed query must not contain the raw control characters.
+    const headings = screen.getAllByRole("heading");
+    const allText = headings.map((h) => h.textContent).join(" ");
+    expect(allText).not.toMatch(/\r|\n|\x00/);
+  });
+
+  it("caps an overlong ?q= param at 200 characters (Issue #1419)", () => {
+    const longQuery = "a".repeat(500);
+    render(<SearchResultsPage searchParams={{ q: longQuery }} />);
+
+    // The displayed query in the result-count text must be capped, not the full 500 chars.
+    const paragraph = screen.getByText(/showing/i);
+    expect(paragraph.textContent?.length).toBeLessThan(300);
+  });
 });

--- a/tests/unit/sessionHandler.test.ts
+++ b/tests/unit/sessionHandler.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import { SIGN_IN_PATH, getSignInUrl } from '../../lib/client/sessionHandler';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  SIGN_IN_PATH,
+  getSignInUrl,
+  wipeClientState,
+  AUTH_STORAGE_KEYS,
+  FORM_STATE_PREFIX,
+  SESSION_STORAGE_FORM_KEYS,
+} from '../../lib/client/sessionHandler';
 
 describe('SIGN_IN_PATH', () => {
   it('should be the root path', () => {
@@ -29,5 +36,91 @@ describe('getSignInUrl', () => {
   it('encodes a path with spaces', () => {
     const url = getSignInUrl('/my profile');
     expect(url).toBe('/?next=%2Fmy%20profile');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wipeClientState — Issue #1430: wipe form state on logout
+// ---------------------------------------------------------------------------
+
+describe('wipeClientState', () => {
+  let lsStore: Record<string, string>;
+  let ssStore: Record<string, string>;
+
+  beforeEach(() => {
+    lsStore = {};
+    ssStore = {};
+
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('localStorage', {
+      get length() { return Object.keys(lsStore).length; },
+      getItem: (k: string) => lsStore[k] ?? null,
+      setItem: (k: string, v: string) => { lsStore[k] = v; },
+      removeItem: (k: string) => { delete lsStore[k]; },
+      key: (i: number) => Object.keys(lsStore)[i] ?? null,
+      clear: () => { lsStore = {}; },
+    });
+    vi.stubGlobal('sessionStorage', {
+      getItem: (k: string) => ssStore[k] ?? null,
+      setItem: (k: string, v: string) => { ssStore[k] = v; },
+      removeItem: (k: string) => { delete ssStore[k]; },
+      clear: () => { ssStore = {}; },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('removes every known auth key from localStorage', () => {
+    for (const key of AUTH_STORAGE_KEYS) {
+      lsStore[key] = 'some-value';
+    }
+
+    wipeClientState();
+
+    for (const key of AUTH_STORAGE_KEYS) {
+      expect(lsStore[key]).toBeUndefined();
+    }
+  });
+
+  it('removes localStorage keys that start with the form-state prefix', () => {
+    lsStore[`${FORM_STATE_PREFIX}send`] = 'draft-data';
+    lsStore[`${FORM_STATE_PREFIX}bill_42`] = 'bill-draft';
+    lsStore['unrelated_key'] = 'keep-me';
+
+    wipeClientState();
+
+    expect(lsStore[`${FORM_STATE_PREFIX}send`]).toBeUndefined();
+    expect(lsStore[`${FORM_STATE_PREFIX}bill_42`]).toBeUndefined();
+    // Unrelated keys must not be touched
+    expect(lsStore['unrelated_key']).toBe('keep-me');
+  });
+
+  it('removes known sessionStorage draft keys', () => {
+    for (const key of SESSION_STORAGE_FORM_KEYS) {
+      ssStore[key] = 'draft';
+    }
+
+    wipeClientState();
+
+    for (const key of SESSION_STORAGE_FORM_KEYS) {
+      expect(ssStore[key]).toBeUndefined();
+    }
+  });
+
+  it('is a no-op when storage is already empty', () => {
+    // Must not throw
+    expect(() => wipeClientState()).not.toThrow();
+  });
+
+  it('does not remove unrelated localStorage keys', () => {
+    lsStore['theme'] = 'dark';
+    lsStore['locale'] = 'en';
+
+    wipeClientState();
+
+    expect(lsStore['theme']).toBe('dark');
+    expect(lsStore['locale']).toBe('en');
   });
 });


### PR DESCRIPTION
## Summary

This PR lands the security baseline described in issues #1163, #1431, #1430, #1419, and #1401. All changes are defence-in-depth; there is no known active exploitation.

Closes #1163
Closes #1431
Closes #1430
Closes #1419

---

## Threat model

| Issue | Threat mitigated |
|---|---|
| #1163 | Missing documentation means contributors can accidentally bypass or weaken CSRF defences without realising it. Documents the full defence-in-depth stack so auditors and contributors understand what is in place and why. |
| #1431 | An attacker who can influence a `redirectTo` option (e.g. via a crafted `?next=` query parameter stored in localStorage) could redirect the user to a phishing domain after logout or re-authentication. |
| #1430 | After logout, form draft data (e.g. unsaved send-money details) persisted in localStorage/sessionStorage could be read by the next user of the same browser session or by a XSS payload that fires post-logout. |
| #1419 | A `?q=` URL parameter containing CRLF characters or null bytes can corrupt structured log lines (log injection) or produce garbled output when echoed back into the page. |
| #1401 | Pasting from a rich editor or web page can deliver a clipboard payload whose plain-text representation contains raw HTML tags; landing those tags in a field that is later echoed to the DOM or included in a server payload increases XSS surface area. |

---

## Changes

### `docs/CSRF_PROTECTION.md` (Issue #1163)
New document covering:
- Primary defence: `SameSite=Lax` on `remitwise_session` — blocks cross-origin POST submissions.
- Secondary defence: nonce-based wallet challenge/response — makes CSRF against login infeasible.
- Same-origin redirect enforcement via `safeRedirectPath()`.
- Form state wipe on logout via `wipeClientState()`.
- Search query sanitization via `sanitizeSearchQuery()`.
- Clipboard paste stripping via `sanitizePastedValue()`.
- Why a separate CSRF token header is not needed (SameSite + JSON Content-Type + CORS policy).
- Full testing table pointing to each test file.

### Redirect hardening (Issue #1431)
`safeRedirectPath()` in `lib/client/logout.ts` and `lib/client/useCredentialRevoke.ts` already rejects absolute URLs (`https://evil.com`), protocol-relative URLs (`//evil.com`), and any path embedding `://`. The existing tests in `tests/unit/logout-client.test.ts` cover the full set of attack patterns including:
- Absolute HTTPS/HTTP URLs → falls back to `/`
- Protocol-relative URLs → falls back to `/`
- Paths embedding `://` → falls back to `/`
- Stored malicious `redirect_after_auth` values are sanitized by `getPostAuthRedirect()` before use

### Form state wipe on logout (Issue #1430)
`wipeClientState()` in `lib/client/sessionHandler.ts` already clears:
1. All known auth keys from localStorage (`wallet_address`, `wallet_connected`, etc.)
2. All `localStorage` keys starting with `remitwise_form_` (catches dynamic draft keys)
3. Known `sessionStorage` draft keys (`form_draft`, `transfer_draft`, `bill_draft`)

Added dedicated tests in `tests/unit/sessionHandler.test.ts` that verify each of these three sweeps independently, including a test that confirms unrelated keys are not disturbed.

### Search query sanitization (Issue #1419)
Applied `sanitizeSearchQuery()` from `lib/sanitize.ts` in two places:
- **`app/search/page.tsx`**: query read from `searchParams.q` now passes through `sanitizeSearchQuery()` before use, stripping control chars and capping at 200 chars.
- **`components/CommandPalette.tsx`**: query is sanitized before `encodeURIComponent` builds the `/search?q=` URL.

Added negative tests:
- Control characters (CRLF, null byte) in `?q=` are stripped before rendering.
- Overlong queries (500 chars) are capped at 200 chars.

### Clipboard paste rejection (Issue #1401)
Added `onPaste` handler to `TransactionHistorySearchInput` using `sanitizePastedValue()` from `lib/validation/sanitizePaste.ts`:
- When the clipboard carries a `text/html` MIME type, HTML tags are stripped from the plain-text representation before the value reaches the input.
- Plain-text-only pastes (no `text/html` type) are passed through to the browser's default handling unchanged.

Added tests:
- HTML-tagged clipboard payload → stripped plain text reaches `onChange`  *(fails before this change; passes after)*
- Plain-text-only payload → handler does not intercept, `onChange` not called by our code

---

## Hot-path cost
All sanitization functions run in O(n) on the input string. `sanitizeSearchQuery` caps input at 200 characters, bounding the worst-case work. No measurable latency impact on UI interactions.

---

## Testing
- `tests/unit/logout-client.test.ts` — `safeRedirectPath` and `getPostAuthRedirect` negative cases
- `tests/unit/sessionHandler.test.ts` — `wipeClientState` auth keys, form prefix sweep, sessionStorage keys
- `tests/unit/search-page.test.tsx` — CRLF injection and overlong query negative tests
- `tests/unit/dashboard/transaction-history-search-input.test.tsx` — HTML paste stripping and plain-text no-op