### PR TITLE
Closes #1418: Implemented: validate: reject invalid IBAN before submit  #1418

### DIFF
--- a/components/settings/WalletSection.tsx
+++ b/components/settings/WalletSection.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, type ChangeEvent } from "react";
 import { Wallet } from "lucide-react";
 import { useClientTranslator } from "@/lib/i18n/client";
 import { useAutosave } from "@/lib/hooks/useAutosave";
+import { useSafeReload } from "@/lib/hooks/useSafeReload";
 import { isValidIban } from "@/lib/validation/iban";
 import {
   SectionCard,
@@ -148,7 +149,17 @@ export function WalletSection() {
           )}
         </FieldRow>
       </div>
-      <SaveButton labelKey="settings.save_changes" saveState={saveState} />
+      <SaveButton
+        labelKey="settings.save_changes"
+        saveState={saveState}
+        onSave={() => {
+          if (payoutIban && !isValidIban(payoutIban)) {
+            setPayoutIbanError(t("settings.wallet.payout_iban_invalid"));
+            return;
+          }
+          triggerSave();
+        }}
+      />
     </SectionCard>
   );
 }

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -119,6 +119,30 @@
   "settings": {
     "profile": {
       "phone_invalid": "Enter a valid phone number, including country code (e.g. +1 555 123 4567)."
+    },
+    "save_changes": "Save Changes",
+    "preferences_saved_title": "Settings saved",
+    "preferences_saved_description": "Your preferences have been updated.",
+    "save_error_title": "Save failed",
+    "wallet": {
+      "title": "Wallet Settings",
+      "description": "Configure your Stellar wallet and payout preferences.",
+      "testnet": "Testnet",
+      "mainnet": "Mainnet",
+      "network_label": "Network",
+      "network_hint": "Select the Stellar network to connect to.",
+      "soroban_rpc_label": "Soroban RPC URL",
+      "soroban_rpc_hint": "The Soroban RPC endpoint for smart contract interactions.",
+      "soroban_rpc_placeholder": "https://soroban-testnet.stellar.org",
+      "auto_split_label": "Auto Split",
+      "auto_split_toggle": "Enable automatic split",
+      "auto_split_desc": "Automatically allocate incoming remittances across spending, savings, bills, and insurance.",
+      "default_currency_label": "Default Currency",
+      "default_currency_hint": "The default asset for new remittances.",
+      "payout_iban_label": "Payout IBAN",
+      "payout_iban_hint": "The IBAN used for fiat payout conversions.",
+      "payout_iban_placeholder": "e.g. DE89370400440532013000",
+      "payout_iban_invalid": "Please enter a valid IBAN."
     }
   }
 }

--- a/lib/i18n/locales/es.json
+++ b/lib/i18n/locales/es.json
@@ -119,6 +119,30 @@
   "settings": {
     "profile": {
       "phone_invalid": "Introduce un número de teléfono válido, incluyendo el código de país (p. ej. +1 555 123 4567)."
+    },
+    "save_changes": "Guardar Cambios",
+    "preferences_saved_title": "Ajustes guardados",
+    "preferences_saved_description": "Tus preferencias han sido actualizadas.",
+    "save_error_title": "Error al guardar",
+    "wallet": {
+      "title": "Configuración de Billetera",
+      "description": "Configura tu billetera Stellar y preferencias de pago.",
+      "testnet": "Testnet",
+      "mainnet": "Mainnet",
+      "network_label": "Red",
+      "network_hint": "Selecciona la red Stellar a la que conectar.",
+      "soroban_rpc_label": "URL de Soroban RPC",
+      "soroban_rpc_hint": "El endpoint Soroban RPC para interacciones con contratos inteligentes.",
+      "soroban_rpc_placeholder": "https://soroban-testnet.stellar.org",
+      "auto_split_label": "División Automática",
+      "auto_split_toggle": "Habilitar división automática",
+      "auto_split_desc": "Asigna automáticamente las remesas recibidas entre gastos, ahorros, facturos y seguros.",
+      "default_currency_label": "Moneda por Defecto",
+      "default_currency_hint": "El activo por defecto para nuevas remesas.",
+      "payout_iban_label": "IBAN de Pago",
+      "payout_iban_hint": "El IBAN utilizado para conversiones de pago en fiat.",
+      "payout_iban_placeholder": "p. ej. DE89370400440532013000",
+      "payout_iban_invalid": "Por favor, introduce un IBAN válido."
     }
   }
 }


### PR DESCRIPTION
Closes #1418

## What changed
- WalletSection SaveButton now validates the IBAN before allowing save — if the field is non-empty and fails `isValidIban()`, the error is shown and the save is blocked.
- Added the missing `useSafeReload` import (was used but never imported).
- Added all missing `settings.wallet.*` localization keys to both `en.json` and `es.json` so the IBAN error message and all wallet UI labels actually resolve.

## Files changed
- `components/settings/WalletSection.tsx` — import fix + onSave guard
- `lib/i18n/locales/en.json` — wallet i18n keys
- `lib/i18n/locales/es.json` — wallet i18n keys (Spanish)

## Verification
- `npm run typecheck` — clean on changed files
- `npm test` — 9/9 tests pass (iban validation unit tests + WalletSection component tests)
- `npm run lint` — clean