### PR TITLE
DX: add a `just check` command that runs lint + typecheck + test (Closes #1505)

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,3 +3,7 @@
 # XDR it builds. See scripts/seed-invoice.mjs for details.
 seed-invoice:
     node scripts/seed-invoice.mjs
+
+# Run lint + typecheck + test (alias for `npm run check`)
+check:
+    npm run check

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev:reset": "node scripts/dev-reset.mjs",
     "build": "next build --webpack",
     "start": "next start",
+    "check": "npm run lint && npm run typecheck && npm test",
     "check:img-alt": "node scripts/check-img-alt.js",
     "lint": "eslint . && npm run check:img-alt",
     "test": "npm run test:unit",


### PR DESCRIPTION
## Summary

Adds a `check` npm script and a `check` `just` recipe that runs lint + typecheck + test, providing a single command for the full local verification loop.

## Changes

- **package.json**: Added `"check": "npm run lint && npm run typecheck && npm test"` script
- **justfile**: Added `check` recipe that delegates to `npm run check`

## Verification

- `just check` runs `npm run check` which runs `npm run lint` → `npm run typecheck` → `npm test`
- The commands are already documented in CONTRIBUTING.md (lines 92-93) and docs/testing.md (line 243)
- Both the npm script and just recipe are idempotent (safe to re-run)

Closes #1505