### PR TITLE
refactor: collapse duplicate cn helpers into canonical lib/utils/cn.ts (Closes #1421)

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,1 @@
-import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn } from "./utils/cn";

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,6 +1,1 @@
-import { clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: Parameters<typeof clsx>) {
-  return twMerge(clsx(inputs));
-}
+export { cn } from "./cn";


### PR DESCRIPTION
## Summary

Collapses the three duplicate Tailwind classnames helpers into a single canonical implementation.

## What changed

- **`lib/utils/cn.ts`** — kept as the single source of truth (it already has the best JSDoc/typing).
- **`lib/utils.ts`** — now re-exports `cn` from `./utils/cn` instead of duplicating the `twMerge(clsx(...))` body.
- **`lib/utils/index.ts`** — now re-exports `cn` from `./cn` instead of duplicating it.

Previously all three files defined their own `cn` function with slightly different typing (`ClassValue[]` vs `Parameters<typeof clsx>`). This is a runtime no-op: the re-export resolves to the exact same implementation.

## Verification

- `lib/utils/cn.test.ts` — 3 tests pass
- `tests/unit/utils/utils.test.ts` — 2 tests pass
- Runtime behavior unchanged (diff is a no-op at runtime)

Closes #1421